### PR TITLE
skip monitors that are not managed by OctoDNS

### DIFF
--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -849,6 +849,8 @@ class Ns1Provider(BaseProvider):
 
             for monitor in self._client.monitors.values():
                 data = self._parse_notes(monitor['notes'])
+                if not data:
+                    continue
                 if expected_host == data['host'] and \
                    expected_type == data['type']:
                     # This monitor does not belong to this record

--- a/tests/test_octodns_provider_ns1.py
+++ b/tests/test_octodns_provider_ns1.py
@@ -659,6 +659,18 @@ class TestNs1ProviderDynamic(TestCase):
             },
             'four': monitor_four,
             'five': monitor_five,
+            'six': {
+                'config': {
+                    'host': '10.10.10.10',
+                },
+                'notes': 'non-conforming notes',
+            },
+            'seven': {
+                'config': {
+                    'host': '11.11.11.11',
+                },
+                'notes': None,
+            },
         }
 
         # Would match, but won't get there b/c it's not dynamic


### PR DESCRIPTION
Handling the use case when NS1 has a mix of `OctoDNS-managed` and `non-OctoDNS-managed` (empty or non-conforming notes) monitors. Currently, the workflow fails if there are monitors on NS1 that do not have any notes in them, like below:

Here is a sample monitor with `notes: null`
```
{
  "notify_list": null,
  "mute": false,
  "notify_delay": 0,
  "job_type": "tcp",
  "last_log_removal": 1625035726,
  "frequency": 60,
  "rapid_recheck": false,
  "region_scope": "fixed",
  "id": "60dc1356f7866100af91fcc8",
  "notify_repeat": 0,
  "notify_regional": false,
  "regions": [
    "lga"
  ],
  "policy": "quorum",
  "config": {
    "response_timeout": 10000,
    "host": "1.1.1.3",
    "port": 443,
    "send": "GET /_dns",
    "ssl": true
  },
  "status": {
    "lga": {
      "status": "up",
      "since": 1625055526,
      "fail_set": []
    },
    "global": {
      "status": "up",
      "since": 1625055526,
      "fail_set": []
    }
  },
  "notify_failback": true,
  "rules": [],
  "v2": true,
  "v3": false,
  "active": true,
  "name": "emptynotes",
  "notes": null
}
```

