### PR TITLE
Add alt text to images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/octodns/octodns/master/docs/logos/octodns-logo.png?" height=251 width=404>
+<img src="https://raw.githubusercontent.com/octodns/octodns/master/docs/logos/octodns-logo.png?" alt="OctoDNS Logo" height=251 width=404>
 
 ## DNS as code - Tools for managing DNS across multiple providers
 
@@ -158,17 +158,17 @@ In the above case we manually ran OctoDNS from the command line. That works and 
 
 The first step is to create a PR with your changes.
 
-![](/docs/assets/pr.png)
+![GitHub user interface of a pull request](/docs/assets/pr.png)
 
 Assuming the code tests and config validation statuses are green the next step is to do a noop deploy and verify that the changes OctoDNS plans to make are the ones you expect.
 
-![](/docs/assets/noop.png)
+![Output of a noop deployment command](/docs/assets/noop.png)
 
 After that comes a set of reviews. One from a teammate who should have full context on what you're trying to accomplish and visibility in to the changes you're making to do it. The other is from a member of the team here at GitHub that owns DNS, mostly as a sanity check and to make sure that best practices are being followed. As much of that as possible is baked into `octodns-validate`.
 
 After the reviews it's time to branch deploy the change.
 
-![](/docs/assets/deploy.png)
+![Output of a deployment command](/docs/assets/deploy.png)
 
 If that goes smoothly, you again see the expected changes, and verify them with `dig` and/or `octodns-report` you're good to hit the merge button. If there are problems you can quickly do a `.deploy dns/master` to go back to the previous state.
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Further information can be found in [Records Documentation](/docs/records.md).
 We're ready to do a dry-run with our new setup to see what changes it would make. Since we're pretending here we'll act like there are no existing records for `example.com.` in our accounts on either provider.
 
 ```shell
-$ octodns-sync --config-file ./config/production.yaml
+$ octodns-sync --config-file=./config/production.yaml
 ...
 ********************************************************************************
 * example.com.
@@ -146,7 +146,7 @@ There will be other logging information presented on the screen, but successful 
 Now it's time to tell OctoDNS to make things happen. We'll invoke it again with the same options and add a `--doit` on the end to tell it this time we actually want it to try and make the specified changes.
 
 ```shell
-$ octodns-sync --config-file ./config/production.yaml --doit
+$ octodns-sync --config-file=./config/production.yaml --doit
 ...
 ```
 
@@ -177,7 +177,7 @@ If that goes smoothly, you again see the expected changes, and verify them with 
 Very few situations will involve starting with a blank slate which is why there's tooling built in to pull existing data out of providers into a matching config file.
 
 ```shell
-$ octodns-dump --config-file ./config/production.yaml --output-dir tmp/ example.com. route53
+$ octodns-dump --config-file=config/production.yaml --output-dir=tmp/ example.com. route53
 2017-03-15T13:33:34  INFO  Manager __init__: config_file=tmp/production.yaml
 2017-03-15T13:33:34  INFO  Manager dump: zone=example.com., sources=('route53',)
 2017-03-15T13:33:36  INFO  Route53Provider[route53] populate:   found 64 records

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Further information can be found in [Records Documentation](/docs/records.md).
 We're ready to do a dry-run with our new setup to see what changes it would make. Since we're pretending here we'll act like there are no existing records for `example.com.` in our accounts on either provider.
 
 ```shell
-$ octodns-sync --config-file=./config/production.yaml
+$ octodns-sync --config-file ./config/production.yaml
 ...
 ********************************************************************************
 * example.com.
@@ -146,7 +146,7 @@ There will be other logging information presented on the screen, but successful 
 Now it's time to tell OctoDNS to make things happen. We'll invoke it again with the same options and add a `--doit` on the end to tell it this time we actually want it to try and make the specified changes.
 
 ```shell
-$ octodns-sync --config-file=./config/production.yaml --doit
+$ octodns-sync --config-file ./config/production.yaml --doit
 ...
 ```
 
@@ -177,7 +177,7 @@ If that goes smoothly, you again see the expected changes, and verify them with 
 Very few situations will involve starting with a blank slate which is why there's tooling built in to pull existing data out of providers into a matching config file.
 
 ```shell
-$ octodns-dump --config-file=config/production.yaml --output-dir=tmp/ example.com. route53
+$ octodns-dump --config-file ./config/production.yaml --output-dir tmp/ example.com. route53
 2017-03-15T13:33:34  INFO  Manager __init__: config_file=tmp/production.yaml
 2017-03-15T13:33:34  INFO  Manager dump: zone=example.com., sources=('route53',)
 2017-03-15T13:33:36  INFO  Route53Provider[route53] populate:   found 64 records


### PR DESCRIPTION
This PR adds alt text to the images in the README for accessibility. 
Also removes the `=` from the example commands in the README. 

When I did `$ octodns-sync --config-file=./config/production.yaml` it was throwing an error. 
Then, when i did `$ octodns-dump`, it prompted me to put it in this format: `$ octodns-sync --config-file CONFIG_FILE` (without the = sign). Thus, I am making a PR to reflect this change in the README