### PR TITLE
Implement AcmeManagingProcessor

### DIFF
--- a/octodns/processor/acme.py
+++ b/octodns/processor/acme.py
@@ -1,0 +1,33 @@
+#
+#
+#
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
+from logging import getLogger
+
+from .base import BaseProcessor
+
+
+class AcmeIgnoringProcessor(BaseProcessor):
+    log = getLogger('AcmeIgnoringProcessor')
+
+    def __init__(self, name):
+        super(AcmeIgnoringProcessor, self).__init__(name)
+
+    def _process(self, zone, *args, **kwargs):
+        ret = self._clone_zone(zone)
+        for record in zone.records:
+            # Uses a startswith rather than == to ignore subdomain challenges,
+            # e.g. _acme-challenge.foo.domain.com when managing domain.com
+            if record._type == 'TXT' and \
+               record.name.startswith('_acme-challenge'):
+                self.log.info('_process: ignoring %s', record.fqdn)
+                continue
+            ret.add_record(record)
+
+        return ret
+
+    process_source_zone = _process
+    process_target_zone = _process

--- a/octodns/processor/acme.py
+++ b/octodns/processor/acme.py
@@ -10,11 +10,25 @@ from logging import getLogger
 from .base import BaseProcessor
 
 
-class AcmeIgnoringProcessor(BaseProcessor):
-    log = getLogger('AcmeIgnoringProcessor')
+class AcmeMangingProcessor(BaseProcessor):
+    log = getLogger('AcmeMangingProcessor')
 
     def __init__(self, name):
-        super(AcmeIgnoringProcessor, self).__init__(name)
+        '''
+        processors:
+          acme:
+            class: octodns.processor.acme.AcmeMangingProcessor
+
+        ...
+
+        zones:
+          something.com.:
+          ...
+          processors:
+            - acme
+          ...
+        '''
+        super(AcmeMangingProcessor, self).__init__(name)
 
         self._owned = set()
 
@@ -28,6 +42,8 @@ class AcmeIgnoringProcessor(BaseProcessor):
                 record = record.copy()
                 record.values.append('*octoDNS*')
                 record.values.sort()
+                # This assumes we'll see things as sources before targets,
+                # which is the case...
                 self._owned.add(record)
             ret.add_record(record)
         return ret

--- a/tests/test_octodns_processor_acme.py
+++ b/tests/test_octodns_processor_acme.py
@@ -1,0 +1,51 @@
+#
+#
+#
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
+from unittest import TestCase
+
+from octodns.processor.acme import AcmeIgnoringProcessor
+from octodns.record import Record
+from octodns.zone import Zone
+
+zone = Zone('unit.tests.', [])
+for record in [
+    # Will be ignored
+    Record.new(zone, '_acme-challenge', {
+        'ttl': 30,
+        'type': 'TXT',
+        'value': 'magic bit',
+    }),
+    # Not TXT so will live
+    Record.new(zone, '_acme-challenge.aaaa', {
+        'ttl': 30,
+        'type': 'AAAA',
+        'value': '::1',
+    }),
+    # Will be ignored
+    Record.new(zone, '_acme-challenge.foo', {
+        'ttl': 30,
+        'type': 'TXT',
+        'value': 'magic bit',
+    }),
+    # Not acme-challenge so will live
+    Record.new(zone, 'txt', {
+        'ttl': 30,
+        'type': 'TXT',
+        'value': 'Hello World!',
+    }),
+]:
+    zone.add_record(record)
+
+
+class TestAcmeIgnoringProcessor(TestCase):
+
+    def test_basics(self):
+        acme = AcmeIgnoringProcessor('acme')
+
+        got = acme.process_source_zone(zone)
+        self.assertEquals(['_acme-challenge.aaaa', 'txt'],
+                          sorted([r.name for r in got.records]))

--- a/tests/test_octodns_processor_acme.py
+++ b/tests/test_octodns_processor_acme.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, \
 
 from unittest import TestCase
 
-from octodns.processor.acme import AcmeIgnoringProcessor
+from octodns.processor.acme import AcmeMangingProcessor
 from octodns.record import Record
 from octodns.zone import Zone
 
@@ -51,10 +51,10 @@ records = {
 }
 
 
-class TestAcmeIgnoringProcessor(TestCase):
+class TestAcmeMangingProcessor(TestCase):
 
     def test_process_zones(self):
-        acme = AcmeIgnoringProcessor('acme')
+        acme = AcmeMangingProcessor('acme')
 
         source = Zone(zone.name, [])
         # Unrelated stuff that should be untouched


### PR DESCRIPTION
### Before:

```
********************************************************************************
* exxampled.com.
********************************************************************************
* ns1 (Ns1Provider)
*   Delete <TxtRecord TXT 3600, _acme-challenge.exxampled.com., ['hello world']>
*   Delete <TxtRecord TXT 3600, _acme-challenge.foo.exxampled.com., ['hello world']>
*   Summary: Creates=0, Updates=0, Deletes=2, Existing Records=4
********************************************************************************
```

### Config

```yaml
providers:
  config:
    class: octodns.provider.yaml.YamlProvider
    directory: ./config
  ns1:
    class: octodns.provider.ns1.Ns1Provider
    api_key: env/DEV_NS1_API_KEY
    monitor_regions:
      - lga
    shared_notifylist: true

processors:
  acme:
    class: octodns.processor.acme.AcmeIgnoringProcessor

zones:
  exxampled.com.:
    sources:
      - config
    processors:
      - acme
    targets:
      - ns1
```

### After

```
2021-08-05T08:50:49  [4484636160] INFO  AcmeIgnoringProcessor _process: ignoring _acme-challenge.foo.exxampled.com.
2021-08-05T08:50:49  [4484636160] INFO  AcmeIgnoringProcessor _process: ignoring _acme-challenge.exxampled.com.
...
********************************************************************************
No changes were planned
********************************************************************************
```


/cc Fixes https://github.com/octodns/octodns/issues/352
/cc https://letsencrypt.org/docs/challenge-types/#dns-01-challenge
/cc @resmo @shaikatz @jasperroel 