### PR TITLE
Update development dependency - Twine to v3.2.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,4 @@ pycodestyle==2.6.0
 pyflakes==2.2.0
 readme_renderer[md]==26.0
 requests_mock
-twine==1.15.0
+twine==3.2.0


### PR DESCRIPTION
Twine version < 2.0 was reported has a security vulnerability

From Twine version 2.0+, it requires Python 3.6, but doesn't seem to
have other breaking changes.

Reference:

- https://github.com/pypa/twine/issues/491
- https://twine.readthedocs.io/en/latest/changelog.html

```
$ safety check --full-report
+==============================================================================+
|                                                                              |
|                               /$$$$$$            /$$                         |
|                              /$$__  $$          | $$                         |
|           /$$$$$$$  /$$$$$$ | $$  \__//$$$$$$  /$$$$$$   /$$   /$$           |
|          /$$_____/ |____  $$| $$$$   /$$__  $$|_  $$_/  | $$  | $$           |
|         |  $$$$$$   /$$$$$$$| $$_/  | $$$$$$$$  | $$    | $$  | $$           |
|          \____  $$ /$$__  $$| $$    | $$_____/  | $$ /$$| $$  | $$           |
|          /$$$$$$$/|  $$$$$$$| $$    |  $$$$$$$  |  $$$$/|  $$$$$$$           |
|         |_______/  \_______/|__/     \_______/   \___/   \____  $$           |
|                                                          /$$  | $$           |
|                                                         |  $$$$$$/           |
|  by pyup.io                                              \______/            |
|                                                                              |
+==============================================================================+
| REPORT                                                                       |
| checked 88 packages, using default DB                                        |
+============================+===========+==========================+==========+
| package                    | installed | affected                 | ID       |
+============================+===========+==========================+==========+
| twine                      | 1.15.0    | <2.0.0                   | 37504    |
+==============================================================================+
| Twine 2.0.0 bumps requests to 2.20 (or later) to avoid reported security     |
| vulnerabilities in earlier releases (bug 491).                               |
+==============================================================================+
```