### PR TITLE
Add LOC record support to OctoDNS for AXFR source, YAML, Cloudflare and PowerDNS providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ The above command pulled the existing data out of Route53 and placed the results
 |--|--|--|--|--|
 | [AzureProvider](/octodns/provider/azuredns.py) | azure-mgmt-dns | A, AAAA, CAA, CNAME, MX, NS, PTR, SRV, TXT | No | |
 | [Akamai](/octodns/provider/edgedns.py) | edgegrid-python | A, AAAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, SSHFP, TXT | No | |
-| [CloudflareProvider](/octodns/provider/cloudflare.py) | | A, AAAA, ALIAS, CAA, CNAME, MX, NS, PTR, SPF, SRV, TXT | No | CAA tags restricted |
+| [CloudflareProvider](/octodns/provider/cloudflare.py) | | A, AAAA, ALIAS, CAA, CNAME, LOC, MX, NS, PTR, SPF, SRV, TXT | No | CAA tags restricted |
 | [ConstellixProvider](/octodns/provider/constellix.py) | | A, AAAA, ALIAS (ANAME), CAA, CNAME, MX, NS, PTR, SPF, SRV, TXT | No | CAA tags restricted |
 | [DigitalOceanProvider](/octodns/provider/digitalocean.py) | | A, AAAA, CAA, CNAME, MX, NS, TXT, SRV | No | CAA tags restricted |
 | [DnsMadeEasyProvider](/octodns/provider/dnsmadeeasy.py) | | A, AAAA, ALIAS (ANAME), CAA, CNAME, MX, NS, PTR, SPF, SRV, TXT | No | CAA tags restricted |

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ The above command pulled the existing data out of Route53 and placed the results
 | [Selectel](/octodns/provider/selectel.py) | | A, AAAA, CNAME, MX, NS, SPF, SRV, TXT | No | |
 | [Transip](/octodns/provider/transip.py) | transip | A, AAAA, CNAME, MX, SRV, SPF, TXT, SSHFP, CAA | No | |
 | [UltraDns](/octodns/provider/ultra.py) | | A, AAAA, CAA, CNAME, MX, NS, PTR, SPF, SRV, TXT | No | |
-| [AxfrSource](/octodns/source/axfr.py) | | A, AAAA, CAA, CNAME, MX, NS, PTR, SPF, SRV, TXT | No | read-only |
+| [AxfrSource](/octodns/source/axfr.py) | | A, AAAA, CAA, CNAME, LOC, MX, NS, PTR, SPF, SRV, TXT | No | read-only |
 | [ZoneFileSource](/octodns/source/axfr.py) | | A, AAAA, CAA, CNAME, MX, NS, PTR, SPF, SRV, TXT | No | read-only |
 | [TinyDnsFileSource](/octodns/source/tinydns.py) | | A, CNAME, MX, NS, PTR | No | read-only |
 | [YamlProvider](/octodns/provider/yaml.py) | | All | Yes | config |

--- a/docs/records.md
+++ b/docs/records.md
@@ -10,6 +10,7 @@ OctoDNS supports the following record types:
 * `CAA`
 * `CNAME`
 * `DNAME`
+* `LOC`
 * `MX`
 * `NAPTR`
 * `NS`

--- a/octodns/provider/cloudflare.py
+++ b/octodns/provider/cloudflare.py
@@ -505,7 +505,7 @@ class CloudflareProvider(BaseProvider):
         # new records cleanly. In general when there are multiple records for a
         # name & type each will have a distinct/consistent `content` that can
         # serve as a unique identifier.
-        # BUT... there are exceptions. MX, CAA, and SRV don't have a simple
+        # BUT... there are exceptions. MX, CAA, LOC and SRV don't have a simple
         # content as things are currently implemented so we need to handle
         # those explicitly and create unique/hashable strings for them.
         _type = data['type']
@@ -517,6 +517,22 @@ class CloudflareProvider(BaseProvider):
         elif _type == 'SRV':
             data = data['data']
             return '{port} {priority} {target} {weight}'.format(**data)
