### PR TITLE
Remove formal python 2.7 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,7 @@ jobs:
     strategy:
       matrix:
         # Tested versions based on dates in https://devguide.python.org/devcycle/#end-of-life-branches, 
-        # with the addition of 2.7 b/c it's still if pretty wide active use.
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@master
       - name: Setup python

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,5 +5,4 @@ pycodestyle==2.6.0
 pyflakes==2.2.0
 readme_renderer[md]==26.0
 requests_mock
-twine==1.15.0; python_version < '3.2'
 twine==3.2.0; python_version >= '3.2'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,5 @@ pycodestyle==2.6.0
 pyflakes==2.2.0
 readme_renderer[md]==26.0
 requests_mock
-twine==3.2.0
+twine==1.15.0; python_version < '3.2'
+twine==3.2.0; python_version >= '3.2'


### PR DESCRIPTION
I give up. setuptools/pip have started breaking things in earnest and pinned versions of things that have worked for over a year no longer work:

```
      File "/opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/site-packages/setuptools/config.py", line 425, in parse
        section_parser_method(section_options)
      File "/opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/site-packages/setuptools/config.py", line 398, in parse_section
        self[name] = value
      File "/opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/site-packages/setuptools/config.py", line 183, in __setitem__
        value = parser(value)
      File "/opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/site-packages/setuptools/config.py", line 574, in _parse_packages
        'find_namespace: directive is unsupported on Python < 3.3')
    distutils.errors.DistutilsOptionError: find_namespace: directive is unsupported on Python < 3.3
```

I just spent the better part of an 30m trying to reproduce the failure in https://github.com/octodns/octodns/pull/677/checks?check_run_id=1911602044 and I can't do it on my laptop or in docker containers. I do get a number of other failures with 2.7, e.g.

