### PR TITLE
Rename extention zonefile test to avoid existing unit.tests.

### DIFF
--- a/octodns/source/axfr.py
+++ b/octodns/source/axfr.py
@@ -229,14 +229,16 @@ class ZoneFileSource(AxfrBaseSource):
         self._zone_records = {}
 
     def _load_zone_file(self, zone_name):
+
+        zone_filename = zone_name
+        if self.file_extension:
+            zone_filename = '{}{}'.format(zone_name,
+                                          self.file_extension.lstrip('.'))
+
         zonefiles = listdir(self.directory)
-        if zone_name in zonefiles:
+        if zone_filename in zonefiles:
             try:
-                filename = zone_name
-                if self.file_extension:
-                    filename = '{}{}'.format(zone_name,
-                                             self.file_extension.lstrip('.'))
-                z = dns.zone.from_file(join(self.directory, filename),
+                z = dns.zone.from_file(join(self.directory, zone_filename),
                                        zone_name, relativize=False,
                                        check_origin=self.check_origin)
             except DNSException as error:

--- a/tests/test_octodns_source_axfr.py
+++ b/tests/test_octodns_source_axfr.py
@@ -45,12 +45,12 @@ class TestAxfrSource(TestCase):
 
 class TestZoneFileSource(TestCase):
     source = ZoneFileSource('test', './tests/zones')
-    source_extension = ZoneFileSource('test', './tests/zones', 'extension')
 
     def test_zonefiles_with_extension(self):
+        source = ZoneFileSource('test', './tests/zones', 'extension')
         # Load zonefiles with a specified file extension
-        valid = Zone('unit.tests.', [])
-        self.source_extension.populate(valid)
+        valid = Zone('ext.unit.tests.', [])
+        source.populate(valid)
         self.assertEquals(1, len(valid.records))
 
     def test_populate(self):

--- a/tests/zones/ext.unit.tests.extension
+++ b/tests/zones/ext.unit.tests.extension
@@ -1,5 +1,5 @@
-$ORIGIN unit.tests.
-@           3600 IN	SOA	ns1.unit.tests. root.unit.tests. (
+$ORIGIN ext.unit.tests.
+@           3600 IN	SOA	ns1.ext.unit.tests. root.ext.unit.tests. (
                         2018071501		; Serial
                         3600    ; Refresh (1 hour)
                         600     ; Retry (10 minutes)
@@ -8,5 +8,5 @@ $ORIGIN unit.tests.
                     )
 
 ; NS Records
-@           3600  IN  NS  ns1.unit.tests.
-@           3600  IN  NS  ns2.unit.tests.
+@           3600  IN  NS  ns1.ext.unit.tests.
+@           3600  IN  NS  ns2.ext.unit.tests.


### PR DESCRIPTION
The extension handling stuff was getting tricked into working since both `unit.tests.` and `unit.tests.extension` exist.  This was due to looking for `zone_name` in the directory listing which will never exist if using extensions. We need to look for the zone_name + extension in the directory listen and then use that if it exists.

/cc https://github.com/octodns/octodns/pull/663 that lead me to discovering this problem when I tried to fix that one
/cc @yzguy 