### PR TITLE
Enable NS support for non-root NS records

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ The above command pulled the existing data out of Route53 and placed the results
 | [Rackspace](/octodns/provider/rackspace.py) | | A, AAAA, ALIAS, CNAME, MX, NS, PTR, SPF, TXT | No |  |
 | [Route53](/octodns/provider/route53.py) | boto3 | A, AAAA, CAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, TXT | Both | CNAME health checks don't support a Host header |
 | [Selectel](/octodns/provider/selectel.py) | | A, AAAA, CNAME, MX, NS, SPF, SRV, TXT | No | |
-| [Transip](/octodns/provider/transip.py) | transip | A, AAAA, CNAME, MX, SRV, SPF, TXT, SSHFP, CAA | No | |
+| [Transip](/octodns/provider/transip.py) | transip | A, AAAA, CNAME, MX, NS, SRV, SPF, TXT, SSHFP, CAA | No | |
 | [UltraDns](/octodns/provider/ultra.py) | | A, AAAA, CAA, CNAME, MX, NS, PTR, SPF, SRV, TXT | No | |
 | [AxfrSource](/octodns/source/axfr.py) | | A, AAAA, CAA, CNAME, LOC, MX, NS, PTR, SPF, SRV, TXT | No | read-only |
 | [ZoneFileSource](/octodns/source/axfr.py) | | A, AAAA, CAA, CNAME, MX, NS, PTR, SPF, SRV, TXT | No | read-only |

--- a/octodns/provider/transip.py
+++ b/octodns/provider/transip.py
@@ -50,7 +50,7 @@ class TransipProvider(BaseProvider):
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
     SUPPORTS = set(
-        ('A', 'AAAA', 'CNAME', 'MX', 'SRV', 'SPF', 'TXT', 'SSHFP', 'CAA'))
+        ('A', 'AAAA', 'CNAME', 'MX', 'SRV', 'SPF', 'TXT', 'SSHFP', 'CAA', 'NS'))
     # unsupported by OctoDNS: 'TLSA'
     MIN_TTL = 120
     TIMEOUT = 15

--- a/octodns/provider/transip.py
+++ b/octodns/provider/transip.py
@@ -49,8 +49,8 @@ class TransipProvider(BaseProvider):
     '''
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
-    SUPPORTS = set(
-        ('A', 'AAAA', 'CNAME', 'MX', 'SRV', 'SPF', 'TXT', 'SSHFP', 'CAA', 'NS'))
+    SUPPORTS = set(('A', 'AAAA', 'CNAME', 'MX', 'NS', 'SRV', 'SPF', 'TXT',
+                    'SSHFP', 'CAA'))
     # unsupported by OctoDNS: 'TLSA'
     MIN_TTL = 120
     TIMEOUT = 15

--- a/tests/test_octodns_provider_transip.py
+++ b/tests/test_octodns_provider_transip.py
@@ -56,10 +56,11 @@ class MockDomainService(DomainService):
 
                 _dns_entries.extend(entries_for(name, record))
 
-                # NS is not supported as a DNS Entry,
-                # so it should cover the if statement
+                # Add a non-supported type
+                # so it triggers the "is supported" (transip.py:115) check and
+                # give 100% code coverage
                 _dns_entries.append(
-                    DnsEntry('@', '3600', 'NS', 'ns01.transip.nl.'))
+                    DnsEntry('@', '3600', 'BOGUS', 'ns01.transip.nl.'))
 
         self.mockupEntries = _dns_entries
 
@@ -222,7 +223,7 @@ N4OiVz1I3rbZGYa396lpxO6ku8yCglisL1yrSP6DdEUp66ntpKVd
         provider._client = MockDomainService('unittest', self.bogus_key)
         plan = provider.plan(_expected)
 
-        self.assertEqual(14, plan.change_counts['Create'])
+        self.assertEqual(15, plan.change_counts['Create'])
         self.assertEqual(0, plan.change_counts['Update'])
         self.assertEqual(0, plan.change_counts['Delete'])
 
@@ -235,7 +236,7 @@ N4OiVz1I3rbZGYa396lpxO6ku8yCglisL1yrSP6DdEUp66ntpKVd
         provider = TransipProvider('test', 'unittest', self.bogus_key)
         provider._client = MockDomainService('unittest', self.bogus_key)
         plan = provider.plan(_expected)
-        self.assertEqual(14, len(plan.changes))
+        self.assertEqual(15, len(plan.changes))
         changes = provider.apply(plan)
         self.assertEqual(changes, len(plan.changes))
 


### PR DESCRIPTION
Transip api support NS type for non-root records.

This PR will just enable NS support , provider was prepared for supporting NS type records.