### PR TITLE
Implement, document, and test --cautious mode

### DIFF
--- a/octodns/cmds/sync.py
+++ b/octodns/cmds/sync.py
@@ -18,6 +18,10 @@ def main():
     parser.add_argument('--doit', action='store_true', default=False,
                         help='Whether to take action or just show what would '
                         'change')
+    parser.add_argument('--cautious', action='store_true', default=False,
+                        help='Cautiously make changes, any updates or '
+                        'creates will have their TTL set to 60s to allow '
+                        'reverts to take effect more quickly')
     parser.add_argument('--force', action='store_true', default=False,
                         help='Acknowledge that significant changes are being '
                         'made and do them')
@@ -36,7 +40,8 @@ def main():
 
     manager = Manager(args.config_file)
     manager.sync(eligible_zones=args.zone, eligible_targets=args.target,
-                 dry_run=not args.doit, force=args.force)
+                 dry_run=not args.doit, force=args.force,
+                 cautious=args.cautious)
 
 
 if __name__ == '__main__':

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -83,7 +83,7 @@ class Manager(object):
 
         self.include_meta = include_meta or manager_config.get('include_meta',
                                                                False)
-        self.log.info('__init__:   max_workers=%s', self.include_meta)
+        self.log.info('__init__:   include_meta=%s', self.include_meta)
 
         self.log.debug('__init__:   configuring providers')
         self.providers = {}
@@ -229,10 +229,10 @@ class Manager(object):
         return plans
 
     def sync(self, eligible_zones=[], eligible_targets=[], dry_run=True,
-             force=False):
+             force=False, cautious=False):
         self.log.info('sync: eligible_zones=%s, eligible_targets=%s, '
-                      'dry_run=%s, force=%s', eligible_zones, eligible_targets,
-                      dry_run, force)
+                      'dry_run=%s, force=%s, cautious=%s', eligible_zones,
+                      eligible_targets, dry_run, force, cautious)
 
         zones = self.config['zones'].items()
         if eligible_zones:
@@ -287,6 +287,10 @@ class Manager(object):
         # Wait on all results and unpack/flatten them in to a list of target &
         # plan pairs.
         plans = [p for f in futures for p in f.result()]
+
+        if cautious:
+            for target, plan in plans:
+                plan.make_cautious()
 
         for output in self.plan_outputs.values():
             output.run(plans=plans, log=self.log)

--- a/octodns/provider/plan.py
+++ b/octodns/provider/plan.py
@@ -50,6 +50,11 @@ class Plan(object):
                        self.change_counts['Update'],
                        self.change_counts['Delete'], existing_n)
 
+    def make_cautious(self):
+        for change in self.changes:
+            if change.new:
+                change.new.ttl = 60
+
     def raise_if_unsafe(self):
         # TODO: what is safe really?
         if self.existing and \


### PR DESCRIPTION
Normal plan:

```
(env)otter:octodns ross$ PYTHONPATH=. ./octodns/cmds/sync.py --config-file=config/dev.yaml
2018-02-24T16:18:12  [140736612635584] INFO  Manager __init__: config_file=config/dev.yaml
2018-02-24T16:18:12  [140736612635584] INFO  Manager __init__:   max_workers=4
2018-02-24T16:18:12  [140736612635584] INFO  Manager __init__:   include_meta=True
2018-02-24T16:18:12  [140736612635584] INFO  Manager sync: eligible_zones=[], eligible_targets=[], dry_run=True, force=False, cautious=False
2018-02-24T16:18:12  [140736612635584] INFO  Manager sync:   zone=githubtest.net.
2018-02-24T16:18:12  [140736612635584] INFO  Manager sync:   sources=['config'] -> targets=['route53']
2018-02-24T16:18:12  [123145418510336] INFO  YamlProvider[config] populate:   found 17 records
2018-02-24T16:18:12  [123145418510336] INFO  Route53Provider[route53] plan: desired=githubtest.net.
2018-02-24T16:18:13  [123145418510336] INFO  Route53Provider[route53] populate:   found 18 records
2018-02-24T16:18:13  [123145418510336] INFO  Route53Provider[route53] plan:   Creates=1, Updates=1, Deletes=1, Existing Records=18
2018-02-24T16:18:13  [140736612635584] INFO  Manager
********************************************************************************
* githubtest.net.
********************************************************************************
* route53 (Route53Provider)
*   Update
*     <ARecord A 1, test.githubtest.net., ['1.1.1.1', '1.1.1.2', '1.1.1.4']> ->
*     <ARecord A 600, test.githubtest.net., ['1.1.1.1', '1.1.1.2', '1.1.1.3']> (config)
*   Delete <ARecord A 3600, cx.githubtest.net., ['1.2.3.4']>
*   Create <ARecord A 3600, cx2.githubtest.net., ['1.2.3.4']> (config)
*   Summary: Creates=1, Updates=1, Deletes=1, Existing Records=18
********************************************************************************
```

Cautious plan

```
(env)otter:octodns ross$ PYTHONPATH=. ./octodns/cmds/sync.py --config-file=config/dev.yaml --cautious
2018-02-24T16:18:29  [140736612635584] INFO  Manager __init__: config_file=config/dev.yaml
2018-02-24T16:18:29  [140736612635584] INFO  Manager __init__:   max_workers=4
2018-02-24T16:18:29  [140736612635584] INFO  Manager __init__:   include_meta=True
2018-02-24T16:18:29  [140736612635584] INFO  Manager sync: eligible_zones=[], eligible_targets=[], dry_run=True, force=False, cautious=True
2018-02-24T16:18:29  [140736612635584] INFO  Manager sync:   zone=githubtest.net.
2018-02-24T16:18:29  [140736612635584] INFO  Manager sync:   sources=['config'] -> targets=['route53']
2018-02-24T16:18:29  [123145376927744] INFO  YamlProvider[config] populate:   found 17 records
2018-02-24T16:18:29  [123145376927744] INFO  Route53Provider[route53] plan: desired=githubtest.net.
2018-02-24T16:18:30  [123145376927744] INFO  Route53Provider[route53] populate:   found 18 records
2018-02-24T16:18:30  [123145376927744] INFO  Route53Provider[route53] plan:   Creates=1, Updates=1, Deletes=1, Existing Records=18
2018-02-24T16:18:30  [140736612635584] INFO  Manager
********************************************************************************
* githubtest.net.
********************************************************************************
* route53 (Route53Provider)
*   Update
*     <ARecord A 1, test.githubtest.net., ['1.1.1.1', '1.1.1.2', '1.1.1.4']> ->
*     <ARecord A 60, test.githubtest.net., ['1.1.1.1', '1.1.1.2', '1.1.1.3']> (config)
*   Delete <ARecord A 3600, cx.githubtest.net., ['1.2.3.4']>
*   Create <ARecord A 60, cx2.githubtest.net., ['1.2.3.4']> (config)
*   Summary: Creates=1, Updates=1, Deletes=1, Existing Records=18
********************************************************************************
```

This automates something we've done a couple times now to "cautiously" roll out changes in a way where we have a quick path to revert. We've been doing this with two rounds of changes were we manually set the TTLs on the 😨 bits to 60s in the first round and then to the real value we want in the subsequent. This just builds that concept into octoDNS itself.

It seems useful, but feedback/thoughts solicated.

/cc @theojulienne @joewilliams @yzguy @vanbroup 