![image](https://user-images.githubusercontent.com/13583698/124020033-a1f23f80-d99e-11eb-9f96-f42381d05a7a.png)



Try to create a sample dynamic record:
```
www:
  dynamic:
    pools:
      apac:
        fallback: na
        values:
        - value: 1.1.1.1
      na:
        values:
        - value: 2.2.2.2
        - value: 3.3.3.3
    rules:
    - geos:
      - AS
      pool: apac
    - geos:
      - NA
      pool: na
    - pool: na
  octodns:
    healthcheck:
      host: null
      path: /pop/admin
      port: 443
      protocol: HTTPS
  ttl: 300
  type: A
  value: 4.4.4.4
```

Octo SYNC detects change
```
 $ PYTHONPATH=. octodns-sync --config-file=./config/test.yaml 
2021-06-30T12:23:14  [139676584576832] INFO  Manager __init__: config_file=./config/test.yaml
2021-06-30T12:23:14  [139676584576832] INFO  Manager __init__:   max_workers=2
2021-06-30T12:23:14  [139676584576832] INFO  Manager __init__:   include_meta=False
2021-06-30T12:23:14  [139676584576832] INFO  Manager sync: eligible_zones=[], eligible_targets=[], dry_run=True, force=False, plan_output_fh=<stdout>
2021-06-30T12:23:14  [139676584576832] INFO  Manager sync:   zone=sham-test1.com.
2021-06-30T12:23:14  [139676584576832] INFO  Manager sync:   sources=['config'] -> targets=['ns1']
2021-06-30T12:23:14  [139676340684544] INFO  YamlProvider[config] populate:   found 1 records, exists=False
2021-06-30T12:23:14  [139676340684544] INFO  Ns1Provider[ns1] plan: desired=sham-test1.com.
2021-06-30T12:23:15  [139676340684544] INFO  Ns1Provider[ns1] populate:   found 1 records, exists=True
2021-06-30T12:23:15  [139676340684544] INFO  Ns1Provider[ns1] plan:   Creates=1, Updates=0, Deletes=0, Existing Records=1
2021-06-30T12:23:15  [139676584576832] INFO  Manager 
********************************************************************************
* sham-test1.com.
********************************************************************************
* ns1 (Ns1Provider)
*   Create <ARecord A 300, www.sham-test1.com., ['4.4.4.4'], {'apac': {'fallback': 'na', 'values': [{'value': '1.1.1.1', 'weight': 1}]}, 'na': {'fallback': None, 'values': [{'value': '2.2.2.2', 'weight': 1}, {'value': '3.3.3.3', 'weight': 1}]}}, [{'pool': 'apac', 'geos': ['AS']}, {'pool': 'na', 'geos': ['NA']}, {'pool': 'na'}]> (config)
*   Summary: Creates=1, Updates=0, Deletes=0, Existing Records=1
********************************************************************************
```

But SYNC with `--doit` fails because it encountered a monitor without notes. 
```
 $ PYTHONPATH=. octodns-sync --config-file=./config/test.yaml --doit
2021-06-30T12:23:25  [140650846218048] INFO  Manager __init__: config_file=./config/test.yaml
2021-06-30T12:23:25  [140650846218048] INFO  Manager __init__:   max_workers=2
2021-06-30T12:23:25  [140650846218048] INFO  Manager __init__:   include_meta=False
2021-06-30T12:23:25  [140650846218048] INFO  Manager sync: eligible_zones=[], eligible_targets=[], dry_run=False, force=False, plan_output_fh=<stdout>
2021-06-30T12:23:25  [140650846218048] INFO  Manager sync:   zone=sham-test1.com.
2021-06-30T12:23:25  [140650846218048] INFO  Manager sync:   sources=['config'] -> targets=['ns1']
2021-06-30T12:23:25  [140650602325760] INFO  YamlProvider[config] populate:   found 1 records, exists=False
2021-06-30T12:23:25  [140650602325760] INFO  Ns1Provider[ns1] plan: desired=sham-test1.com.
2021-06-30T12:23:26  [140650602325760] INFO  Ns1Provider[ns1] populate:   found 1 records, exists=True
2021-06-30T12:23:26  [140650602325760] INFO  Ns1Provider[ns1] plan:   Creates=1, Updates=0, Deletes=0, Existing Records=1
2021-06-30T12:23:26  [140650846218048] INFO  Manager 
********************************************************************************
* sham-test1.com.
********************************************************************************
* ns1 (Ns1Provider)
*   Create <ARecord A 300, www.sham-test1.com., ['4.4.4.4'], {'apac': {'fallback': 'na', 'values': [{'value': '1.1.1.1', 'weight': 1}]}, 'na': {'fallback': None, 'values': [{'value': '2.2.2.2', 'weight': 1}, {'value': '3.3.3.3', 'weight': 1}]}}, [{'pool': 'apac', 'geos': ['AS']}, {'pool': 'na', 'geos': ['NA']}, {'pool': 'na'}]> (config)
*   Summary: Creates=1, Updates=0, Deletes=0, Existing Records=1
********************************************************************************


2021-06-30T12:23:26  [140650846218048] INFO  Ns1Provider[ns1] apply: making 1 changes to sham-test1.com.
Traceback (most recent call last):
  File "/home/msrivats/mp/octodns/octodns_personal/octodns/env/bin/octodns-sync", line 11, in <module>
    load_entry_point('octodns==0.9.12', 'console_scripts', 'octodns-sync')()
  File "/home/msrivats/mp/octodns/octodns_personal/octodns/octodns/cmds/sync.py", line 40, in main
    force=args.force)
  File "/home/msrivats/mp/octodns/octodns_personal/octodns/octodns/manager.py", line 474, in sync
    total_changes += target.apply(plan)
  File "/home/msrivats/mp/octodns/octodns_personal/octodns/octodns/provider/base.py", line 101, in apply
    self._apply(plan)
  File "/home/msrivats/mp/octodns/octodns_personal/octodns/octodns/provider/ns1.py", line 1379, in _apply
    change)
  File "/home/msrivats/mp/octodns/octodns_personal/octodns/octodns/provider/ns1.py", line 1326, in _apply_Create
    getattr(self, '_params_for_{}'.format(_type))(new)
  File "/home/msrivats/mp/octodns/octodns_personal/octodns/octodns/provider/ns1.py", line 1198, in _params_for_A
    return self._params_for_dynamic(record)
  File "/home/msrivats/mp/octodns/octodns_personal/octodns/octodns/provider/ns1.py", line 1142, in _params_for_dynamic
    existing_monitors = self._monitors_for(record)
  File "/home/msrivats/mp/octodns/octodns_personal/octodns/octodns/provider/ns1.py", line 854, in _monitors_for
    if expected_host == data['host'] and \
KeyError: 'host'
```

