### PR TITLE
Major reworking of root NS handling, create & update, no delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ The above command pulled the existing data out of Route53 and placed the results
 
 | Provider | Record Support | GeoDNS Support | Notes |
 |--|--|--|--|
-| [CloudflareProvider](/octodns/provider/cloudflare.py) | A, AAAA, CNAME, MX, NS, SPF, TXT | No | |
-| [DnsimpleProvider](/octodns/provider/dnsimple.py) | All | No | |
-| [DynProvider](/octodns/provider/dyn.py) | All | Yes | |
+| [CloudflareProvider](/octodns/provider/cloudflare.py) | A, AAAA, CNAME, MX, NS, SPF, TXT | No | Unknown state, don't have access to test |
+| [DnsimpleProvider](/octodns/provider/dnsimple.py) | All | No | No root NS record support |
+| [DynProvider](/octodns/provider/dyn.py) | All | Yes | No root NS record support |
 | [Ns1Provider](/octodns/provider/ns1.py) | All | No | |
 | [PowerDnsProvider](/octodns/provider/powerdns.py) | All | No | |
 | [Route53](/octodns/provider/route53.py) | A, AAAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, TXT | Yes | |

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The above command pulled the existing data out of Route53 and placed the results
 
 | Provider | Record Support | GeoDNS Support | Notes |
 |--|--|--|--|
-| [CloudflareProvider](/octodns/provider/cloudflare.py) | A, AAAA, CNAME, MX, NS, SPF, TXT | No | Unknown state, don't have access to test |
+| [CloudflareProvider](/octodns/provider/cloudflare.py) | A, AAAA, CNAME, MX, NS, SPF, TXT | No | |
 | [DnsimpleProvider](/octodns/provider/dnsimple.py) | All | No | No root NS record support |
 | [DynProvider](/octodns/provider/dyn.py) | All | Yes | No root NS record support |
 | [Ns1Provider](/octodns/provider/ns1.py) | All | No | |

--- a/README.md
+++ b/README.md
@@ -147,16 +147,16 @@ The above command pulled the existing data out of Route53 and placed the results
 
 ## Supported providers
 
-| Provider | Record Support | GeoDNS Support | Notes |
+| Provider | Record Support | GeoDNS Support | Root NS support | Notes |
 |--|--|--|--|
-| [CloudflareProvider](/octodns/provider/cloudflare.py) | A, AAAA, CNAME, MX, NS, SPF, TXT | No | |
-| [DnsimpleProvider](/octodns/provider/dnsimple.py) | All | No | No root NS record support |
-| [DynProvider](/octodns/provider/dyn.py) | All | Yes | No root NS record support |
-| [Ns1Provider](/octodns/provider/ns1.py) | All | No | |
-| [PowerDnsProvider](/octodns/provider/powerdns.py) | All | No | |
-| [Route53](/octodns/provider/route53.py) | A, AAAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, TXT | Yes | |
-| [TinyDNSSource](/octodns/source/tinydns.py) | A, CNAME, MX, NS, PTR | No | read-only |
-| [YamlProvider](/octodns/provider/yaml.py) | All | Yes | config |
+| [CloudflareProvider](/octodns/provider/cloudflare.py) | A, AAAA, CNAME, MX, NS, SPF, TXT | No | No | |
+| [DnsimpleProvider](/octodns/provider/dnsimple.py) | All | No | No | |
+| [DynProvider](/octodns/provider/dyn.py) | All | Yes | No | |
+| [Ns1Provider](/octodns/provider/ns1.py) | All | No | Yes | |
+| [PowerDnsProvider](/octodns/provider/powerdns.py) | All | No | Yes | |
+| [Route53](/octodns/provider/route53.py) | A, AAAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, TXT | Yes | Yes | |
+| [TinyDNSSource](/octodns/source/tinydns.py) | A, CNAME, MX, NS, PTR | No | Yes | read-only |
+| [YamlProvider](/octodns/provider/yaml.py) | All | Yes | Yes | config |
 
 ## Custom Sources and Providers
 

