### PR TITLE
Route53 assumes some records to be always fqdn.

### DIFF
--- a/octodns/provider/route53.py
+++ b/octodns/provider/route53.py
@@ -944,6 +944,12 @@ class Route53Provider(BaseProvider):
                 if record_type not in self.SUPPORTS:
                     # Skip stuff we don't support
                     continue
+                # Route53 treats some records always as fully qualified
+                if record_type in ['CNAME', 'SRV', 'NS']:
+                    rrs = rrset["ResourceRecords"]
+                    rrs = [{k: v if v.endswith('.') else v + '.'
+                            for k, v in r.items()} for r in rrs]
+                    rrset["ResourceRecords"] = rrs
                 if record_name.startswith('_octodns-'):
                     # Part of a dynamic record
                     try:


### PR DESCRIPTION
 Route53 assumes some records to be always fqdn even if it can store them without the trailing dot. Append the trailing dot in such cases when pulling data from their API.

This attempts to fix https://github.com/octodns/octodns/issues/647