### PR TITLE
check for identical monitor and skip creating one if found

### DIFF
--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -1162,15 +1162,21 @@ class Ns1Provider(BaseProvider):
 
         # Build a list of primary values for each pool, including their
         # feed_id (monitor)
+        value_feed = dict()
         pool_answers = defaultdict(list)
         for pool_name, pool in sorted(pools.items()):
             for value in pool.data['values']:
                 weight = value['weight']
                 value = value['value']
-                existing = existing_monitors.get(value)
-                monitor_id, feed_id = self._monitor_sync(record, value,
-                                                         existing)
-                active_monitors.add(monitor_id)
+                feed_id = value_feed.get(value)
+                # check for identical monitor and skip creating one if found
+                if not feed_id:
+                    existing = existing_monitors.get(value)
+                    monitor_id, feed_id = self._monitor_sync(record, value,
+                                                             existing)
+                    value_feed[value] = feed_id
+                    active_monitors.add(monitor_id)
+
                 pool_answers[pool_name].append({
                     'answer': [value],
                     'weight': weight,

--- a/tests/test_octodns_provider_ns1.py
+++ b/tests/test_octodns_provider_ns1.py
@@ -1332,6 +1332,10 @@ class TestNs1ProviderDynamic(TestCase):
         # This indirectly calls into _params_for_dynamic and tests the
         # handling to get there
         record = self.record()
+        # copy an existing answer from a different pool to 'lhr' so
+        # in order to test answer repetition across pools (monitor reuse)
+        record.dynamic._data()['pools']['lhr']['values'].append(
+            record.dynamic._data()['pools']['iad']['values'][0])
         ret, _ = provider._params_for_A(record)
 
         # Given that record has both country and region in the rules,


### PR DESCRIPTION
```
www:
  dynamic:
    pools:
      apac:
        fallback: na
        values:
        - value: 1.1.1.1      <---- repeats
      na:
        values:
        - value: 2.2.2.2
        - value: 1.1.1.1      <---- repeats
    rules:
    - geos:
      - AS
      pool: apac
    - geos:
      - NA
      pool: na
    - pool: na
  octodns:
    healthcheck:
      host: null
      path: /pop/admin
      port: 443
      protocol: HTTPS
  ttl: 300
  type: A
  value: 4.4.4.4
```
This PR implements monitor reuse instead of creating multiple identical ones. As seen in the example above, creating dynamic record was failing since the answer `1.1.1.1` is present in both pools `apac` and `na`. This PR should fix that. 