+        elif _type == 'LOC':
+            data = data['data']
+            loc = (
+                '{lat_degrees}',
+                '{lat_minutes}',
+                '{lat_seconds}',
+                '{lat_direction}',
+                '{long_degrees}',
+                '{long_minutes}',
+                '{long_seconds}',
+                '{long_direction}',
+                '{altitude}',
+                '{size}',
+                '{precision_horz}',
+                '{precision_vert}')
+            return ' '.join(loc).format(**data)
         return data['content']
 
     def _apply_Create(self, change):

--- a/octodns/provider/powerdns.py
+++ b/octodns/provider/powerdns.py
@@ -15,8 +15,8 @@ from .base import BaseProvider
 class PowerDnsBaseProvider(BaseProvider):
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
-    SUPPORTS = set(('A', 'AAAA', 'ALIAS', 'CAA', 'CNAME', 'MX', 'NAPTR', 'NS',
-                    'PTR', 'SPF', 'SSHFP', 'SRV', 'TXT'))
+    SUPPORTS = set(('A', 'AAAA', 'ALIAS', 'CAA', 'CNAME', 'LOC', 'MX', 'NAPTR',
+                    'NS', 'PTR', 'SPF', 'SSHFP', 'SRV', 'TXT'))
     TIMEOUT = 5
 
     def __init__(self, id, host, api_key, port=8081,
@@ -101,6 +101,33 @@ class PowerDnsBaseProvider(BaseProvider):
 
     _data_for_SPF = _data_for_quoted
     _data_for_TXT = _data_for_quoted
+
+    def _data_for_LOC(self, rrset):
+        values = []
+        for record in rrset['records']:
+            lat_degrees, lat_minutes, lat_seconds, lat_direction, \
+                long_degrees, long_minutes, long_seconds, long_direction, \
+                altitude, size, precision_horz, precision_vert = \
+                record['content'].replace('m', '').split(' ', 11)
+            values.append({
+                'lat_degrees': int(lat_degrees),
+                'lat_minutes': int(lat_minutes),
+                'lat_seconds': float(lat_seconds),
+                'lat_direction': lat_direction,
+                'long_degrees': int(long_degrees),
+                'long_minutes': int(long_minutes),
+                'long_seconds': float(long_seconds),
+                'long_direction': long_direction,
+                'altitude': float(altitude),
+                'size': float(size),
+                'precision_horz': float(precision_horz),
+                'precision_vert': float(precision_vert),
+            })
+        return {
+            'ttl': rrset['ttl'],
+            'type': rrset['type'],
+            'values': values
+        }
 
     def _data_for_MX(self, rrset):
         values = []
@@ -284,6 +311,27 @@ class PowerDnsBaseProvider(BaseProvider):
 
     _records_for_SPF = _records_for_quoted
     _records_for_TXT = _records_for_quoted
+
+    def _records_for_LOC(self, record):
+        return [{
+            'content':
+                '%d %d %0.3f %s %d %d %.3f %s %0.2fm %0.2fm %0.2fm %0.2fm' %
+                (
+                    int(v.lat_degrees),
+                    int(v.lat_minutes),
+                    float(v.lat_seconds),
+                    v.lat_direction,
+                    int(v.long_degrees),
+                    int(v.long_minutes),
+                    float(v.long_seconds),
+                    v.long_direction,
+                    float(v.altitude),
+                    float(v.size),
+                    float(v.precision_horz),
+                    float(v.precision_vert)
+                ),
+            'disabled': False
+        } for v in record.values]
 
     def _records_for_MX(self, record):
         return [{

--- a/octodns/provider/yaml.py
+++ b/octodns/provider/yaml.py
@@ -104,7 +104,7 @@ class YamlProvider(BaseProvider):
     '''
     SUPPORTS_GEO = True
     SUPPORTS_DYNAMIC = True
-    SUPPORTS = set(('A', 'AAAA', 'ALIAS', 'CAA', 'CNAME', 'DNAME', 'MX',
+    SUPPORTS = set(('A', 'AAAA', 'ALIAS', 'CAA', 'CNAME', 'DNAME', 'LOC', 'MX',
                     'NAPTR', 'NS', 'PTR', 'SSHFP', 'SPF', 'SRV', 'TXT'))
 
     def __init__(self, id, directory, default_ttl=3600, enforce_order=True,

--- a/octodns/source/axfr.py
+++ b/octodns/source/axfr.py
@@ -26,8 +26,8 @@ class AxfrBaseSource(BaseSource):
 
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
-    SUPPORTS = set(('A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NS', 'PTR', 'SPF',
-                    'SRV', 'TXT'))
+    SUPPORTS = set(('A', 'AAAA', 'CAA', 'CNAME', 'LOC', 'MX', 'NS', 'PTR',
+                    'SPF', 'SRV', 'TXT'))
 
     def __init__(self, id):
         super(AxfrBaseSource, self).__init__(id)
@@ -51,6 +51,33 @@ class AxfrBaseSource(BaseSource):
                 'flags': flags,
                 'tag': tag,
                 'value': value.replace('"', '')
+            })
+        return {
+            'ttl': records[0]['ttl'],
+            'type': _type,
+            'values': values
+        }
+
+    def _data_for_LOC(self, _type, records):
+        values = []
+        for record in records:
+            lat_degrees, lat_minutes, lat_seconds, lat_direction, \
+                long_degrees, long_minutes, long_seconds, long_direction, \
+                altitude, size, precision_horz, precision_vert = \
+                record['value'].replace('m', '').split(' ', 11)
+            values.append({
+                'lat_degrees': lat_degrees,
+                'lat_minutes': lat_minutes,
+                'lat_seconds': lat_seconds,
+                'lat_direction': lat_direction,
+                'long_degrees': long_degrees,
+                'long_minutes': long_minutes,
+                'long_seconds': long_seconds,
+                'long_direction': long_direction,
+                'altitude': altitude,
+                'size': size,
+                'precision_horz': precision_horz,
+                'precision_vert': precision_vert,
             })
         return {
             'ttl': records[0]['ttl'],

--- a/tests/config/unit.tests.yaml
+++ b/tests/config/unit.tests.yaml
@@ -77,6 +77,34 @@ included:
     - test
   type: CNAME
   value: unit.tests.
+loc:
+  ttl: 300
+  type: LOC
+  values:
+  - altitude: 20
+    lat_degrees: 31
+    lat_direction: S
+    lat_minutes: 58
+    lat_seconds: 52.1
+    long_degrees: 115
+    long_direction: E
+    long_minutes: 49
+    long_seconds: 11.7
+    precision_horz: 10
+    precision_vert: 2
+    size: 10
+  - altitude: 20
+    lat_degrees: 53
+    lat_direction: N
+    lat_minutes: 13
+    lat_seconds: 10
+    long_degrees: 2
+    long_direction: W
+    long_minutes: 18
+    long_seconds: 26
+    precision_horz: 1000
+    precision_vert: 2
+    size: 10
 mx:
   ttl: 300
   type: MX

--- a/tests/fixtures/cloudflare-dns_records-page-2.json
+++ b/tests/fixtures/cloudflare-dns_records-page-2.json
@@ -173,64 +173,14 @@
       "meta": {
         "auto_added": false
       }
-    },
-    {
-      "id": "fc12ab34cd5611334422ab3322997656",
-      "type": "SRV",
-      "name": "_srv._tcp.unit.tests",
-      "data": {
-        "service": "_srv",
-        "proto": "_tcp",
-        "name": "unit.tests",
-        "priority": 12,
-        "weight": 20,
-        "port": 30,
-        "target": "foo-2.unit.tests"
-      },
-      "proxiable": true,
-      "proxied": false,
-      "ttl": 600,
-      "locked": false,
-      "zone_id": "ff12ab34cd5611334422ab3322997650",
-      "zone_name": "unit.tests",
-      "modified_on": "2017-03-11T18:01:43.940682Z",
-      "created_on": "2017-03-11T18:01:43.940682Z",
-      "meta": {
-        "auto_added": false
-      }
-    },
-    {
-      "id": "fc12ab34cd5611334422ab3322997656",
-      "type": "SRV",
-      "name": "_srv._tcp.unit.tests",
-      "data": {
-        "service": "_srv",
-        "proto": "_tcp",
-        "name": "unit.tests",
-        "priority": 10,
-        "weight": 20,
-        "port": 30,
-        "target": "foo-1.unit.tests"
-      },
-      "proxiable": true,
-      "proxied": false,
-      "ttl": 600,
-      "locked": false,
-      "zone_id": "ff12ab34cd5611334422ab3322997650",
-      "zone_name": "unit.tests",
-      "modified_on": "2017-03-11T18:01:43.940682Z",
-      "created_on": "2017-03-11T18:01:43.940682Z",
-      "meta": {
-        "auto_added": false
-      }
     }
   ],
   "result_info": {
     "page": 2,
-    "per_page": 11,
-    "total_pages": 2,
+    "per_page": 10,
+    "total_pages": 3,
     "count": 10,
-    "total_count": 20
+    "total_count": 24
   },
   "success": true,
   "errors": [],

--- a/tests/fixtures/cloudflare-dns_records-page-3.json
+++ b/tests/fixtures/cloudflare-dns_records-page-3.json
@@ -1,0 +1,128 @@
+{
+  "result": [
+    {
+      "id": "fc12ab34cd5611334422ab3322997656",
+      "type": "SRV",
+      "name": "_srv._tcp.unit.tests",
+      "data": {
+        "service": "_srv",
+        "proto": "_tcp",
+        "name": "unit.tests",
+        "priority": 12,
+        "weight": 20,
+        "port": 30,
+        "target": "foo-2.unit.tests"
+      },
+      "proxiable": true,
+      "proxied": false,
+      "ttl": 600,
+      "locked": false,
+      "zone_id": "ff12ab34cd5611334422ab3322997650",
+      "zone_name": "unit.tests",
+      "modified_on": "2017-03-11T18:01:43.940682Z",
+      "created_on": "2017-03-11T18:01:43.940682Z",
+      "meta": {
+        "auto_added": false
+      }
+    },
+    {
+      "id": "fc12ab34cd5611334422ab3322997656",
+      "type": "SRV",
+      "name": "_srv._tcp.unit.tests",
+      "data": {
+        "service": "_srv",
+        "proto": "_tcp",
+        "name": "unit.tests",
+        "priority": 10,
+        "weight": 20,
+        "port": 30,
+        "target": "foo-1.unit.tests"
+      },
+      "proxiable": true,
+      "proxied": false,
+      "ttl": 600,
+      "locked": false,
+      "zone_id": "ff12ab34cd5611334422ab3322997650",
+      "zone_name": "unit.tests",
+      "modified_on": "2017-03-11T18:01:43.940682Z",
+      "created_on": "2017-03-11T18:01:43.940682Z",
+      "meta": {
+        "auto_added": false
+      }
+    },
+    {
+      "id": "372e67954025e0ba6aaa6d586b9e0b59",
+      "type": "LOC",
+      "name": "loc.unit.tests",
+      "content": "IN LOC 31 58 52.1 S 115 49 11.7 E 20m 10m 10m 2m",
+      "proxiable": true,
+      "proxied": false,
+      "ttl": 300,
+      "locked": false,
+      "zone_id": "ff12ab34cd5611334422ab3322997650",
+      "zone_name": "unit.tests",
+      "created_on": "2020-01-28T05:20:00.12345Z",
+      "modified_on": "2020-01-28T05:20:00.12345Z",
+      "data": {
+        "lat_degrees": 31,
+        "lat_minutes": 58,
+        "lat_seconds": 52.1,
+        "lat_direction": "S",
+        "long_degrees": 115,
+        "long_minutes": 49,
+        "long_seconds": 11.7,
+        "long_direction": "E",
+        "altitude": 20,
+        "size": 10,
+        "precision_horz": 10,
+        "precision_vert": 2
+      },
+      "meta": {
+         "auto_added": true,
+         "source": "primary"
+      }
+    },
+    {
+      "id": "372e67954025e0ba6aaa6d586b9e0b59",
+      "type": "LOC",
+      "name": "loc.unit.tests",
+      "content": "IN LOC 53 14 10 N 2 18 26 W 20m 10m 1000m 2m",
+      "proxiable": true,
+      "proxied": false,
+      "ttl": 300,
+      "locked": false,
+      "zone_id": "ff12ab34cd5611334422ab3322997650",
+      "zone_name": "unit.tests",
+      "created_on": "2020-01-28T05:20:00.12345Z",
+      "modified_on": "2020-01-28T05:20:00.12345Z",
+      "data": {
+        "lat_degrees": 53,
+        "lat_minutes": 13,
+        "lat_seconds": 10,
+        "lat_direction": "N",
+        "long_degrees": 2,
+        "long_minutes": 18,
+        "long_seconds": 26,
+        "long_direction": "W",
+        "altitude": 20,
+        "size": 10,
+        "precision_horz": 1000,
+        "precision_vert": 2
+      },
+      "meta": {
+         "auto_added": true,
+         "source": "primary"
+      }
+    }
+  ],
+  "result_info": {
+    "page": 3,
+    "per_page": 10,
+    "total_pages": 3,
+    "count": 4,
+    "total_count": 24
+  },
+  "success": true,
+  "errors": [],
+  "messages": []
+}

--- a/tests/fixtures/powerdns-full-data.json
+++ b/tests/fixtures/powerdns-full-data.json
@@ -34,6 +34,22 @@
         },
         {
             "comments": [],
+            "name": "loc.unit.tests.",
+            "records": [
+                {
+		    "content": "31 58 52.100 S 115 49 11.700 E 20.00m 10.00m 10.00m 2.00m",
+                    "disabled": false
+                },
+                {
+		    "content": "53 13 10.000 N 2 18 26.000 W 20.00m 10.00m 1000.00m 2.00m",
+                    "disabled": false
+                }
+            ],
+            "ttl": 300,
+            "type": "LOC"
+        },
+        {
+            "comments": [],
             "name": "sub.unit.tests.",
             "records": [
                 {

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -118,12 +118,12 @@ class TestManager(TestCase):
             environ['YAML_TMP_DIR'] = tmpdir.dirname
             tc = Manager(get_config_filename('simple.yaml')) \
                 .sync(dry_run=False)
-            self.assertEquals(22, tc)
+            self.assertEquals(23, tc)
 
             # try with just one of the zones
             tc = Manager(get_config_filename('simple.yaml')) \
                 .sync(dry_run=False, eligible_zones=['unit.tests.'])
-            self.assertEquals(16, tc)
+            self.assertEquals(17, tc)
 
             # the subzone, with 2 targets
             tc = Manager(get_config_filename('simple.yaml')) \
@@ -138,18 +138,18 @@ class TestManager(TestCase):
             # Again with force
             tc = Manager(get_config_filename('simple.yaml')) \
                 .sync(dry_run=False, force=True)
-            self.assertEquals(22, tc)
+            self.assertEquals(23, tc)
 
             # Again with max_workers = 1
             tc = Manager(get_config_filename('simple.yaml'), max_workers=1) \
                 .sync(dry_run=False, force=True)
-            self.assertEquals(22, tc)
+            self.assertEquals(23, tc)
 
             # Include meta
             tc = Manager(get_config_filename('simple.yaml'), max_workers=1,
                          include_meta=True) \
                 .sync(dry_run=False, force=True)
-            self.assertEquals(26, tc)
+            self.assertEquals(27, tc)
 
     def test_eligible_sources(self):
         with TemporaryDirectory() as tmpdir:
@@ -215,13 +215,13 @@ class TestManager(TestCase):
                 fh.write('---\n{}')
 
             changes = manager.compare(['in'], ['dump'], 'unit.tests.')
-            self.assertEquals(16, len(changes))
+            self.assertEquals(17, len(changes))
 
             # Compound sources with varying support
             changes = manager.compare(['in', 'nosshfp'],
                                       ['dump'],
                                       'unit.tests.')
-            self.assertEquals(15, len(changes))
+            self.assertEquals(16, len(changes))
 
             with self.assertRaises(ManagerException) as ctx:
                 manager.compare(['nope'], ['dump'], 'unit.tests.')

--- a/tests/test_octodns_provider_cloudflare.py
+++ b/tests/test_octodns_provider_cloudflare.py
@@ -340,6 +340,10 @@ class TestCloudflareProvider(TestCase):
         self.assertTrue(plan.exists)
         # creates a the new value and then deletes all the old
         provider._request.assert_has_calls([
+            call('DELETE', '/zones/ff12ab34cd5611334422ab3322997650/'
+                 'dns_records/fc12ab34cd5611334422ab3322997653'),
+            call('DELETE', '/zones/ff12ab34cd5611334422ab3322997650/'
+                 'dns_records/fc12ab34cd5611334422ab3322997654'),
             call('PUT', '/zones/42/dns_records/'
                  'fc12ab34cd5611334422ab3322997655', data={
                      'content': '3.2.3.4',
@@ -347,11 +351,7 @@ class TestCloudflareProvider(TestCase):
                      'name': 'ttl.unit.tests',
                      'proxied': False,
                      'ttl': 300
-                 }),
-            call('DELETE', '/zones/ff12ab34cd5611334422ab3322997650/'
-                 'dns_records/fc12ab34cd5611334422ab3322997653'),
-            call('DELETE', '/zones/ff12ab34cd5611334422ab3322997650/'
-                 'dns_records/fc12ab34cd5611334422ab3322997654')
+                 })
         ])
 
     def test_update_add_swap(self):

--- a/tests/test_octodns_provider_cloudflare.py
+++ b/tests/test_octodns_provider_cloudflare.py
@@ -747,6 +747,23 @@ class TestCloudflareProvider(TestCase):
                 },
                 'type': 'SRV',
             }),
+            ('31 58 52.1 S 115 49 11.7 E 20 10 10 2', {
+                'data': {
+                    'lat_degrees': 31,
+                    'lat_minutes': 58,
+                    'lat_seconds': 52.1,
+                    'lat_direction': 'S',
+                    'long_degrees': 115,
+                    'long_minutes': 49,
+                    'long_seconds': 11.7,
+                    'long_direction': 'E',
+                    'altitude': 20,
+                    'size': 10,
+                    'precision_horz': 10,
+                    'precision_vert': 2,
+                },
+                'type': 'LOC',
+            }),
         ):
             self.assertEqual(expected, provider._gen_key(data))
 

--- a/tests/test_octodns_provider_constellix.py
+++ b/tests/test_octodns_provider_constellix.py
@@ -132,7 +132,7 @@ class TestConstellixProvider(TestCase):
         plan = provider.plan(self.expected)
 
         # No root NS, no ignored, no excluded, no unsupported
-        n = len(self.expected.records) - 6
+        n = len(self.expected.records) - 7
         self.assertEquals(n, len(plan.changes))
         self.assertEquals(n, provider.apply(plan))
 

--- a/tests/test_octodns_provider_digitalocean.py
+++ b/tests/test_octodns_provider_digitalocean.py
@@ -163,7 +163,7 @@ class TestDigitalOceanProvider(TestCase):
         plan = provider.plan(self.expected)
 
         # No root NS, no ignored, no excluded, no unsupported
-        n = len(self.expected.records) - 8
+        n = len(self.expected.records) - 9
         self.assertEquals(n, len(plan.changes))
         self.assertEquals(n, provider.apply(plan))
         self.assertFalse(plan.exists)

--- a/tests/test_octodns_provider_dnsimple.py
+++ b/tests/test_octodns_provider_dnsimple.py
@@ -136,8 +136,8 @@ class TestDnsimpleProvider(TestCase):
         ]
         plan = provider.plan(self.expected)
 
-        # No root NS, no ignored, no excluded
-        n = len(self.expected.records) - 4
+        # No root NS, no ignored, no excluded, no unsupported
+        n = len(self.expected.records) - 5
         self.assertEquals(n, len(plan.changes))
         self.assertEquals(n, provider.apply(plan))
         self.assertFalse(plan.exists)

--- a/tests/test_octodns_provider_dnsmadeeasy.py
+++ b/tests/test_octodns_provider_dnsmadeeasy.py
@@ -134,7 +134,7 @@ class TestDnsMadeEasyProvider(TestCase):
         plan = provider.plan(self.expected)
 
         # No root NS, no ignored, no excluded, no unsupported
-        n = len(self.expected.records) - 6
+        n = len(self.expected.records) - 7
         self.assertEquals(n, len(plan.changes))
         self.assertEquals(n, provider.apply(plan))
 

--- a/tests/test_octodns_provider_easydns.py
+++ b/tests/test_octodns_provider_easydns.py
@@ -374,7 +374,7 @@ class TestEasyDNSProvider(TestCase):
         plan = provider.plan(self.expected)
 
         # No root NS, no ignored, no excluded, no unsupported
-        n = len(self.expected.records) - 7
+        n = len(self.expected.records) - 8
         self.assertEquals(n, len(plan.changes))
         self.assertEquals(n, provider.apply(plan))
         self.assertFalse(plan.exists)

--- a/tests/test_octodns_provider_gandi.py
+++ b/tests/test_octodns_provider_gandi.py
@@ -192,8 +192,8 @@ class TestGandiProvider(TestCase):
         ]
         plan = provider.plan(self.expected)
 
-        # No root NS, no ignored, no excluded
-        n = len(self.expected.records) - 4
+        # No root NS, no ignored, no excluded, no LOC
+        n = len(self.expected.records) - 5
         self.assertEquals(n, len(plan.changes))
         self.assertEquals(n, provider.apply(plan))
         self.assertFalse(plan.exists)

--- a/tests/test_octodns_provider_powerdns.py
+++ b/tests/test_octodns_provider_powerdns.py
@@ -185,8 +185,8 @@ class TestPowerDnsProvider(TestCase):
         expected = Zone('unit.tests.', [])
         source = YamlProvider('test', join(dirname(__file__), 'config'))
         source.populate(expected)
-        expected_n = len(expected.records) - 4
-        self.assertEquals(16, expected_n)
+        expected_n = len(expected.records) - 3
+        self.assertEquals(17, expected_n)
 
         # No diffs == no changes
         with requests_mock() as mock:
@@ -194,7 +194,7 @@ class TestPowerDnsProvider(TestCase):
 
             zone = Zone('unit.tests.', [])
             provider.populate(zone)
-            self.assertEquals(16, len(zone.records))
+            self.assertEquals(17, len(zone.records))
             changes = expected.changes(zone, provider)
             self.assertEquals(0, len(changes))
 

--- a/tests/test_octodns_provider_powerdns.py
+++ b/tests/test_octodns_provider_powerdns.py
@@ -185,7 +185,7 @@ class TestPowerDnsProvider(TestCase):
         expected = Zone('unit.tests.', [])
         source = YamlProvider('test', join(dirname(__file__), 'config'))
         source.populate(expected)
-        expected_n = len(expected.records) - 3
+        expected_n = len(expected.records) - 4
         self.assertEquals(16, expected_n)
 
         # No diffs == no changes
@@ -291,7 +291,7 @@ class TestPowerDnsProvider(TestCase):
         expected = Zone('unit.tests.', [])
         source = YamlProvider('test', join(dirname(__file__), 'config'))
         source.populate(expected)
-        self.assertEquals(19, len(expected.records))
+        self.assertEquals(20, len(expected.records))
 
         # A small change to a single record
         with requests_mock() as mock:

--- a/tests/test_octodns_provider_yaml.py
+++ b/tests/test_octodns_provider_yaml.py
@@ -35,7 +35,7 @@ class TestYamlProvider(TestCase):
 
         # without it we see everything
         source.populate(zone)
-        self.assertEquals(19, len(zone.records))
+        self.assertEquals(20, len(zone.records))
 
         source.populate(dynamic_zone)
         self.assertEquals(5, len(dynamic_zone.records))
@@ -58,12 +58,12 @@ class TestYamlProvider(TestCase):
 
             # We add everything
             plan = target.plan(zone)
-            self.assertEquals(16, len([c for c in plan.changes
+            self.assertEquals(17, len([c for c in plan.changes
                                        if isinstance(c, Create)]))
             self.assertFalse(isfile(yaml_file))
 
             # Now actually do it
-            self.assertEquals(16, target.apply(plan))
+            self.assertEquals(17, target.apply(plan))
             self.assertTrue(isfile(yaml_file))
 
             # Dynamic plan
@@ -87,7 +87,7 @@ class TestYamlProvider(TestCase):
 
             # A 2nd sync should still create everything
             plan = target.plan(zone)
-            self.assertEquals(16, len([c for c in plan.changes
+            self.assertEquals(17, len([c for c in plan.changes
                                        if isinstance(c, Create)]))
 
             with open(yaml_file) as fh:
@@ -106,6 +106,7 @@ class TestYamlProvider(TestCase):
                 self.assertTrue('values' in data.pop('naptr'))
                 self.assertTrue('values' in data.pop('sub'))
                 self.assertTrue('values' in data.pop('txt'))
+                self.assertTrue('values' in data.pop('loc'))
                 # these are stored as singular 'value'
                 self.assertTrue('value' in data.pop('aaaa'))
                 self.assertTrue('value' in data.pop('cname'))

--- a/tests/test_octodns_source_axfr.py
+++ b/tests/test_octodns_source_axfr.py
@@ -73,7 +73,7 @@ class TestZoneFileSource(TestCase):
         # Load zonefiles without a specified file extension
         valid = Zone('unit.tests.', [])
         source.populate(valid)
-        self.assertEquals(12, len(valid.records))
+        self.assertEquals(13, len(valid.records))
 
     def test_populate(self):
         # Valid zone file in directory

--- a/tests/test_octodns_source_axfr.py
+++ b/tests/test_octodns_source_axfr.py
@@ -36,7 +36,7 @@ class TestAxfrSource(TestCase):
         ]
 
         self.source.populate(got)
-        self.assertEquals(12, len(got.records))
+        self.assertEquals(13, len(got.records))
 
         with self.assertRaises(AxfrSourceZoneTransferFailed) as ctx:
             zone = Zone('unit.tests.', [])
@@ -79,12 +79,12 @@ class TestZoneFileSource(TestCase):
         # Valid zone file in directory
         valid = Zone('unit.tests.', [])
         self.source.populate(valid)
-        self.assertEquals(12, len(valid.records))
+        self.assertEquals(13, len(valid.records))
 
         # 2nd populate does not read file again
         again = Zone('unit.tests.', [])
         self.source.populate(again)
-        self.assertEquals(12, len(again.records))
+        self.assertEquals(13, len(again.records))
 
         # bust the cache
         del self.source._zone_records[valid.name]

--- a/tests/zones/unit.tests.tst
+++ b/tests/zones/unit.tests.tst
@@ -32,6 +32,10 @@ mx          300   IN  MX  20  smtp-2.unit.tests.
 mx          300   IN  MX  30  smtp-3.unit.tests.
 mx          300   IN  MX  40  smtp-1.unit.tests.
 
+; LOC Records
+loc         300   IN  LOC 31 58 52.1 S 115 49 11.7 E 20m 10m 10m 2m
+loc         300   IN  LOC 53 14 10 N 2 18 26 W 20m 10m 1000m 2m
+
 ; A Records
 @           300   IN  A   1.2.3.4
 @           300   IN  A   1.2.3.5


### PR DESCRIPTION
This pull request adds support for LOC records.   We were using OctoDNS to sync from YAML to Cloudflare, initial sync was failing due to a LOC record being present on Cloudflare.   This gave the excuse to implement this functionality.