### PR TITLE
CloudflareProvider: Map TTL=1 to 300

### DIFF
--- a/tests/test_octodns_provider_cloudflare.py
+++ b/tests/test_octodns_provider_cloudflare.py
@@ -686,3 +686,11 @@ class TestCloudflareProvider(TestCase):
 
         plan = provider.plan(wanted)
         self.assertEquals(False, hasattr(plan, 'changes'))
+
+    def test_ttl_mapping(self):
+        provider = CloudflareProvider('test', 'email', 'token')
+
+        self.assertEquals(120, provider._ttl_data(120))
+        self.assertEquals(120, provider._ttl_data(120))
+        self.assertEquals(3600, provider._ttl_data(3600))
+        self.assertEquals(300, provider._ttl_data(1))


### PR DESCRIPTION
This will map the Cloudflare ttl of 1 to 300s which based on [this support thread](https://support.cloudflare.com/hc/en-us/articles/200168866-What-does-the-Automatic-TTL-value-mean-) is the behavior users would be getting there. The result of this will be that automatic ttl things dumped from CF would have 300s ttls in the resulting output which would once synced to CF and other places result in matching/preserving behaviors. It won't change anything that's already 1 in CF unless the record otherwise is being modified.

I think this is our best option for handling the automatic TTLs with the mindset of trying to get multiple providers to behavior the same way from a single config (octoDNS's mindset.)

/cc Fixes https://github.com/github/octodns/issues/202
/cc Replaces https://github.com/github/octodns/pull/204
/cc @vanbroup @ad-m for thoughts