### PR TITLE
Change the auth value to have a proper string not a binary rep

### DIFF
--- a/octodns/provider/easydns.py
+++ b/octodns/provider/easydns.py
@@ -59,7 +59,7 @@ class EasyDNSClient(object):
         self.base_path = self.SANDBOX if sandbox else self.LIVE
         sess = Session()
         sess.headers.update({'Authorization': 'Basic {}'
-                             .format(self.auth_key)})
+                             .format(self.auth_key.decode('utf-8'))})
         sess.headers.update({'accept': 'application/json'})
         self._sess = sess
 


### PR DESCRIPTION
I was unable to actually authorize to EasyDNS because the Authorization Header was sending data as b'[encoded_data]' instead of the actual string needed. So I changed that so that I could authorize properly.