### PR TITLE
UltradnsProvider: Add support for ALIAS type (fix #644)

### DIFF
--- a/octodns/provider/ultra.py
+++ b/octodns/provider/ultra.py
@@ -459,7 +459,7 @@ class UltraProvider(BaseProvider):
                 if existing_type == "ALIAS":
                     existing_type = "APEXALIAS"
 
-                path = '/v2/zones/{}/rrsets/{}/{    }'.format(zone_name,
+                path = '/v2/zones/{}/rrsets/{}/{}'.format(zone_name,
                                                           existing_type,
                                                           existing.fqdn)
                 self._delete(path, json_response=False)

--- a/octodns/provider/ultra.py
+++ b/octodns/provider/ultra.py
@@ -455,10 +455,11 @@ class UltraProvider(BaseProvider):
                                                 existing.name + '.')
 
                 # UltraDNS treats the `APEXALIAS` type as the octodns `ALIAS`.
-                if existing._type == "ALIAS":
-                    existing._type = "APEXALIAS"
+                existing_type = existing._type
+                if existing_type == "ALIAS":
+                    existing_type = "APEXALIAS"
 
                 path = '/v2/zones/{}/rrsets/{}/{    }'.format(zone_name,
-                                                          existing._type,
+                                                          existing_type,
                                                           existing.fqdn)
                 self._delete(path, json_response=False)

--- a/octodns/provider/ultra.py
+++ b/octodns/provider/ultra.py
@@ -36,12 +36,12 @@ class UltraProvider(BaseProvider):
     '''
     Neustar UltraDNS provider
 
-    Documentation for Ultra REST API requires a login:
-    https://portal.ultradns.com/static/docs/REST-API_User_Guide.pdf
-    Implemented to the May 20, 2020 version of the document (dated on page ii)
-    Also described as Version 2.83.0 (title page)
+    Documentation for Ultra REST API:
+    https://ultra-portalstatic.ultradns.com/static/docs/REST-API_User_Guide.pdf
+    Implemented to the May 26, 2021 version of the document (dated on page ii)
+    Also described as Version 3.18.0 (title page)
 
-    Tested against 3.0.0-20200627220036.81047f5
+    Tested against 3.20.1-20210521075351.36b9297
     As determined by querying https://api.ultradns.com/version
 
     ultra:
@@ -57,6 +57,7 @@ class UltraProvider(BaseProvider):
     RECORDS_TO_TYPE = {
         'A (1)': 'A',
         'AAAA (28)': 'AAAA',
+        'APEXALIAS (65282)': 'ALIAS',
         'CAA (257)': 'CAA',
         'CNAME (5)': 'CNAME',
         'MX (15)': 'MX',
@@ -72,6 +73,7 @@ class UltraProvider(BaseProvider):
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
     TIMEOUT = 5
+    ZONE_REQUEST_LIMIT = 1000
 
     def _request(self, method, path, params=None,
                  data=None, json=None, json_response=True):
@@ -151,7 +153,7 @@ class UltraProvider(BaseProvider):
     def zones(self):
         if self._zones is None:
             offset = 0
-            limit = 100
+            limit = self.ZONE_REQUEST_LIMIT
             zones = []
             paging = True
             while paging:
@@ -401,8 +403,15 @@ class UltraProvider(BaseProvider):
 
     def _gen_data(self, record):
         zone_name = self._remove_prefix(record.fqdn, record.name + '.')
+
+        # UltraDNS treats the `APEXALIAS` type as the octodns `ALIAS`.
+        if record._type == "ALIAS":
+            record_type = "APEXALIAS"
+        else:
+            record_type = record._type
+
         path = '/v2/zones/{}/rrsets/{}/{}'.format(zone_name,
-                                                  record._type,
+                                                  record_type,
                                                   record.fqdn)
         contents_for = getattr(self, '_contents_for_{}'.format(record._type))
         return path, contents_for(record)
@@ -444,7 +453,12 @@ class UltraProvider(BaseProvider):
                existing._type == self.RECORDS_TO_TYPE[record['rrtype']]:
                 zone_name = self._remove_prefix(existing.fqdn,
                                                 existing.name + '.')
-                path = '/v2/zones/{}/rrsets/{}/{}'.format(zone_name,
+
+                # UltraDNS treats the `APEXALIAS` type as the octodns `ALIAS`.
+                if existing._type == "ALIAS":
+                    existing._type = "APEXALIAS"
+
+                path = '/v2/zones/{}/rrsets/{}/{    }'.format(zone_name,
                                                           existing._type,
                                                           existing.fqdn)
                 self._delete(path, json_response=False)

--- a/octodns/provider/ultra.py
+++ b/octodns/provider/ultra.py
@@ -73,7 +73,7 @@ class UltraProvider(BaseProvider):
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
     TIMEOUT = 5
-    ZONE_REQUEST_LIMIT = 1000
+    ZONE_REQUEST_LIMIT = 100
 
     def _request(self, method, path, params=None,
                  data=None, json=None, json_response=True):
@@ -213,6 +213,7 @@ class UltraProvider(BaseProvider):
 
     _data_for_PTR = _data_for_single
     _data_for_CNAME = _data_for_single
+    _data_for_ALIAS = _data_for_single
 
     def _data_for_CAA(self, _type, records):
         return {
@@ -376,6 +377,7 @@ class UltraProvider(BaseProvider):
         }
 
     _contents_for_PTR = _contents_for_CNAME
+    _contents_for_ALIAS = _contents_for_CNAME
 
     def _contents_for_SRV(self, record):
         return {

--- a/tests/fixtures/ultra-records-page-2.json
+++ b/tests/fixtures/ultra-records-page-2.json
@@ -32,7 +32,16 @@
             "rdata": [
                 "www.octodns1.test."
             ]
+        },
+        {
+            "ownerName": "host1.octodns1.test.",
+            "rrtype": "RRSET (70)",
+            "ttl": 3600,
+            "rdata": [
+                "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855"
+            ]
         }
+        
     ],
     "resultInfo": {
         "totalCount": 13,

--- a/tests/test_octodns_provider_ultra.py
+++ b/tests/test_octodns_provider_ultra.py
@@ -274,7 +274,7 @@ class TestUltraProvider(TestCase):
 
             self.assertTrue(provider.populate(zone))
             self.assertEquals('octodns1.test.', zone.name)
-            self.assertEquals(11, len(zone.records))
+            self.assertEquals(12, len(zone.records))
             self.assertEquals(4, mock.call_count)
 
     def test_apply(self):
@@ -352,8 +352,8 @@ class TestUltraProvider(TestCase):
         }))
 
         plan = provider.plan(wanted)
-        self.assertEquals(10, len(plan.changes))
-        self.assertEquals(10, provider.apply(plan))
+        self.assertEquals(11, len(plan.changes))
+        self.assertEquals(11, provider.apply(plan))
         self.assertTrue(plan.exists)
 
         provider._request.assert_has_calls([
@@ -492,6 +492,15 @@ class TestUltraProvider(TestCase):
              Record.new(zone, 'txt',
                         {'ttl': 60, 'type': 'TXT',
                          'values': ['abc', 'def']})),
+
+            # ALIAS
+            ('', 'ALIAS',
+             '/v2/zones/unit.tests./rrsets/APEXALIAS/unit.tests.',
+             {'ttl': 60, 'rdata': ['target.unit.tests.']},
+             Record.new(zone, '',
+                        {'ttl': 60, 'type': 'ALIAS',
+                         'value': 'target.unit.tests.'})),
+
         ):
             # Validate path and payload based on record meet expectations
             path, payload = provider._gen_data(expected_record)


### PR DESCRIPTION
- Update API documentation to publicly available URL
- Test and update the currently observed UltraDNS version
- Add support for the Octodns ALIAS type (APEXALIAS in UltraDNS parlance)
- Update zone query limit from 100 to 1000