--- a/octodns/provider/base.py
+++ b/octodns/provider/base.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
 from ..source.base import BaseSource
+from ..record import Delete
 from ..zone import Zone
 from logging import getLogger
 
@@ -89,8 +90,13 @@ class BaseProvider(BaseSource):
         '''
         An opportunity for providers to filter out false positives due to
         pecularities in their implementation. E.g. minimum TTLs.
+
+        By default we omit root NS record Deletes so that we NEVER delete them,
+        we'll allow Create and Update changes.
         '''
-        return True
+        return not (isinstance(change, Delete) and
+                    change.existing._type == 'NS' and
+                    change.existing.name == '')
 
     def _extra_changes(self, existing, changes):
         '''

--- a/octodns/provider/dyn.py
+++ b/octodns/provider/dyn.py
@@ -167,6 +167,15 @@ class DynProvider(BaseProvider):
     def SUPPORTS_GEO(self):
         return self.traffic_directors_enabled
 
+    def _include_change(self, change):
+        '''
+        Dyn doesn't allow full management of root NS records, can't delete
+        theirs, so for now they're unsupported.
+        '''
+        return not (change.record._type == 'NS' and
+                    change.record.name == '') and \
+            super(DynProvider, self)._include_change(change)
+
     def _check_dyn_sess(self):
         # We don't have to worry about locking for the check since the
         # underlying pieces are pre-thread. We can check to see if this thread

--- a/octodns/provider/powerdns.py
+++ b/octodns/provider/powerdns.py
@@ -254,9 +254,6 @@ class PowerDnsBaseProvider(BaseProvider):
             'records': records_for(existing)
         }
 
-    def _get_nameserver_record(self, existing):
-        return None
-
     def _extra_changes(self, existing, _):
         self.log.debug('_extra_changes: zone=%s', existing.name)
 
@@ -348,13 +345,6 @@ class PowerDnsProvider(PowerDnsBaseProvider):
         api_key: api-key
         # The port on which PowerDNS api is listening (optional, default 8081)
         port: 8081
-        # The nameservers to use for this provider (optional,
-        #   default unmanaged)
-        nameserver_values:
-            - 1.2.3.4.
-            - 1.2.3.5.
-        # The nameserver record TTL when managed, (optional, default 600)
-        nameserver_ttl: 600
     '''
 
     def __init__(self, id, host, api_key, port=8081, nameserver_values=None,
@@ -370,11 +360,4 @@ class PowerDnsProvider(PowerDnsBaseProvider):
         self.nameserver_ttl = nameserver_ttl
 
     def _get_nameserver_record(self, existing):
-        if self.nameserver_values:
-            return Record.new(existing, '', {
-                'type': 'NS',
-                'ttl': self.nameserver_ttl,
-                'values': self.nameserver_values,
-            }, source=self)
-
-        return super(PowerDnsProvider, self)._get_nameserver_record(existing)
+        return None

--- a/octodns/zone.py
+++ b/octodns/zone.py
@@ -19,12 +19,6 @@ class DuplicateRecordException(Exception):
     pass
 
 
-def _is_eligible(record):
-    # Should this record be considered when computing changes
-    # We ignore all top-level NS records
-    return record._type != 'NS' or record.name != ''
-
-
 class Zone(object):
     log = getLogger('Zone')
 
@@ -75,7 +69,7 @@ class Zone(object):
         changes = []
 
         # Find diffs & removes
-        for record in filter(_is_eligible, self.records):
+        for record in self.records:
             try:
                 desired_record = desired_records[record]
             except KeyError:
@@ -102,7 +96,7 @@ class Zone(object):
         # Find additions, things that are in desired, but missing in ourselves.
         # This uses set math and our special __hash__ and __cmp__ functions as
         # well
-        for record in filter(_is_eligible, desired.records - self.records):
+        for record in desired.records - self.records:
             if not target.supports(record):
                 self.log.debug('changes:  skipping record=%s %s - %s does not '
                                'support it', record.fqdn, record._type,

--- a/tests/fixtures/powerdns-full-data.json
+++ b/tests/fixtures/powerdns-full-data.json
@@ -204,15 +204,15 @@
             "name": "unit.tests.",
             "records": [
                 {
-                    "content": "1.1.1.1.",
+                    "content": "6.2.3.4.",
                     "disabled": false
                 },
                 {
-                    "content": "4.4.4.4.",
+                    "content": "7.2.3.4.",
                     "disabled": false
                 }
             ],
-            "ttl": 600,
+            "ttl": 3600,
             "type": "NS"
         },
         {

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -93,12 +93,12 @@ class TestManager(TestCase):
             environ['YAML_TMP_DIR'] = tmpdir.dirname
             tc = Manager(get_config_filename('simple.yaml')) \
                 .sync(dry_run=False)
-            self.assertEquals(19, tc)
+            self.assertEquals(20, tc)
 
             # try with just one of the zones
             tc = Manager(get_config_filename('simple.yaml')) \
                 .sync(dry_run=False, eligible_zones=['unit.tests.'])
-            self.assertEquals(13, tc)
+            self.assertEquals(14, tc)
 
             # the subzone, with 2 targets
             tc = Manager(get_config_filename('simple.yaml')) \
@@ -113,12 +113,12 @@ class TestManager(TestCase):
             # Again with force
             tc = Manager(get_config_filename('simple.yaml')) \
                 .sync(dry_run=False, force=True)
-            self.assertEquals(19, tc)
+            self.assertEquals(20, tc)
 
             # Again with max_workers = 1
             tc = Manager(get_config_filename('simple.yaml'), max_workers=1) \
                 .sync(dry_run=False, force=True)
-            self.assertEquals(19, tc)
+            self.assertEquals(20, tc)
 
     def test_eligible_targets(self):
         with TemporaryDirectory() as tmpdir:
@@ -144,13 +144,13 @@ class TestManager(TestCase):
                 fh.write('---\n{}')
 
             changes = manager.compare(['in'], ['dump'], 'unit.tests.')
-            self.assertEquals(13, len(changes))
+            self.assertEquals(14, len(changes))
 
             # Compound sources with varying support
             changes = manager.compare(['in', 'nosshfp'],
                                       ['dump'],
                                       'unit.tests.')
-            self.assertEquals(12, len(changes))
+            self.assertEquals(13, len(changes))
 
             with self.assertRaises(Exception) as ctx:
                 manager.compare(['nope'], ['dump'], 'unit.tests.')

--- a/tests/test_octodns_provider_cloudflare.py
+++ b/tests/test_octodns_provider_cloudflare.py
@@ -121,7 +121,8 @@ class TestCloudflareProvider(TestCase):
             self.assertEquals(9, len(zone.records))
 
             changes = self.expected.changes(zone, provider)
-            self.assertEquals(0, len(changes))
+            # root NS change wouldn't be included in plans
+            self.assertEquals(1, len(changes))
 
         # re-populating the same zone/records comes out of cache, no calls
         again = Zone('unit.tests.', [])

--- a/tests/test_octodns_provider_dnsimple.py
+++ b/tests/test_octodns_provider_dnsimple.py
@@ -80,7 +80,8 @@ class TestDnsimpleProvider(TestCase):
             provider.populate(zone)
             self.assertEquals(14, len(zone.records))
             changes = self.expected.changes(zone, provider)
-            self.assertEquals(0, len(changes))
+            # one change, the root NS record, plan would omit it though
+            self.assertEquals(1, len(changes))
 
         # 2nd populate makes no network calls/all from cache
         again = Zone('unit.tests.', [])
@@ -190,13 +191,13 @@ class TestDnsimpleProvider(TestCase):
         self.assertEquals(2, provider.apply(plan))
         # recreate for update, and deletes for the 2 parts of the other
         provider._client._request.assert_has_calls([
+            call('DELETE', '/zones/unit.tests/records/11189899'),
             call('POST', '/zones/unit.tests/records', data={
                 'content': '3.2.3.4',
                 'type': 'A',
                 'name': 'ttl',
                 'ttl': 300
             }),
-            call('DELETE', '/zones/unit.tests/records/11189899'),
             call('DELETE', '/zones/unit.tests/records/11189897'),
             call('DELETE', '/zones/unit.tests/records/11189898')
         ])

--- a/tests/test_octodns_provider_dnsimple.py
+++ b/tests/test_octodns_provider_dnsimple.py
@@ -191,13 +191,13 @@ class TestDnsimpleProvider(TestCase):
         self.assertEquals(2, provider.apply(plan))
         # recreate for update, and deletes for the 2 parts of the other
         provider._client._request.assert_has_calls([
-            call('DELETE', '/zones/unit.tests/records/11189899'),
             call('POST', '/zones/unit.tests/records', data={
                 'content': '3.2.3.4',
                 'type': 'A',
                 'name': 'ttl',
                 'ttl': 300
             }),
+            call('DELETE', '/zones/unit.tests/records/11189899'),
             call('DELETE', '/zones/unit.tests/records/11189897'),
             call('DELETE', '/zones/unit.tests/records/11189898')
-        ])
+        ], any_order=True)

