### PR TITLE
Replace some nbsp chars that have slipped into manager.py somehow

### DIFF
--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -288,7 +288,7 @@ class Manager(object):
                     self.log.error('Invalid alias zone {}, target {} does '
                                    'not exist'.format(zone_name, source_zone))
                     raise ManagerException('Invalid alias zone {}: '
-                                           'source zone {} does not exist'
+                                           'source zone {} does not exist'
                                            .format(zone_name, source_zone))
 
                 # Check that the source zone is not an alias zone itself.
@@ -296,7 +296,7 @@ class Manager(object):
                     self.log.error('Invalid alias zone {}, target {} is an '
                                    'alias zone'.format(zone_name, source_zone))
                     raise ManagerException('Invalid alias zone {}: source '
-                                           'zone {} is an alias zone'
+                                           'zone {} is an alias zone'
                                            .format(zone_name, source_zone))
 
                 aliased_zones[zone_name] = source_zone
@@ -482,13 +482,13 @@ class Manager(object):
                 if source_zone not in self.config['zones']:
                     self.log.exception('Invalid alias zone')
                     raise ManagerException('Invalid alias zone {}: '
-                                           'source zone {} does not exist'
+                                           'source zone {} does not exist'
                                            .format(zone_name, source_zone))
 
                 if 'alias' in self.config['zones'][source_zone]:
                     self.log.exception('Invalid alias zone')
                     raise ManagerException('Invalid alias zone {}: '
-                                           'source zone {} is an alias zone'
+                                           'source zone {} is an alias zone'
                                            .format(zone_name, source_zone))
 
                 # this is just here to satisfy coverage, see

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -180,7 +180,7 @@ class TestManager(TestCase):
                 tc = Manager(get_config_filename('unknown-source-zone.yaml')) \
                     .sync()
             self.assertEquals('Invalid alias zone alias.tests.: source zone '
-                              'does-not-exists.tests. does not exist',
+                              'does-not-exists.tests. does not exist',
                               text_type(ctx.exception))
 
             # Alias zone that points to another alias zone.
@@ -188,7 +188,7 @@ class TestManager(TestCase):
                 tc = Manager(get_config_filename('alias-zone-loop.yaml')) \
                     .sync()
             self.assertEquals('Invalid alias zone alias-loop.tests.: source '
-                              'zone alias.tests. is an alias zone',
+                              'zone alias.tests. is an alias zone',
                               text_type(ctx.exception))
 
     def test_compare(self):


### PR DESCRIPTION
```
(env) salmon:octodns ross$ python --version
Python 2.7.16
(env) salmon:octodns ross$ pip --version
pip 20.3.1 from /private/tmp/foo/env/lib/python2.7/site-packages/pip (python 2.7)
(env) salmon:foo ross$ octodns-sync
Traceback (most recent call last):
  File "/private/tmp/foo/env/bin/octodns-sync", line 11, in <module>
    load_entry_point('octodns', 'console_scripts', 'octodns-sync')()
  File "/private/tmp/foo/env/lib/python2.7/site-packages/pkg_resources/__init__.py", line 489, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/private/tmp/foo/env/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2852, in load_entry_point
    return ep.load()
  File "/private/tmp/foo/env/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2443, in load
    return self.resolve()
  File "/private/tmp/foo/env/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2449, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/private/tmp/foo/env/src/octodns/octodns/cmds/sync.py", line 10, in <module>
    from octodns.manager import Manager
  File "/private/tmp/foo/env/src/octodns/octodns/manager.py", line 291
SyntaxError: Non-ASCII character '\xc2' in file /private/tmp/foo/env/src/octodns/octodns/manager.py on line 291, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```

```
$ grep -rn -P --color=always '[^[:print:]]' *.py octodns/ tests/ | head
octodns/record/geo_data.py:18:            'CI': {'name': "Côte d'Ivoire"},
octodns/record/geo_data.py:48:            'RE': {'name': 'Réunion'},
octodns/record/geo_data.py:129:            'AX': {'name': 'Åland Islands'},
octodns/record/geo_data.py:181:            'BL': {'name': 'Saint Barthélemy'},
octodns/record/geo_data.py:202:            'CW': {'name': 'Curaçao'},
octodns/manager.py:291:                                           'source zone {} does not exist'
octodns/manager.py:299:                                           'zone {} is an alias zone'
octodns/manager.py:485:                                           'source zone {} does not exist'
octodns/manager.py:491:                                           'source zone {} is an alias zone'
tests/zones/invalid.zone.:2:@           3600 IN SOA     ns1.invalid.zone. root.invalid.zone. (
```

The geo_data.py file has a utf-8 flag, so it's fine. Will be pushing up another commit that gets the rest of them shortly. 

/cc https://github.com/octodns/octodns/issues/643#issuecomment-742630228 which I found this while looking into