### PR TITLE
Modify Azure DNS Client logic to lazy load

### DIFF
--- a/octodns/provider/azuredns.py
+++ b/octodns/provider/azuredns.py
@@ -327,19 +327,19 @@ class AzureProvider(BaseProvider):
         if not self._dns_client_handle:
             # Not initialized yet, we need to do that.
             credentials = ServicePrincipalCredentials(
-                self._dns_client_client_id, 
-                secret=self._dns_client_key, 
+                self._dns_client_client_id,
+                secret=self._dns_client_key,
                 tenant=self._dns_client_directory_id
             )
             self._dns_client_handle = DnsManagementClient(
-                credentials, 
+                credentials,
                 self._dns_client_subscription_id
             )
-            
+
         return self._dns_client_handle
+
     def _set_dns_client(self, client)
         self.dns_client_handle = client
-            
 
     def __init__(self, id, client_id, key, directory_id, sub_id,
                  resource_group, *args, **kwargs):

--- a/octodns/provider/azuredns.py
+++ b/octodns/provider/azuredns.py
@@ -352,7 +352,7 @@ class AzureProvider(BaseProvider):
         self._dns_client_key = key
         self._dns_client_directory_id = directory_id
         self._dns_client_subscription_id = sub_id
-        self._dns_client = property(_get_dns_client, _set_dns_client)
+        self._dns_client = property(_get_dns_client)
         self._resource_group = resource_group
         self._azure_zones = set()
 

--- a/octodns/provider/azuredns.py
+++ b/octodns/provider/azuredns.py
@@ -342,7 +342,7 @@ class AzureProvider(BaseProvider):
         self._azure_zones = set()
 
     @property
-    def _dns_client(self)
+    def _dns_client(self):
         if self._dns_client is None:
             credentials = ServicePrincipalCredentials(
                 self._dns_client_client_id,

--- a/octodns/provider/azuredns.py
+++ b/octodns/provider/azuredns.py
@@ -337,6 +337,8 @@ class AzureProvider(BaseProvider):
             )
             
         return self._dns_client_handle