--- a/tests/test_octodns_provider_dyn.py
+++ b/tests/test_octodns_provider_dyn.py
@@ -330,7 +330,12 @@ class TestDynProvider(TestCase):
             call('/AllRecord/unit.tests/unit.tests./', 'GET', {'detail': 'Y'})
         ])
         changes = self.expected.changes(got, SimpleProvider())
-        self.assertEquals([], changes)
+        # plan would filter out the root NS create we see here
+        self.assertEquals(1, len(changes))
+        change = changes[0]
+        self.assertIsInstance(change, Create)
+        self.assertEquals('NS', change.new._type)
+        self.assertEquals('', change.new.name)
 
     @patch('dyn.core.SessionEngine.execute')
     def test_sync(self, execute_mock):

--- a/tests/test_octodns_provider_ns1.py
+++ b/tests/test_octodns_provider_ns1.py
@@ -198,8 +198,7 @@ class TestNs1Provider(TestCase):
         desired.records.update(self.expected)
 
         plan = provider.plan(desired)
-        # everything except the root NS
-        expected_n = len(self.expected) - 1
+        expected_n = len(self.expected)
         self.assertEquals(expected_n, len(plan.changes))
 
         # Fails, general error

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -278,15 +278,14 @@ class TestRoute53Provider(TestCase):
                 'Name': 'unit.tests.',
                 'Type': 'NS',
                 'ResourceRecords': [{
-                    'Value': 'ns1.unit.tests.',
+                    'Value': '8.2.3.4.',
+                }, {
+                    'Value': '9.2.3.4.',
                 }],
                 'TTL': 67,
             }, {
                 'Name': 'sub.unit.tests.',
                 'Type': 'NS',
-                'GeoLocation': {
-                    'ContinentCode': 'AF',
-                },
                 'ResourceRecords': [{
                     'Value': '5.2.3.4.',
                 }, {
@@ -347,7 +346,7 @@ class TestRoute53Provider(TestCase):
                              {'HostedZoneId': 'z42'})
 
         plan = provider.plan(self.expected)
-        self.assertEquals(8, len(plan.changes))
+        self.assertEquals(9, len(plan.changes))
         for change in plan.changes:
             self.assertIsInstance(change, Create)
         stubber.assert_no_pending_responses()
@@ -366,7 +365,7 @@ class TestRoute53Provider(TestCase):
                                  'SubmittedAt': '2017-01-29T01:02:03Z',
                              }}, {'HostedZoneId': 'z42', 'ChangeBatch': ANY})
 
