### PR TITLE
Clarify Mythic Beasts uses DNS API v1

### DIFF
--- a/octodns/provider/mythicbeasts.py
+++ b/octodns/provider/mythicbeasts.py
@@ -76,7 +76,7 @@ class MythicBeastsProvider(BaseProvider):
     zones:
       my.domain.:
         targets:
-          - mythic
+          - mythicbeasts
     '''
 
     RE_MX = re.compile(r'^(?P<preference>[0-9]+)\s+(?P<exchange>\S+)$',

--- a/octodns/provider/mythicbeasts.py
+++ b/octodns/provider/mythicbeasts.py
@@ -70,8 +70,8 @@ class MythicBeastsProvider(BaseProvider):
       ...
       mythicbeasts:
         class: octodns.provider.mythicbeasts.MythicBeastsProvider
-          passwords:
-            my.domain.: 'password'
+        passwords:
+          my.domain.: 'DNS API v1 password'
 
     zones:
       my.domain.:


### PR DESCRIPTION
Clarify Mythic Beasts uses DNS API v1 and fix the provider YAML in `class MythicBeastsProvider(BaseProvider)`.

This pull request would modify the inline documentation, not the provider code.