### PR TITLE
Capture plan output in File as argument to sync

### DIFF
--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -270,8 +270,9 @@ class Manager(object):
     def sync(self, eligible_zones=[], eligible_sources=[], eligible_targets=[],
              dry_run=True, force=False, plan_output_fh=stdout):
         self.log.info('sync: eligible_zones=%s, eligible_targets=%s, '
-                      'dry_run=%s, force=%s', eligible_zones, eligible_targets,
-                      dry_run, force)
+                      'dry_run=%s, force=%s, plan_output_fh=%s',
+                      eligible_zones, eligible_targets, dry_run, force,
+                      plan_output_fh)
 
         zones = self.config['zones'].items()
         if eligible_zones:

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -272,7 +272,7 @@ class Manager(object):
         self.log.info('sync: eligible_zones=%s, eligible_targets=%s, '
                       'dry_run=%s, force=%s, plan_output_fh=%s',
                       eligible_zones, eligible_targets, dry_run, force,
-                      plan_output_fh)
+                      getattr(plan_output_fh, 'name', plan_output_fh.__class__.__name__))
 
         zones = self.config['zones'].items()
         if eligible_zones:

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -9,6 +9,7 @@ from concurrent.futures import ThreadPoolExecutor
 from importlib import import_module
 from os import environ
 from six import text_type
+from sys import stdout
 import logging
 
 from .provider.base import BaseProvider
@@ -267,7 +268,7 @@ class Manager(object):
         return plans, zone
 
     def sync(self, eligible_zones=[], eligible_sources=[], eligible_targets=[],
-             dry_run=True, force=False):
+             dry_run=True, force=False, plan_output_fh=stdout):
         self.log.info('sync: eligible_zones=%s, eligible_targets=%s, '
                       'dry_run=%s, force=%s', eligible_zones, eligible_targets,
                       dry_run, force)
@@ -276,7 +277,7 @@ class Manager(object):
         if eligible_zones:
             zones = [z for z in zones if z[0] in eligible_zones]
 
-        aliased_zones  = {}
+        aliased_zones = {}
         futures = []
         for zone_name, config in zones:
             self.log.info('sync:   zone=%s', zone_name)
@@ -402,7 +403,7 @@ class Manager(object):
         plans.sort(key=self._plan_keyer, reverse=True)
 
         for output in self.plan_outputs.values():
-            output.run(plans=plans, log=self.log)
+            output.run(plans=plans, log=self.log, fh=plan_output_fh)
 
         if not force:
             self.log.debug('sync:   checking safety')

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -269,10 +269,12 @@ class Manager(object):
 
     def sync(self, eligible_zones=[], eligible_sources=[], eligible_targets=[],
              dry_run=True, force=False, plan_output_fh=stdout):
-        self.log.info('sync: eligible_zones=%s, eligible_targets=%s, '
-                      'dry_run=%s, force=%s, plan_output_fh=%s',
-                      eligible_zones, eligible_targets, dry_run, force,
-                      getattr(plan_output_fh, 'name', plan_output_fh.__class__.__name__))
+
+        self.log.info(
+            'sync: eligible_zones=%s, eligible_targets=%s, dry_run=%s, '
+            'force=%s, plan_output_fh=%s',
+            eligible_zones, eligible_targets, dry_run, force,
+            getattr(plan_output_fh, 'name', plan_output_fh.__class__.__name__))
 
         zones = self.config['zones'].items()
         if eligible_zones:

--- a/tests/config/plan-output-filehandle.yaml
+++ b/tests/config/plan-output-filehandle.yaml
@@ -1,0 +1,6 @@
+manager:
+  plan_outputs:
+    "doesntexist":
+      class: octodns.provider.plan.DoesntExist
+providers: {}
+zones: {}

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -18,7 +18,6 @@ from octodns.zone import Zone
 from mock import MagicMock, patch
 from unittest import TestCase
 
-
 from helpers import DynamicProvider, GeoProvider, NoSshFpProvider, \
     SimpleProvider, TemporaryDirectory
 

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -8,13 +8,16 @@ from __future__ import absolute_import, division, print_function, \
 from os import environ
 from os.path import dirname, join
 from six import text_type
-from unittest import TestCase
 
 from octodns.record import Record
 from octodns.manager import _AggregateTarget, MainThreadExecutor, Manager, \
     ManagerException
 from octodns.yaml import safe_load
 from octodns.zone import Zone
+
+from mock import MagicMock, patch
+from unittest import TestCase
+
 
 from helpers import DynamicProvider, GeoProvider, NoSshFpProvider, \
     SimpleProvider, TemporaryDirectory
@@ -370,6 +373,24 @@ class TestManager(TestCase):
             # This will blow up, we don't fallback for source
             with self.assertRaises(TypeError):
                 manager._populate_and_plan('unit.tests.', [NoZone()], [])
+
+    @patch('octodns.manager.Manager._get_named_class')
+    def test_sync_passes_file_handle(self, mock):
+        plan_output_mock = MagicMock()
+        plan_output_class_mock = MagicMock()
+        plan_output_class_mock.return_value = plan_output_mock
+        mock.return_value = plan_output_class_mock
+        fh_mock = MagicMock()
+
+        Manager(get_config_filename('plan-output-filehandle.yaml')
+                ).sync(plan_output_fh=fh_mock)
+
+        # Since we only care about the fh kwarg, and different _PlanOutputs are
+        # are free to require arbitrary kwargs anyway, we concern ourselves
+        # with checking the value of fh only.
+        plan_output_mock.run.assert_called()
+        _, kwargs = plan_output_mock.run.call_args
+        self.assertEqual(fh_mock, kwargs.get('fh'))
 
 
 class TestMainThreadExecutor(TestCase):


### PR DESCRIPTION
Capture plan output in File as argument to sync.

The `Manager.sync` method accepts a `plan_output_fh` argument, which is passed
to `_PlanOutput.run` as `fh`. This latter functionality already exists. The
goal is to make it easier to capture plan output in a human-readable format
as part of CI/CD automation.