### PR TITLE
Revert "Stopped running CI for doc changes."

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,5 @@
 name: OctoDNS
-on:
-  pull_request:
-    paths-ignore:
-      - '**.md'
+on: [pull_request]
 
 jobs:
   ci:


### PR DESCRIPTION
This reverts commit a8366aa02db6fac3d090f0d9a12edf3f7916ab4a.

If CI is skipped for MD changes doc-only PRs can't be merged b/c the builds are required (to be passing) to merge. Doesn't hurt to go ahead and run them, little annoying, but otherwise things are stuck:

<img width="951" alt="Screen Shot 2021-03-17 at 5 05 36 PM" src="https://user-images.githubusercontent.com/12789/111554149-ff8db380-8742-11eb-9f26-1143ada05933.png">