### PR TITLE
Change DNSimple's Provider to query zones instead domains

### DIFF
--- a/octodns/provider/dnsimple.py
+++ b/octodns/provider/dnsimple.py
@@ -51,8 +51,8 @@ class DnsimpleClient(object):
         resp.raise_for_status()
         return resp
 
-    def domain(self, name):
-        path = '/domains/{}'.format(name)
+    def zone(self, name):
+        path = '/zones/{}'.format(name)
         return self._request('GET', path).json()
 
     def domain_create(self, name):
@@ -442,7 +442,7 @@ class DnsimpleProvider(BaseProvider):
 
         domain_name = desired.name[:-1]
         try:
-            self._client.domain(domain_name)
+            self._client.zone(domain_name)
         except DnsimpleClientNotFound:
             self.log.debug('_apply:   no matching zone, creating domain')
             self._client.domain_create(domain_name)


### PR DESCRIPTION
A quick summary of a problem with the current DNSimple provider:
Let's suppose that I have the following config:

zones:
  30.100.194.in-addr.arpa.:
    sources:
      - config
    targets:
      - dnsimple

Even if a customer has this Reverse zone configured in DNSimple, this
fails with:

400 Bad Request for url: https://api.sandbox.dnsimple.com/v2/x/domains

because it is trying to create a domain because the zone wasn't found.
octodns.provider.dnsimple.DnsimpleClientNotFound: Not found

This happens because the GET /domains endpoint at DNSimple does not
bring Reverse Zones. To make this work nice, we should use /zones/
instead making it return properly the reverse zones.