-        self.assertEquals(8, provider.apply(plan))
+        self.assertEquals(9, provider.apply(plan))
         stubber.assert_no_pending_responses()
 
         # Delete by monkey patching in a populate that includes an extra record
@@ -579,7 +578,7 @@ class TestRoute53Provider(TestCase):
                              {})
 
         plan = provider.plan(self.expected)
-        self.assertEquals(8, len(plan.changes))
+        self.assertEquals(9, len(plan.changes))
         for change in plan.changes:
             self.assertIsInstance(change, Create)
         stubber.assert_no_pending_responses()
@@ -626,7 +625,7 @@ class TestRoute53Provider(TestCase):
                                  'SubmittedAt': '2017-01-29T01:02:03Z',
                              }}, {'HostedZoneId': 'z42', 'ChangeBatch': ANY})
 
-        self.assertEquals(8, provider.apply(plan))
+        self.assertEquals(9, provider.apply(plan))
         stubber.assert_no_pending_responses()
 
     def test_health_checks_pagination(self):
@@ -1180,16 +1179,16 @@ class TestRoute53Provider(TestCase):
     @patch('octodns.provider.route53.Route53Provider._really_apply')
     def test_apply_1(self, really_apply_mock):
 
-        # 17 RRs with max of 18 should only get applied in one call
-        provider, plan = self._get_test_plan(18)
+        # 19 RRs with max of 20 should only get applied in one call
+        provider, plan = self._get_test_plan(20)
         provider.apply(plan)
         really_apply_mock.assert_called_once()
 
     @patch('octodns.provider.route53.Route53Provider._really_apply')
     def test_apply_2(self, really_apply_mock):
 