```
./script/test
........................F.........../octodns-master/env/lib/python2.7/site-packages/jwt/utils.py:8: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.hazmat.primitives.asymmetric.utils import (
.......E............................................................................................................................................................................................................................................E.F..................................................................................E..................
======================================================================
ERROR: test_check_for_alias (test_octodns_provider_azuredns.Test_CheckAzureAlias)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/octodns-master/tests/test_octodns_provider_azuredns.py", line 366, in test_check_for_alias
    alias_record = type('C', (object,), {})
TypeError: type() argument 1 must be string, not unicode

======================================================================
ERROR: test_gen_data (test_octodns_provider_ultra.TestUltraProvider)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/octodns-master/tests/test_octodns_provider_ultra.py", line 503, in test_gen_data
    expected_payload, False)
  File "/octodns-master/octodns/provider/ultra.py", line 272, in _record_for
    data = data_for(_type, records)
  File "/octodns-master/octodns/provider/ultra.py", line 198, in _data_for_AAAA
    records['rdata'][i] = str(ip_address(v))
  File "/octodns-master/env/lib/python2.7/site-packages/ipaddress.py", line 165, in ip_address
    ' a unicode object?' % address)
AddressValueError: '::1' does not appear to be an IPv4 or IPv6 address. Did you pass in a bytes (str in Python 2) instead of a unicode object?
-------------------- >> begin captured logging << --------------------
UltraProvider[test]: DEBUG: __init__: id=test, account=testacct, username=user, password=***
UltraProvider[test]: DEBUG: __init__: id=test, apply_disabled=False, update_pcent_threshold=0.30, delete_pcent_threshold=0.30
UltraProvider[test]: DEBUG: _request: method=POST, path=/v2/authorization/token
requests_mock.adapter: DEBUG: POST https://restapi.ultradns.com/v2/authorization/token 200
UltraProvider[test]: DEBUG: _request:   status=200
Zone: DEBUG: __init__: zone=Zone<unit.tests.>, sub_zones=[]
Record: DEBUG: __init__: zone.name=unit.tests., type=    ARecord, name=a
Record: DEBUG: __init__: zone.name=unit.tests., type=    ARecord, name=a
Record: DEBUG: __init__: zone.name=unit.tests., type= AaaaRecord, name=aaaa
Record: DEBUG: __init__: zone.name=unit.tests., type= AaaaRecord, name=aaaa
Record: DEBUG: __init__: zone.name=unit.tests., type=  CaaRecord, name=caa
Record: DEBUG: __init__: zone.name=unit.tests., type=CnameRecord, name=cname
Record: DEBUG: __init__: zone.name=unit.tests., type=   MxRecord, name=mx
Record: DEBUG: __init__: zone.name=unit.tests., type=   NsRecord, name=ns
Record: DEBUG: __init__: zone.name=unit.tests., type=  PtrRecord, name=ptr
Record: DEBUG: __init__: zone.name=unit.tests., type=  SpfRecord, name=spf
Record: DEBUG: __init__: zone.name=unit.tests., type=  SrvRecord, name=_srv._tcp
Record: DEBUG: __init__: zone.name=unit.tests., type=  TxtRecord, name=txt
Record: DEBUG: __init__: zone.name=unit.tests., type=    ARecord, name=a
Record: DEBUG: __init__: zone.name=unit.tests., type=    ARecord, name=a
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: Failure: ImportError (No module named mock)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/octodns-master/env/lib/python2.7/site-packages/nose/loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "/octodns-master/env/lib/python2.7/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/octodns-master/env/lib/python2.7/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/octodns-master/tests/test_octodns_source_envvar.py", line 3, in <module>
    from unittest.mock import patch
ImportError: No module named mock

======================================================================
FAIL: test_populate_lenient_fallback (test_octodns_manager.TestManager)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/octodns-master/tests/test_octodns_manager.py", line 372, in test_populate_lenient_fallback
    manager._populate_and_plan('unit.tests.', [NoZone()], [])
AssertionError: TypeError not raised
-------------------- >> begin captured logging << --------------------
Manager: INFO: __init__: config_file=/octodns-master/tests/config/simple.yaml
Manager: INFO: __init__:   max_workers=2
Manager: INFO: __init__:   include_meta=False
Manager: DEBUG: __init__:   configuring providers
YamlProvider[dump2]: DEBUG: __init__: id=dump2, directory=/tmp/tmpAHtSVJ, default_ttl=3600, enforce_order=1, populate_should_replace=0
YamlProvider[dump2]: DEBUG: __init__: id=dump2, apply_disabled=False, update_pcent_threshold=0.30, delete_pcent_threshold=0.30
YamlProvider[dump]: DEBUG: __init__: id=dump, directory=/tmp/tmpAHtSVJ, default_ttl=3600, enforce_order=1, populate_should_replace=0
YamlProvider[dump]: DEBUG: __init__: id=dump, apply_disabled=False, update_pcent_threshold=0.30, delete_pcent_threshold=0.30
YamlProvider[in]: DEBUG: __init__: id=in, directory=tests/config, default_ttl=3600, enforce_order=1, populate_should_replace=0
YamlProvider[in]: DEBUG: __init__: id=in, apply_disabled=False, update_pcent_threshold=0.30, delete_pcent_threshold=0.30
Manager: DEBUG: sync:   populating, zone=unit.tests., lenient=False
Manager: DEBUG: configured_sub_zones: subs=[u'subzone']
Zone: DEBUG: __init__: zone=Zone<unit.tests.>, sub_zones=set([u'subzone'])
Manager: WARNING: : provider NoLenient does not accept lenient param
Manager: DEBUG: sync:   planning, zone=unit.tests.
Manager: DEBUG: sync:   populating, zone=unit.tests., lenient=False
Manager: DEBUG: configured_sub_zones: subs=[u'subzone']
Zone: DEBUG: __init__: zone=Zone<unit.tests.>, sub_zones=set([u'subzone'])
Manager: WARNING: : provider NoZone does not accept lenient param
Manager: DEBUG: sync:   planning, zone=unit.tests.
--------------------- >> end captured logging << ---------------------

======================================================================
FAIL: test_login (test_octodns_provider_ultra.TestUltraProvider)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/octodns-master/tests/test_octodns_provider_ultra.py", line 58, in test_login
    self.assertEquals(mock.last_request.text, expected_payload)
AssertionError: u'username=user&password=rightpass&grant_type=password' != 'grant_type=password&username=user&password=rightpass'
-------------------- >> begin captured logging << --------------------
UltraProvider[test]: DEBUG: __init__: id=test, account=account, username=user, password=***
UltraProvider[test]: DEBUG: __init__: id=test, apply_disabled=False, update_pcent_threshold=0.30, delete_pcent_threshold=0.30
UltraProvider[test]: DEBUG: _request: method=POST, path=/v2/authorization/token
requests_mock.adapter: DEBUG: POST https://restapi.ultradns.com/v2/authorization/token 401
UltraProvider[test]: DEBUG: _request:   status=401
UltraProvider[test]: DEBUG: __init__: id=test, account=account, username=user, password=***
UltraProvider[test]: DEBUG: __init__: id=test, apply_disabled=False, update_pcent_threshold=0.30, delete_pcent_threshold=0.30
UltraProvider[test]: DEBUG: _request: method=POST, path=/v2/authorization/token
requests_mock.adapter: DEBUG: POST https://restapi.ultradns.com/v2/authorization/token 200
UltraProvider[test]: DEBUG: _request:   status=200
--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------
Ran 384 tests in 12.676s

FAILED (errors=3, failures=2)
```

So calling it a day. Anyone still using 2.7 can probably continue to do it for the time being, but ymmv and I would expect things to start breaking pretty hard soon. 😦 

