### PR TITLE
NS1 _apply_Update needs to gc monitors w/existing

### DIFF
--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -1358,7 +1358,9 @@ class Ns1Provider(BaseProvider):
         params, active_monitor_ids = \
             getattr(self, '_params_for_{}'.format(_type))(new)
         self._client.records_update(zone, domain, _type, **params)
-        self._monitors_gc(new, active_monitor_ids)
+        # If we're cleaning up we need to send in the old record since it'd
+        # have anything that needs cleaning up
+        self._monitors_gc(change.existing, active_monitor_ids)
 
     def _apply_Delete(self, ns1_zone, change):
         existing = change.existing


### PR DESCRIPTION
monitors_for in the Ns1Provider needs to be passed the old/existing record when doing an update as that's the one that may have had monitors that need to be cleaned up. Prior to this change a dynamic -> normal record update wouldn't find any existing monitors and thus would never clean up the old monitors. 

https://github.com/octodns/octodns/blob/a1ef4206682e10aa818b6fc4f02fa967a33700c2/octodns/provider/ns1.py#L861-L864

/cc @pavantc for review (should be able to assign soon)