### PR TITLE
AzureProvider: Support private zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ It is similar to [Netflix/denominator](https://github.com/Netflix/denominator).
 - [Table of Contents](#table-of-contents)
 - [Getting started](#getting-started)
   - [Workspace](#workspace)
+    - [Installing a specific commit SHA](#installing-a-specific-commit-sha)
   - [Config](#config)
   - [Noop](#noop)
   - [Making changes](#making-changes)
@@ -192,7 +193,7 @@ The above command pulled the existing data out of Route53 and placed the results
 
 | Provider | Requirements | Record Support | Dynamic | Notes |
 |--|--|--|--|--|
-| [AzureProvider](/octodns/provider/azuredns.py) | azure-identity, azure-mgmt-dns, azure-mgmt-trafficmanager | A, AAAA, CAA, CNAME, MX, NS, PTR, SRV, TXT | Alpha (A, AAAA, CNAME) | |
+| [AzureProvider](/octodns/provider/azuredns.py) | azure-identity, azure-mgmt-dns, azure-mgmt-privatedns, azure-mgmt-trafficmanager | A, AAAA, CAA, CNAME, MX, NS, PTR, SRV, TXT | Alpha (A, AAAA, CNAME) | |
 | [Akamai](/octodns/provider/edgedns.py) | edgegrid-python | A, AAAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, SSHFP, TXT | No | |
 | [CloudflareProvider](/octodns/provider/cloudflare.py) | | A, AAAA, ALIAS, CAA, CNAME, LOC, MX, NS, PTR, SPF, SRV, TXT | No | CAA tags restricted |
 | [ConstellixProvider](/octodns/provider/constellix.py) | | A, AAAA, ALIAS (ANAME), CAA, CNAME, MX, NS, PTR, SPF, SRV, TXT | No | CAA tags restricted |

--- a/octodns/provider/azuredns.py
+++ b/octodns/provider/azuredns.py
@@ -925,8 +925,8 @@ class AzureProvider(BaseProvider):
         seen_profiles = {}
         extra = []
         for record in desired.records:
-            if not getattr(record, 'dynamic', False):
-                # Already changed, or not dynamic, no need to check it
+            if not getattr(record, 'dynamic', False) or self._private:
+                # Already changed, private, or not dynamic; don't check
                 continue
 
             # Abort if there are unsupported dynamic record configurations
@@ -1251,7 +1251,7 @@ class AzureProvider(BaseProvider):
         dynamic = getattr(record, 'dynamic', False)
         root_profile = None
         endpoints = []
-        if dynamic:
+        if dynamic and not self._private:
             profiles = self._generate_traffic_managers(record)
             root_profile = profiles[-1]
             if record._type in ['A', 'AAAA'] and len(profiles) > 1:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ PyYaml==5.4
 azure-common==1.1.27
 azure-identity==1.5.0
 azure-mgmt-dns==8.0.0
+azure-mgmt-privatedns==1.0.0
 azure-mgmt-trafficmanager==0.51.0
 boto3==1.15.9
 botocore==1.18.9


### PR DESCRIPTION
This change adds support for private zones in the Azure DNS provider. My approach was to add `private` as a parameter to the provider, rather than trying to do it on a per-zone basis. NS and CAA records are unsupported (by Azure, not just this provider). If a dynamic record is passed when private is enabled, the dynamic data will be ignored. This is because from what I can tell traffic managers for private zones are not a thing, so dynamic won't work, since it's implemented via traffic manager.

Need to update tests, but would love to get feedback!