### PR TITLE
v0.9.13 version bump and CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.9.13 - 2021-..-.. -
+## v0.9.13 - 2021-07-18 - Processors Alpha
 
 #### Noteworthy changes
 
@@ -13,6 +13,16 @@
 * `SX' &amp; 'UM` country support added to NS1Provider, not yet in the North 
    America list for backwards compatibility reasons. They will be added in the
    next releaser.
+
+#### Stuff
+
+* Lots of progress on the partial/beta support for dynamic records in Azure,
+  still not production ready.
+* NS1 fix for when a pool only exists as a fallback
+* Zone level lenient flag
+* Validate weight makes sense for pools with a single record
+* UltraDNS support for aliases and general fixes/improvements
+* Misc doc fixes and improvements
 
 ## v0.9.12 - 2021-04-30 - Enough time has passed
 

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -3,4 +3,4 @@
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-__VERSION__ = '0.9.12'
+__VERSION__ = '0.9.13'


### PR DESCRIPTION
## v0.9.13 - 2021-07-18 - Processors Alpha

#### Noteworthy changes

* Alpha support for Processors has been added. Processors allow for hooking
  into the source, target, and planing process to make nearly arbitrary changes
  to data. See the [octodns/processor/](/octodns/processor) directory for
  examples. The change has been designed to have no impact on the process
  unless the `processors` key is present in zone configs.
* Fixes NS1 provider's geotarget limitation of using `NA` continent. Now, when
  `NA` is used in geos it considers **all** the countries of `North America`
  insted of just `us-east`, `us-west` and `us-central` regions
* `SX' &amp; 'UM` country support added to NS1Provider, not yet in the North 
   America list for backwards compatibility reasons. They will be added in the
   next releaser.

#### Stuff

* Lots of progress on the partial/beta support for dynamic records in Azure,
  still not production ready.
* NS1 fix for when a pool only exists as a fallback
* Zone level lenient flag
* Validate weight makes sense for pools with a single record
* UltraDNS support for aliases and general fixes/improvements
* Misc doc fixes and improvements