+    def _set_dns_client(self, client)
+        self.dns_client_handle = client
             
 
     def __init__(self, id, client_id, key, directory_id, sub_id,
@@ -352,7 +354,7 @@ class AzureProvider(BaseProvider):
         self._dns_client_key = key
         self._dns_client_directory_id = directory_id
         self._dns_client_subscription_id = sub_id
-        self._dns_client = property(_get_dns_client)
+        self._dns_client = property(_get_dns_client, _set_dns_client)
         self._resource_group = resource_group
         self._azure_zones = set()
 

--- a/octodns/provider/azuredns.py
+++ b/octodns/provider/azuredns.py
@@ -323,24 +323,6 @@ class AzureProvider(BaseProvider):
     SUPPORTS = set(('A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NS', 'PTR', 'SRV',
                     'TXT'))
 
-    def _get_dns_client(self):
-        if not self._dns_client_handle:
-            # Not initialized yet, we need to do that.
-            credentials = ServicePrincipalCredentials(
-                self._dns_client_client_id,
-                secret=self._dns_client_key,
-                tenant=self._dns_client_directory_id
-            )
-            self._dns_client_handle = DnsManagementClient(
-                credentials,
-                self._dns_client_subscription_id
-            )
-
-        return self._dns_client_handle
-
-    def _set_dns_client(self, client)
-        self.dns_client_handle = client
-
     def __init__(self, id, client_id, key, directory_id, sub_id,
                  resource_group, *args, **kwargs):
         self.log = logging.getLogger('AzureProvider[{}]'.format(id))
@@ -354,9 +336,24 @@ class AzureProvider(BaseProvider):
         self._dns_client_key = key
         self._dns_client_directory_id = directory_id
         self._dns_client_subscription_id = sub_id
-        self._dns_client = property(_get_dns_client, _set_dns_client)
+        self._dns_client = None
+
         self._resource_group = resource_group
         self._azure_zones = set()
+
+    @property
+    def _dns_client(self)
+        if self._dns_client is None:
+            credentials = ServicePrincipalCredentials(
+                self._dns_client_client_id,
+                secret=self._dns_client_key,
+                tenant=self._dns_client_directory_id
+            )
+            self._dns_client = DnsManagementClient(
+                credentials,
+                self._dns_client_subscription_id
+            )
+        return self._dns_client
 
     def _populate_zones(self):
         self.log.debug('azure_zones: loading')

--- a/tests/test_octodns_provider_azuredns.py
+++ b/tests/test_octodns_provider_azuredns.py
@@ -389,7 +389,8 @@ class TestAzureDnsProvider(TestCase):
             :type return: AzureProvider
         '''
         provider = AzureProvider('mock_id', 'mock_client', 'mock_key',
-                             'mock_directory', 'mock_sub', 'mock_rg')
+                                 'mock_directory', 'mock_sub', 'mock_rg'
+        )
         # Fetch the client to force it to load the creds
         client = provider._dns_client
         return provider

--- a/tests/test_octodns_provider_azuredns.py
+++ b/tests/test_octodns_provider_azuredns.py
@@ -392,7 +392,7 @@ class TestAzureDnsProvider(TestCase):
                                  'mock_directory', 'mock_sub', 'mock_rg'
                                  )
         # Fetch the client to force it to load the creds
-        client = provider._dns_client
+        provider._dns_client
         return provider
 
     def test_populate_records(self):

--- a/tests/test_octodns_provider_azuredns.py
+++ b/tests/test_octodns_provider_azuredns.py
@@ -376,8 +376,6 @@ class TestAzureDnsProvider(TestCase):
     def _provider(self):
         return self._get_provider('mock_spc', 'mock_dns_client')
 
-    @patch('octodns.provider.azuredns.DnsManagementClient')
-    @patch('octodns.provider.azuredns.ServicePrincipalCredentials')
     def _get_provider(self, mock_spc, mock_dns_client):
         '''Returns a mock AzureProvider object to use in testing.
 
@@ -390,7 +388,9 @@ class TestAzureDnsProvider(TestCase):
         '''
         return AzureProvider('mock_id', 'mock_client', 'mock_key',
                              'mock_directory', 'mock_sub', 'mock_rg')
-
+    
+    @patch('octodns.provider.azuredns.DnsManagementClient')
+    @patch('octodns.provider.azuredns.ServicePrincipalCredentials')
     def test_populate_records(self):
         provider = self._get_provider()
 
@@ -501,7 +501,9 @@ class TestAzureDnsProvider(TestCase):
         exists = provider.populate(zone)
         self.assertTrue(exists)
         self.assertEquals(len(zone.records), 17)
-
+    
+    @patch('octodns.provider.azuredns.DnsManagementClient')
+    @patch('octodns.provider.azuredns.ServicePrincipalCredentials')
     def test_populate_zone(self):
         provider = self._get_provider()
 
@@ -512,7 +514,9 @@ class TestAzureDnsProvider(TestCase):
         provider._populate_zones()
 
         self.assertEquals(len(provider._azure_zones), 1)
-
+    
+    @patch('octodns.provider.azuredns.DnsManagementClient')
+    @patch('octodns.provider.azuredns.ServicePrincipalCredentials')
     def test_bad_zone_response(self):
         provider = self._get_provider()
 
@@ -539,6 +543,8 @@ class TestAzureDnsProvider(TestCase):
         self.assertEquals(19, provider.apply(Plan(zone, zone,
                                                   deletes, True)))
 
+    @patch('octodns.provider.azuredns.DnsManagementClient')
+    @patch('octodns.provider.azuredns.ServicePrincipalCredentials')
     def test_create_zone(self):
         provider = self._get_provider()
 
@@ -555,6 +561,8 @@ class TestAzureDnsProvider(TestCase):
         self.assertEquals(19, provider.apply(Plan(None, desired, changes,
                                                   True)))
 
+    @patch('octodns.provider.azuredns.DnsManagementClient')
+    @patch('octodns.provider.azuredns.ServicePrincipalCredentials')
     def test_check_zone_no_create(self):
         provider = self._get_provider()
 

--- a/tests/test_octodns_provider_azuredns.py
+++ b/tests/test_octodns_provider_azuredns.py
@@ -375,7 +375,7 @@ class Test_CheckAzureAlias(TestCase):
 class TestAzureDnsProvider(TestCase):
     def _provider(self):
         return self._get_provider('mock_spc', 'mock_dns_client')
-    
+
     @patch('octodns.provider.azuredns.DnsManagementClient')
     @patch('octodns.provider.azuredns.ServicePrincipalCredentials')
     def _get_provider(self, mock_spc, mock_dns_client):
@@ -393,9 +393,7 @@ class TestAzureDnsProvider(TestCase):
         # Fetch the client to force it to load the creds
         client = provider._dns_client
         return provider
-    
-    @patch('octodns.provider.azuredns.DnsManagementClient')
-    @patch('octodns.provider.azuredns.ServicePrincipalCredentials')
+
     def test_populate_records(self):
         provider = self._get_provider()
 
@@ -506,9 +504,7 @@ class TestAzureDnsProvider(TestCase):
         exists = provider.populate(zone)
         self.assertTrue(exists)
         self.assertEquals(len(zone.records), 17)
-    
-    @patch('octodns.provider.azuredns.DnsManagementClient')
-    @patch('octodns.provider.azuredns.ServicePrincipalCredentials')
+
     def test_populate_zone(self):
         provider = self._get_provider()
 
@@ -519,9 +515,7 @@ class TestAzureDnsProvider(TestCase):
         provider._populate_zones()
 
         self.assertEquals(len(provider._azure_zones), 1)
-    
-    @patch('octodns.provider.azuredns.DnsManagementClient')
-    @patch('octodns.provider.azuredns.ServicePrincipalCredentials')
+
     def test_bad_zone_response(self):
         provider = self._get_provider()
 
@@ -548,8 +542,6 @@ class TestAzureDnsProvider(TestCase):
         self.assertEquals(19, provider.apply(Plan(zone, zone,
                                                   deletes, True)))
 
-    @patch('octodns.provider.azuredns.DnsManagementClient')
-    @patch('octodns.provider.azuredns.ServicePrincipalCredentials')
     def test_create_zone(self):
         provider = self._get_provider()
 
@@ -566,8 +558,6 @@ class TestAzureDnsProvider(TestCase):
         self.assertEquals(19, provider.apply(Plan(None, desired, changes,
                                                   True)))
 
-    @patch('octodns.provider.azuredns.DnsManagementClient')
-    @patch('octodns.provider.azuredns.ServicePrincipalCredentials')
     def test_check_zone_no_create(self):
         provider = self._get_provider()
 

--- a/tests/test_octodns_provider_azuredns.py
+++ b/tests/test_octodns_provider_azuredns.py
@@ -375,7 +375,9 @@ class Test_CheckAzureAlias(TestCase):
 class TestAzureDnsProvider(TestCase):
     def _provider(self):
         return self._get_provider('mock_spc', 'mock_dns_client')
-
+    
+    @patch('octodns.provider.azuredns.DnsManagementClient')
+    @patch('octodns.provider.azuredns.ServicePrincipalCredentials')
     def _get_provider(self, mock_spc, mock_dns_client):
         '''Returns a mock AzureProvider object to use in testing.
 
@@ -386,8 +388,11 @@ class TestAzureDnsProvider(TestCase):
 
             :type return: AzureProvider
         '''
-        return AzureProvider('mock_id', 'mock_client', 'mock_key',
+        provider = AzureProvider('mock_id', 'mock_client', 'mock_key',
                              'mock_directory', 'mock_sub', 'mock_rg')
+        # Fetch the client to force it to load the creds
+        client = provider._dns_client
+        return provider
     
     @patch('octodns.provider.azuredns.DnsManagementClient')
     @patch('octodns.provider.azuredns.ServicePrincipalCredentials')

--- a/tests/test_octodns_provider_azuredns.py
+++ b/tests/test_octodns_provider_azuredns.py
@@ -390,7 +390,7 @@ class TestAzureDnsProvider(TestCase):
         '''
         provider = AzureProvider('mock_id', 'mock_client', 'mock_key',
                                  'mock_directory', 'mock_sub', 'mock_rg'
-        )
+                                 )
         # Fetch the client to force it to load the creds
         client = provider._dns_client
         return provider


### PR DESCRIPTION
Lazy loading the Azure DNS client ensures that the necessary network calls only occur when it is time to actually do something with the client.