-        # 17 RRs with max of 17 should only get applied in two calls
-        provider, plan = self._get_test_plan(17)
+        # 18 RRs with max of 18 should only get applied in two calls
+        provider, plan = self._get_test_plan(18)
         provider.apply(plan)
         self.assertEquals(2, really_apply_mock.call_count)
 

--- a/tests/test_octodns_provider_yaml.py
+++ b/tests/test_octodns_provider_yaml.py
@@ -49,12 +49,12 @@ class TestYamlProvider(TestCase):
 
             # We add everything
             plan = target.plan(zone)
-            self.assertEquals(13, len(filter(lambda c: isinstance(c, Create),
+            self.assertEquals(14, len(filter(lambda c: isinstance(c, Create),
                                              plan.changes)))
             self.assertFalse(isfile(yaml_file))
 
             # Now actually do it
-            self.assertEquals(13, target.apply(plan))
+            self.assertEquals(14, target.apply(plan))
             self.assertTrue(isfile(yaml_file))
 
             # There should be no changes after the round trip
@@ -64,7 +64,7 @@ class TestYamlProvider(TestCase):
 
             # A 2nd sync should still create everything
             plan = target.plan(zone)
-            self.assertEquals(13, len(filter(lambda c: isinstance(c, Create),
+            self.assertEquals(14, len(filter(lambda c: isinstance(c, Create),
                                              plan.changes)))
 
             with open(yaml_file) as fh:

--- a/tests/test_octodns_source_tinydns.py
+++ b/tests/test_octodns_source_tinydns.py
@@ -86,6 +86,11 @@ class TestTinyDnsFileSource(TestCase):
                     'value': 'smtp-2-host.example.com.',
                 }]
             }),
+            ('', {
+                'type': 'NS',
+                'ttl': 3600,
+                'values': ['ns1.ns.com.', 'ns2.ns.com.']
+            }),
         ):
             record = Record.new(expected, name, data)
             expected.add_record(record)


### PR DESCRIPTION
- Cloudflare, Dyn & DnsimpleProvider don't support editing root NS records, Dyn may be
  able to sort of, but you can't remove their own...
- Improve DnsimpleClient's info on http errors
- Remove special root NS handling code from PowerDnsProvider, in this the
  case it used to support things should now be managed in the zone. Dynamic
  support still exists in PowerDnsBaseProvider to enable "other" use cases
- _is_eligible removed from zone, all records are eligible as far as it's
  concerned now.
- Bunch of tweaks to tests to handle the fact that root NS stuff are now
  included in changes.


Closes https://github.com/github/octodns/issues/38