### PR TITLE
Add fqdn module to setup.py as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
         'PyYaml>=4.2b1',
         'dnspython>=1.15.0',
         'futures>=3.2.0; python_version<"3.2"',
+        'fqdn>=1.5.0',
         'ipaddress>=1.0.22; python_version<"3.3"',
         'natsort>=5.5.0',
         'pycountry>=19.8.18',


### PR DESCRIPTION
Addresses #658 

fqdn module as a requirement was missed in setup.py, no big deal. Just adding it.