### PR TITLE
PowerDNS: Delete records before creating or modifying records

### DIFF
--- a/octodns/provider/powerdns.py
+++ b/octodns/provider/powerdns.py
@@ -386,7 +386,7 @@ class PowerDnsBaseProvider(BaseProvider):
         # Ensure that any DELETE modifications always occur before any REPLACE
         # modifications. This ensures that an A record can be replaced by a
         # CNAME record and vice-versa.
-        mods = sorted(mods, key=itemgetter('changetype'))
+        mods.sort(key=itemgetter('changetype'))
 
         self.log.debug('_apply:   sending change request')
 

--- a/octodns/provider/powerdns.py
+++ b/octodns/provider/powerdns.py
@@ -6,8 +6,8 @@ from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
 from requests import HTTPError, Session
-import logging
 from operator import itemgetter
+import logging
 
 from ..record import Create, Record
 from .base import BaseProvider


### PR DESCRIPTION
This PR is related to the overall ordering issue discussed in https://github.com/octodns/octodns/issues/656, though solves this specifically for the PowerDNS provider.

When replacing an `A` record with a `CNAME` record or vice-versa, the existing record must be removed in a PowerDNS `DELETE` change first, otherwise the PowerDNS `REPLACE` change will fail, as a `CNAME` and `A` record cannot co-exist, even briefly.

/cc @ross @dbussink 