### PR TITLE
Force the value passed to FQDN to be a str

### DIFF
--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -758,7 +758,9 @@ class _TargetValue(object):
             reasons.append('empty value')
         elif not data:
             reasons.append('missing value')
-        elif not FQDN(data, allow_underscores=True).is_valid:
+        # NOTE: FQDN complains if the data it receives isn't a str, it doesn't
+        # allow unicode... This is likely specific to 2.7
+        elif not FQDN(str(data), allow_underscores=True).is_valid:
             reasons.append('{} value "{}" is not a valid FQDN'
                            .format(_type, data))
         elif not data.endswith('.'):


### PR DESCRIPTION
When working with python 2.7 and `unicode` strings FQDN complains that what's passed to it isn't a `str`. This should work around that for as long as we support python 2.7.

/cc @rreichel3 for 👍 