### PR TITLE
Include "special" _octodns values in Record.__repr__

### DIFF
--- a/octodns/record.py
+++ b/octodns/record.py
@@ -10,6 +10,16 @@ from logging import getLogger
 import re
 
 
+def _stringify(d, prefix=''):
+    buf = []
+    for k, v in sorted(d.items()):
+        if isinstance(v, dict):
+            v = _stringify(v, '{}{}.'.format(prefix, k))
+        buf.append('{}{}={}'.format(prefix, k, v))
+
+    return ', '.join(buf)
+
+
 class Change(object):
 
     def __init__(self, existing, new):
@@ -319,9 +329,12 @@ class _ValuesMixin(object):
     def __repr__(self):
         values = "['{}']".format("', '".join([unicode(v)
                                               for v in self.values]))
-        return '<{} {} {}, {}, {}>'.format(self.__class__.__name__,
-                                           self._type, self.ttl,
-                                           self.fqdn, values)
+        special = ''
+        if self._octodns:
+            special = ', {}'.format(_stringify(self._octodns))
+        return '<{} {} {}, {}, {}{}>'.format(self.__class__.__name__,
+                                             self._type, self.ttl,
+                                             self.fqdn, values, special)
 
 
 class _GeoMixin(_ValuesMixin):


### PR DESCRIPTION

This includes the `octodns` bits in `Record.__repr__`. The upside of this is that you can see the special bits that may be pushed to your providers, downside is that it could be noisy and not all special things apply to all providers and things pulled out of providers will only include the things that provider knows about.

## Example of the "good" case, CF proxied

```yaml
'*.sub':
  octodns:
    cloudflare:
      proxied: True
  ttl: 144
  type: A
  values: 
  - 2.2.3.3
  - 3.3.4.4
  - 4.4.5.5
```

```
********************************************************************************
* githubtest.net.
********************************************************************************
* cloudflare (CloudflareProvider)
*   Update
*     <ARecord A 144, *.sub.githubtest.net., ['2.2.3.3', '3.3.4.4', '4.4.5.5'], cloudflare=cloudflare.proxied=False> ->
*     <ARecord A 144, *.sub.githubtest.net., ['2.2.3.3', '3.3.4.4', '4.4.5.5'], cloudflare=cloudflare.proxied=True> (config)
*   Summary: Creates=0, Updates=1, Deletes=0, Existing Records=20
********************************************************************************
```

## Example of the "bad" case, where things aren't super clear

```yaml
'*.sub':
  octodns:
    cloudflare:
      other: False
      proxied: True
    something: True
  ttl: 144
  type: A
  values: 
  - 2.2.3.3
  - 3.3.4.4
  - 4.4.5.5
```

```
********************************************************************************
* githubtest.net.
********************************************************************************
* cloudflare (CloudflareProvider)
*   Update
*     <ARecord A 144, *.sub.githubtest.net., ['2.2.3.3', '3.3.4.4', '4.4.5.5'], cloudflare=cloudflare.proxied=False> ->
*     <ARecord A 144, *.sub.githubtest.net., ['2.2.3.3', '3.3.4.4', '4.4.5.5'], cloudflare=cloudflare.other=False, cloudflare.proxied=True, something=True> (config)
*   Summary: Creates=0, Updates=1, Deletes=0, Existing Records=20
********************************************************************************
```

/cc https://github.com/github/octodns/issues/284
/cc @parkr @begincalendar