### PR TITLE
Ignore UltraDNS records with unsupported rrtypes and log warning.

### DIFF
--- a/octodns/provider/ultra.py
+++ b/octodns/provider/ultra.py
@@ -291,7 +291,7 @@ class UltraProvider(BaseProvider):
                     _type = self.RECORDS_TO_TYPE[record['rrtype']]
                 except KeyError:
                     self.log.warning('populate: ignoring record with '
-                                     'unsupported rrtype=%s', record)
+                                     'unsupported rrtype, %s  %s', name, record['rrtype'])
                     continue
                 values[name][_type] = record
 

--- a/octodns/provider/ultra.py
+++ b/octodns/provider/ultra.py
@@ -287,7 +287,12 @@ class UltraProvider(BaseProvider):
                 name = zone.hostname_from_fqdn(record['ownerName'])
                 if record['rrtype'] == 'SOA (6)':
                     continue
-                _type = self.RECORDS_TO_TYPE[record['rrtype']]
+                try:
+                    _type = self.RECORDS_TO_TYPE[record['rrtype']]
+                except KeyError:
+                    self.log.warning('populate: ignoring record with '
+                                     'unsupported rrtype=%s', record)
+                    continue
                 values[name][_type] = record
 
             for name, types in values.items():

--- a/octodns/provider/ultra.py
+++ b/octodns/provider/ultra.py
@@ -291,7 +291,8 @@ class UltraProvider(BaseProvider):
                     _type = self.RECORDS_TO_TYPE[record['rrtype']]
                 except KeyError:
                     self.log.warning('populate: ignoring record with '
-                                     'unsupported rrtype, %s  %s', name, record['rrtype'])
+                                     'unsupported rrtype, %s  %s',
+                                     name, record['rrtype'])
                     continue
                 values[name][_type] = record
 

--- a/tests/fixtures/ultra-records-page-1.json
+++ b/tests/fixtures/ultra-records-page-1.json
@@ -87,7 +87,7 @@
         }
     ],
     "resultInfo": {
-        "totalCount": 12,
+        "totalCount": 13,
         "offset": 0,
         "returnedCount": 10
     }

--- a/tests/fixtures/ultra-records-page-2.json
+++ b/tests/fixtures/ultra-records-page-2.json
@@ -24,11 +24,19 @@
                 "order": "FIXED",
                 "description": "octodns1.test."
             }
+        },
+        {
+            "ownerName": "octodns1.test.",
+            "rrtype": "APEXALIAS (65282)",
+            "ttl": 3600,
+            "rdata": [
+                "www.octodns1.test."
+            ]
         }
     ],
     "resultInfo": {
-        "totalCount": 12,
+        "totalCount": 13,
         "offset": 10,
-        "returnedCount": 2
+        "returnedCount": 3
     }
 }

--- a/tests/fixtures/ultra-zones-page-1.json
+++ b/tests/fixtures/ultra-zones-page-1.json
@@ -19,7 +19,7 @@
                 "dnssecStatus": "UNSIGNED",
                 "status": "ACTIVE",
                 "owner": "phelpstest",
-                "resourceRecordCount": 5,
+                "resourceRecordCount": 6,
                 "lastModifiedDateTime": "2020-06-19T01:05Z"
             }
         },


### PR DESCRIPTION
This is a workaround for the issue in https://github.com/octodns/octodns/issues/644
In case we encounter an unsupported record type like APEXALIAS, print a warning with the record and continue.