### PR TITLE
Add Lenience Flag to Sync

### DIFF
--- a/octodns/cmds/sync.py
+++ b/octodns/cmds/sync.py
@@ -22,6 +22,9 @@ def main():
                         help='Acknowledge that significant changes are being '
                         'made and do them')
 
+    parser.add_argument('--lenient', action='store_true', default=False,
+                        help='Do not strictly follow DNS standard.')
+
     parser.add_argument('zone', nargs='*', default=[],
                         help='Limit sync to the specified zone(s)')
 
@@ -36,7 +39,7 @@ def main():
 
     manager = Manager(args.config_file)
     manager.sync(eligible_zones=args.zone, eligible_targets=args.target,
-                 dry_run=not args.doit, force=args.force)
+                 dry_run=not args.doit, force=args.force, lenient=args.lenient)
 
 
 if __name__ == '__main__':

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -217,7 +217,8 @@ class Manager(object):
 
     def _populate_and_plan(self, zone_name, sources, targets, lenient=False):
 
-        self.log.debug('sync:   populating, zone=%s, lenient=%s', zone_name, lenient)
+        self.log.debug('sync:   populating, zone=%s, lenient=%s',
+                       zone_name, lenient)
         zone = Zone(zone_name,
                     sub_zones=self.configured_sub_zones(zone_name))
         for source in sources:
@@ -243,8 +244,8 @@ class Manager(object):
     def sync(self, eligible_zones=[], eligible_targets=[], dry_run=True,
              force=False, lenient=False):
         self.log.info('sync: eligible_zones=%s, eligible_targets=%s, '
-                      'dry_run=%s, force=%s, lenient=%s', eligible_zones, eligible_targets,
-                      dry_run, force, lenient)
+                      'dry_run=%s, force=%s, lenient=%s', eligible_zones,
+                      eligible_targets, dry_run, force, lenient)
 
         zones = self.config['zones'].items()
         if eligible_zones:
@@ -294,7 +295,8 @@ class Manager(object):
                                                                      target))
 
             futures.append(self._executor.submit(self._populate_and_plan,
-                                                 zone_name, sources, targets, lenient))
+                                                 zone_name, sources,
+                                                 targets, lenient))
 
         # Wait on all results and unpack/flatten them in to a list of target &
         # plan pairs.

--- a/octodns/provider/googlecloud.py
+++ b/octodns/provider/googlecloud.py
@@ -230,7 +230,8 @@ class GoogleCloudProvider(BaseProvider):
                 data['ttl'] = gcloud_record.ttl
                 self.log.debug('populate: adding record {} records: {!s}'
                                .format(record_name, data))
-                record = Record.new(zone, record_name, data, source=self, lenient=lenient)
+                record = Record.new(zone, record_name, data, source=self,
+                                    lenient=lenient)
                 zone.add_record(record, lenient=lenient)
 
         self.log.info('populate: found %s records, exists=%s',

--- a/octodns/provider/googlecloud.py
+++ b/octodns/provider/googlecloud.py
@@ -230,7 +230,7 @@ class GoogleCloudProvider(BaseProvider):
                 data['ttl'] = gcloud_record.ttl
                 self.log.debug('populate: adding record {} records: {!s}'
                                .format(record_name, data))
-                record = Record.new(zone, record_name, data, source=self)
+                record = Record.new(zone, record_name, data, source=self, lenient=lenient)
                 zone.add_record(record, lenient=lenient)
 
         self.log.info('populate: found %s records, exists=%s',

--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -1154,7 +1154,7 @@ class SrvRecord(_ValuesMixin, Record):
     def validate(cls, name, data):
         reasons = []
         if not cls._name_re.match(name):
-            reasons.append('invalid name')
+            reasons.append('invalid name for SRV record')
         reasons.extend(super(SrvRecord, cls).validate(name, data))
         return reasons
 

--- a/octodns/source/axfr.py
+++ b/octodns/source/axfr.py
@@ -206,12 +206,16 @@ class ZoneFileSource(AxfrBaseSource):
 
         self._zone_records = {}
 
-    def _load_zone_file(self, zone_name):
+    def _load_zone_file(self, zone_name, lenient=False):
         zonefiles = listdir(self.directory)
+        check_origin = True
+        if lenient:
+            check_origin = False
         if zone_name in zonefiles:
             try:
                 z = dns.zone.from_file(join(self.directory, zone_name),
-                                       zone_name, relativize=False)
+                                       zone_name, check_origin=check_origin,
+                                       relativize=False)
             except DNSException as error:
                 raise ZoneFileSourceLoadFailure(error)
         else:
@@ -219,10 +223,10 @@ class ZoneFileSource(AxfrBaseSource):
 
         return z
 
-    def zone_records(self, zone):
+    def zone_records(self, zone, lenient=False):
         if zone.name not in self._zone_records:
             try:
-                z = self._load_zone_file(zone.name)
+                z = self._load_zone_file(zone.name, lenient=lenient)
                 records = []
                 for (name, ttl, rdata) in z.iterate_rdatas():
                     rdtype = dns.rdatatype.to_text(rdata.rdtype)

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -1694,7 +1694,7 @@ class TestRecordValidation(TestCase):
                     'target': 'foo.bar.baz.'
                 }
             })
-        self.assertEquals(['invalid name'], ctx.exception.reasons)
+        self.assertEquals(['invalid name for SRV record'], ctx.exception.reasons)
 
         # missing priority
         with self.assertRaises(ValidationError) as ctx:

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -1694,7 +1694,8 @@ class TestRecordValidation(TestCase):
                     'target': 'foo.bar.baz.'
                 }
             })
-        self.assertEquals(['invalid name for SRV record'], ctx.exception.reasons)
+        self.assertEquals(['invalid name for SRV record'],
+                          ctx.exception.reasons)
 
         # missing priority
         with self.assertRaises(ValidationError) as ctx:

--- a/tests/zones/invalid.zone.
+++ b/tests/zones/invalid.zone.
@@ -6,3 +6,7 @@ $ORIGIN invalid.zone.
                         604800  ; Expire (1 week)
                         3600    ; NXDOMAIN ttl (1 hour)
                     )
+
+; SRV Records
+srv   600   IN  SRV 10 20 30 foo-1.invalid.zone.
+srv   600   IN  SRV 10 20 30 foo-2.invalid.zone.


### PR DESCRIPTION
This PR:

- Adds a lenience flag to the sync command
- When enabled this flag:
    - Allows non-spec SRV records (e.g.: dig SRV mongodb.example.org )
    - Disables check_origin on AXFR import
- Makes the SRV record "invalid name" more descriptive

I created this PR so we can do AXFR's against CoreDNS in a kubernetes cluster. CoreDNS creates non-spec SRV records and does not include the required NS records in an AXFR.

All together, this PR allow us to have CoreDNS create and manage DNS records in the cluster but have Google Cloud DNS actually serve the DNS records.