### PR TITLE
ZoneFileSource: allow users to specify file extension

### DIFF
--- a/octodns/source/axfr.py
+++ b/octodns/source/axfr.py
@@ -206,17 +206,24 @@ class ZoneFileSource(AxfrBaseSource):
         class: octodns.source.axfr.ZoneFileSource
         # The directory holding the zone files
         # Filenames should match zone name (eg. example.com.)
+        # with optional extension specified with file_extension
         directory: ./zonefiles
+        # File extension on zone files
+        # Appended to zone name to locate file
+        # (optional, default None)
+        file_extension: zone
         # Should sanity checks of the origin node be done
         # (optional, default true)
         check_origin: false
     '''
-    def __init__(self, id, directory, check_origin=True):
+    def __init__(self, id, directory, file_extension=None, check_origin=True):
         self.log = logging.getLogger('ZoneFileSource[{}]'.format(id))
-        self.log.debug('__init__: id=%s, directory=%s, check_origin=%s', id,
-                       directory, check_origin)
+        self.log.debug('__init__: id=%s, directory=%s, file_extension=%s, '
+                       'check_origin=%s', id,
+                       directory, file_extension, check_origin)
         super(ZoneFileSource, self).__init__(id)
         self.directory = directory
+        self.file_extension = file_extension
         self.check_origin = check_origin
 
         self._zone_records = {}
@@ -225,7 +232,11 @@ class ZoneFileSource(AxfrBaseSource):
         zonefiles = listdir(self.directory)
         if zone_name in zonefiles:
             try:
-                z = dns.zone.from_file(join(self.directory, zone_name),
+                filename = zone_name
+                if self.file_extension:
+                    filename = '{}{}'.format(zone_name,
+                                             self.file_extension.lstrip('.'))
+                z = dns.zone.from_file(join(self.directory, filename),
                                        zone_name, relativize=False,
                                        check_origin=self.check_origin)
             except DNSException as error:

--- a/tests/test_octodns_source_axfr.py
+++ b/tests/test_octodns_source_axfr.py
@@ -45,6 +45,13 @@ class TestAxfrSource(TestCase):
 
 class TestZoneFileSource(TestCase):
     source = ZoneFileSource('test', './tests/zones')
+    source_extension = ZoneFileSource('test', './tests/zones', 'extension')
+
+    def test_zonefiles_with_extension(self):
+        # Load zonefiles with a specified file extension
+        valid = Zone('unit.tests.', [])
+        self.source_extension.populate(valid)
+        self.assertEquals(1, len(valid.records))
 
     def test_populate(self):
         # Valid zone file in directory

--- a/tests/zones/unit.tests.extension
+++ b/tests/zones/unit.tests.extension
@@ -1,0 +1,12 @@
+$ORIGIN unit.tests.
+@           3600 IN	SOA	ns1.unit.tests. root.unit.tests. (
+                        2018071501		; Serial
+                        3600    ; Refresh (1 hour)
+                        600     ; Retry (10 minutes)
+                        604800  ; Expire (1 week)
+                        3600    ; NXDOMAIN ttl (1 hour)
+                    )
+
+; NS Records
+@           3600  IN  NS  ns1.unit.tests.
+@           3600  IN  NS  ns2.unit.tests.


### PR DESCRIPTION
Addresses #657 

The Source previously just looked for a file with the same name as the zone, eg `example.com.` in a specified directory. Windows does not allow files to end in a period, which means the default file naming does not work with Windows.

This change allows a user to specify an optional `file_extension` option in the configuration of the source, by doing this OctoDNS will look for a file with the format of `zonename+extension`, eg `example.com.zone`. This allows users to use any extension they want, which commonly `.db`, `.zone` are used with BIND zone files.

```yaml
zonefile:
  class: octodns.source.axfr.ZoneFileSource
  directory: ./zonefiles
  file_extension: zone
```


When specifying the extension, it can contain the leading `.` or not, it will be stripped off regardless, then appended to the zonename, which already contains a period.

/cc @ttk