### PR TITLE
Minor Python 2.7 fixes

### DIFF
--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -243,7 +243,8 @@ class Manager(object):
                 try:
                     source.populate(zone, lenient=lenient)
                 except TypeError as e:
-                    if "keyword argument 'lenient'" not in text_type(e):
+                    if ("unexpected keyword argument 'lenient'"
+                            not in text_type(e)):
                         raise
                     self.log.warn(': provider %s does not accept lenient '
                                   'param', source.__class__.__name__)

--- a/tests/test_octodns_provider_ultra.py
+++ b/tests/test_octodns_provider_ultra.py
@@ -1,3 +1,12 @@
+from __future__ import unicode_literals
+
+try:
+    # Python 3
+    from urllib.parse import parse_qs
+except ImportError:
+    # Python 2
+    from urlparse import parse_qs
+
 from mock import Mock, call
 from os.path import dirname, join
 from requests import HTTPError
@@ -55,7 +64,8 @@ class TestUltraProvider(TestCase):
             self.assertEquals(1, mock.call_count)
             expected_payload = "grant_type=password&username=user&"\
                                "password=rightpass"
-            self.assertEquals(mock.last_request.text, expected_payload)
+            self.assertEquals(parse_qs(mock.last_request.text),
+                              parse_qs(expected_payload))
 
     def test_get_zones(self):
         provider = _get_provider()

--- a/tests/test_octodns_provider_ultra.py
+++ b/tests/test_octodns_provider_ultra.py
@@ -1,17 +1,11 @@
 from __future__ import unicode_literals
 
-try:
-    # Python 3
-    from urllib.parse import parse_qs
-except ImportError:
-    # Python 2
-    from urlparse import parse_qs
-
 from mock import Mock, call
 from os.path import dirname, join
 from requests import HTTPError
 from requests_mock import ANY, mock as requests_mock
 from six import text_type
+from six.moves.urllib import parse
 from unittest import TestCase
 from json import load as json_load
 
@@ -64,8 +58,8 @@ class TestUltraProvider(TestCase):
             self.assertEquals(1, mock.call_count)
             expected_payload = "grant_type=password&username=user&"\
                                "password=rightpass"
-            self.assertEquals(parse_qs(mock.last_request.text),
-                              parse_qs(expected_payload))
+            self.assertEquals(parse.parse_qs(mock.last_request.text),
+                              parse.parse_qs(expected_payload))
 
     def test_get_zones(self):
         provider = _get_provider()

--- a/tests/test_octodns_source_envvar.py
+++ b/tests/test_octodns_source_envvar.py
@@ -1,6 +1,12 @@
 from six import text_type
 from unittest import TestCase
-from unittest.mock import patch
+
+try:
+    # Python 3
+    from unittest.mock import patch
+except ImportError:
+    # Python 2
+    from mock import patch
 
 from octodns.source.envvar import EnvVarSource
 from octodns.source.envvar import EnvironmentVariableNotFoundException

--- a/tests/test_octodns_source_envvar.py
+++ b/tests/test_octodns_source_envvar.py
@@ -1,12 +1,6 @@
+from mock import patch
 from six import text_type
 from unittest import TestCase
-
-try:
-    # Python 3
-    from unittest.mock import patch
-except ImportError:
-    # Python 2
-    from mock import patch
 
 from octodns.source.envvar import EnvVarSource
 from octodns.source.envvar import EnvironmentVariableNotFoundException


### PR DESCRIPTION
One minor fix in the octodns manager and two in the tests. They are described in the commits, please let me know if I should get into more detail here as well.

These were spotted because the tests run in Python 2.7 against the master branch code were failing. Maybe one improvement that could be made would be to have two environments, one for Python 2 and one for Python 3, and tests to be run in both of these. This would imply changes to `script/bootstrap` and `script/test`.