### PR TITLE
Add a validation requiring single value weight=1

### DIFF
--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -573,6 +573,10 @@ class _DynamicMixin(object):
                         reasons.append('missing value in pool "{}" '
                                        'value {}'.format(_id, value_num))
 
+                if len(values) == 1 and values[0].get('weight', 1) != 1:
+                    reasons.append('pool "{}" has single value with '
+                                   'weight!=1'.format(_id))
+
                 fallback = pool.get('fallback', None)
                 if fallback is not None:
                     if fallback in pools:

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -3412,7 +3412,7 @@ class TestDynamicRecords(TestCase):
         self.assertEquals(['pool "one" is missing values'],
                           ctx.exception.reasons)
 
-        # pool valu not a dict
+        # pool value not a dict
         a_data = {
             'dynamic': {
                 'pools': {
@@ -3594,6 +3594,33 @@ class TestDynamicRecords(TestCase):
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
         self.assertEquals(['invalid weight "foo" in pool "three" value 2'],
+                          ctx.exception.reasons)
+
+        # single value with weight!=1
+        a_data = {
+            'dynamic': {
+                'pools': {
+                    'one': {
+                        'values': [{
+                            'weight': 12,
+                            'value': '6.6.6.6',
+                        }],
+                    },
+                },
+                'rules': [{
+                    'pool': 'one',
+                }],
+            },
+            'ttl': 60,
+            'type': 'A',
+            'values': [
+                '1.1.1.1',
+                '2.2.2.2',
+            ],
+        }
+        with self.assertRaises(ValidationError) as ctx:
+            Record.new(self.zone, 'bad', a_data)
+        self.assertEquals(['pool "one" has single value with weight!=1'],
                           ctx.exception.reasons)
 
         # invalid fallback


### PR DESCRIPTION
Dynamic record pools with a single value should always have `weight=1` on that value if specified, default is 1 if not.

/cc https://github.com/octodns/octodns/pull/706#pullrequestreview-660473308 @viranch which brought up the need for this validation.