### PR TITLE
Multi-value PTR records

### DIFF
--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -294,30 +294,8 @@ class Manager(object):
             for processor in processors:
                 plan = processor.process_plan(plan, sources=sources,
                                               target=target)
-            if not plan:
-                continue
-
-            # Multi value PTR check
-            for change in plan.changes:
-                record = change.new
-                if not record:
-                    # Delete - doesn't need to be checked
-                    continue
-
-                if record._type == 'PTR' and len(record.values) > 1 and not \
-                   target.SUPPORTS_MUTLIVALUE_PTR:
-                    self.log.warn('target=%s does not support multi-value PTR '
-                                  'record %s; using %s as its only answer',
-                                  target, record.fqdn, record.value)
-                    # Make a new copy of the record so as to not change a
-                    # potentially shared object
-                    change.new = Record.new(record.zone, record.name, {
-                        'type': record._type,
-                        'ttl': record.ttl,
-                        'value': record.value,
-                    }, source=record.source, lenient=lenient)
-
-            plans.append((target, plan))
+            if plan:
+                plans.append((target, plan))
 
         # Return the zone as it's the desired state
         return plans, zone

--- a/octodns/provider/azuredns.py
+++ b/octodns/provider/azuredns.py
@@ -456,6 +456,7 @@ class AzureProvider(BaseProvider):
     '''
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = True
+    SUPPORTS_MUTLIVALUE_PTR = True
     SUPPORTS = set(('A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NS', 'PTR', 'SRV',
                     'TXT'))
 

--- a/octodns/provider/azuredns.py
+++ b/octodns/provider/azuredns.py
@@ -707,8 +707,8 @@ class AzureProvider(BaseProvider):
         return {'values': [_check_endswith_dot(val) for val in vals]}
 
     def _data_for_PTR(self, azrecord):
-        ptrdname = azrecord.ptr_records[0].ptrdname
-        return {'value': _check_endswith_dot(ptrdname)}
+        vals = [ar.ptrdname for ar in azrecord.ptr_records]
+        return {'values': [_check_endswith_dot(val) for val in vals]}
 
     def _data_for_SRV(self, azrecord):
         return {'values': [{'priority': ar.priority, 'weight': ar.weight,

--- a/octodns/provider/base.py
+++ b/octodns/provider/base.py
@@ -61,7 +61,7 @@ class BaseProvider(BaseSource):
                               'will use only %s for %s', record.value,
                               record.fqdn)
                 record = record.copy()
-                record.values = [record.values[0]]
+                record.values = [record.value]
 
             new_desired.add_record(record)
 

--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -20,7 +20,7 @@ from ..record import Record, Update
 from .base import BaseProvider
 
 
-def _check_endswith_dot(string):
+def _ensure_endswith_dot(string):
     return string if string.endswith('.') else '{}.'.format(string)
 
 
@@ -814,7 +814,7 @@ class Ns1Provider(BaseProvider):
                 if record['type'] in ['ALIAS', 'CNAME', 'MX', 'NS', 'PTR',
                                       'SRV']:
                     record['short_answers'] = [
-                        _check_endswith_dot(a)
+                        _ensure_endswith_dot(a)
                         for a in record['short_answers']
                     ]
 

--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -261,6 +261,7 @@ class Ns1Provider(BaseProvider):
     '''
     SUPPORTS_GEO = True
     SUPPORTS_DYNAMIC = True
+    SUPPORTS_MUTLIVALUE_PTR = True
     SUPPORTS = set(('A', 'AAAA', 'ALIAS', 'CAA', 'CNAME', 'MX', 'NAPTR',
                     'NS', 'PTR', 'SPF', 'SRV', 'TXT', 'URLFWD'))
 

--- a/octodns/provider/yaml.py
+++ b/octodns/provider/yaml.py
@@ -104,6 +104,7 @@ class YamlProvider(BaseProvider):
     '''
     SUPPORTS_GEO = True
     SUPPORTS_DYNAMIC = True
+    SUPPORTS_MUTLIVALUE_PTR = True
     SUPPORTS = set(('A', 'AAAA', 'ALIAS', 'CAA', 'CNAME', 'DNAME', 'LOC', 'MX',
                     'NAPTR', 'NS', 'PTR', 'SSHFP', 'SPF', 'SRV', 'TXT',
                     'URLFWD'))

--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -1286,7 +1286,7 @@ class PtrRecord(_ValuesMixin, Record):
     @property
     def value(self):
         if len(self.values) == 1:
-            return self.values[0]
+            return self.data['value']
 
         raise AttributeError("Multi-value PTR record has no attribute 'value'")
 

--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -1285,10 +1285,7 @@ class PtrRecord(_ValuesMixin, Record):
     # multi-value PTR records.
     @property
     def value(self):
-        if len(self.values) == 1:
-            return self.data['value']
-
-        raise AttributeError("Multi-value PTR record has no attribute 'value'")
+        return self.values[0]
 
 
 class SshfpValue(EqualityTupleMixin):

--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -1256,12 +1256,39 @@ class NsRecord(_ValuesMixin, Record):
 
 
 class PtrValue(_TargetValue):
-    pass
+
+    @classmethod
+    def validate(cls, values, _type):
+        if not isinstance(values, list):
+            values = [values]
+
+        reasons = []
+
+        if not values:
+            reasons.append('missing values')
+
+        for value in values:
+            reasons.extend(super(PtrValue, cls).validate(value, _type))
+
+        return reasons
+
+    @classmethod
+    def process(cls, values):
+        return [super(PtrValue, cls).process(v) for v in values]
 
 
-class PtrRecord(_ValueMixin, Record):
+class PtrRecord(_ValuesMixin, Record):
     _type = 'PTR'
     _value_type = PtrValue
+
+    # This is for backward compatibility with providers that don't support
+    # multi-value PTR records.
+    @property
+    def value(self):
+        if len(self.values) == 1:
+            return self.values[0]
+
+        raise AttributeError("Multi-value PTR record has no attribute 'value'")
 
 
 class SshfpValue(EqualityTupleMixin):

--- a/octodns/source/base.py
+++ b/octodns/source/base.py
@@ -8,6 +8,8 @@ from __future__ import absolute_import, division, print_function, \
 
 class BaseSource(object):
 
+    SUPPORTS_MUTLIVALUE_PTR = False
+
     def __init__(self, id):
         self.id = id
         if not getattr(self, 'log', False):

--- a/tests/config/split/unit.tests.tst/ptr.yaml
+++ b/tests/config/split/unit.tests.tst/ptr.yaml
@@ -2,4 +2,4 @@
 ptr:
   ttl: 300
   type: PTR
-  value: foo.bar.com.
+  values: [foo.bar.com.]

--- a/tests/config/unit.tests.yaml
+++ b/tests/config/unit.tests.yaml
@@ -152,7 +152,7 @@ naptr:
 ptr:
   ttl: 300
   type: PTR
-  value: foo.bar.com.
+  values: [foo.bar.com.]
 spf:
   ttl: 600
   type: SPF

--- a/tests/test_octodns_provider_azuredns.py
+++ b/tests/test_octodns_provider_azuredns.py
@@ -150,6 +150,11 @@ octo_records.append(Record.new(zone, 'txt3', {
     'type': 'TXT',
     'values': ['txt multiple test', long_txt]}))
 
+octo_records.append(Record.new(zone, 'ptr2', {
+    'ttl': 11,
+    'type': 'PTR',
+    'values': ['ptr21.unit.tests.', 'ptr22.unit.tests.']}))
+
 azure_records = []
 _base0 = _AzureRecord('TestAzure', octo_records[0])
 _base0.zone_name = 'unit.tests'
@@ -337,6 +342,15 @@ _base18.params['ttl'] = 10
 _base18.params['txt_records'] = [TxtRecord(value=['txt multiple test']),
                                  TxtRecord(value=[long_txt_az1, long_txt_az2])]
 azure_records.append(_base18)
+
+_base19 = _AzureRecord('TestAzure', octo_records[19])
+_base19.zone_name = 'unit.tests'
+_base19.relative_record_set_name = 'ptr2'
+_base19.record_type = 'PTR'
+_base19.params['ttl'] = 11
+_base19.params['ptr_records'] = [PtrRecord(ptrdname='ptr21.unit.tests.'),
+                                 PtrRecord(ptrdname='ptr22.unit.tests.')]
+azure_records.append(_base19)
 
 
 class Test_AzureRecord(TestCase):
@@ -2054,15 +2068,16 @@ class TestAzureDnsProvider(TestCase):
     def test_apply(self):
         provider = self._get_provider()
 
-        half = int(len(octo_records) / 2)
+        expected_n = len(octo_records)
+        half = int(expected_n / 2)
         changes = [Create(r) for r in octo_records[:half]] + \
             [Update(r, r) for r in octo_records[half:]]
         deletes = [Delete(r) for r in octo_records]
 
-        self.assertEquals(19, provider.apply(Plan(None, zone,
-                                                  changes, True)))
-        self.assertEquals(19, provider.apply(Plan(zone, zone,
-                                                  deletes, True)))
+        self.assertEquals(expected_n, provider.apply(Plan(None, zone,
+                                                     changes, True)))
+        self.assertEquals(expected_n, provider.apply(Plan(zone, zone,
+                                                     deletes, True)))
 
     def test_apply_create_dynamic(self):
         provider = self._get_provider()
@@ -2320,8 +2335,9 @@ class TestAzureDnsProvider(TestCase):
         _get = provider._dns_client.zones.get
         _get.side_effect = CloudError(Mock(status=404), err_msg)
 
-        self.assertEquals(19, provider.apply(Plan(None, desired, changes,
-                                                  True)))
+        expected_n = len(octo_records)
+        self.assertEquals(expected_n, provider.apply(Plan(None, desired,
+                                                          changes, True)))
 
     def test_check_zone_no_create(self):
         provider = self._get_provider()

--- a/tests/test_octodns_provider_base.py
+++ b/tests/test_octodns_provider_base.py
@@ -230,6 +230,20 @@ class TestBaseProvider(TestCase):
         # We filtered out the only change
         self.assertFalse(plan)
 
+    def test_process_desired_zone(self):
+        zone1 = Zone('unit.tests.', [])
+        record1 = Record.new(zone1, 'ptr', {
+            'type': 'PTR',
+            'ttl': 3600,
+            'values': ['foo.com.', 'bar.com.'],
+        })
+        zone1.add_record(record1)
+
+        zone2 = HelperProvider('hasptr')._process_desired_zone(zone1)
+        record2 = list(zone2.records)[0]
+
+        self.assertEqual(len(record2.values), 1)
+
     def test_safe_none(self):
         # No changes is safe
         Plan(None, None, [], True).raise_if_unsafe()

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -2755,16 +2755,6 @@ class TestRecordValidation(TestCase):
         self.assertEquals(['PTR value "foo.bar" missing trailing .'],
                           ctx.exception.reasons)
 
-        # multi-value requesting single-value
-        with self.assertRaises(AttributeError) as ctx:
-            Record.new(self.zone, '', {
-                'type': 'PTR',
-                'ttl': 600,
-                'values': ['foo.com.', 'bar.net.'],
-            }).value
-        self.assertEquals("Multi-value PTR record has no attribute 'value'",
-                          text_type(ctx.exception))
-
     def test_SSHFP(self):
         # doesn't blow up
         Record.new(self.zone, '', {

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -2733,7 +2733,7 @@ class TestRecordValidation(TestCase):
                 'type': 'PTR',
                 'ttl': 600,
             })
-        self.assertEquals(['missing value'], ctx.exception.reasons)
+        self.assertEquals(['missing values'], ctx.exception.reasons)
 
         # not a valid FQDN
         with self.assertRaises(ValidationError) as ctx:
@@ -2754,6 +2754,16 @@ class TestRecordValidation(TestCase):
             })
         self.assertEquals(['PTR value "foo.bar" missing trailing .'],
                           ctx.exception.reasons)
+
+        # multi-value requesting single-value
+        with self.assertRaises(AttributeError) as ctx:
+            Record.new(self.zone, '', {
+                'type': 'PTR',
+                'ttl': 600,
+                'values': ['foo.com.', 'bar.net.'],
+            }).value
+        self.assertEquals("Multi-value PTR record has no attribute 'value'",
+                          text_type(ctx.exception))
 
     def test_SSHFP(self):
         # doesn't blow up


### PR DESCRIPTION
Many providers support multi-value PTR records. octoDNS assumes all PTR records are single value. This PR adds support for multi-value PTRs in a backward compatible way so that providers that don't support it don't break.

Only Azure DNS and NS1 make use of this for now, because I only have access to those two for testing. I've tested the new multi-value as well as current single-value formats on both providers and they seem to work well. Since this is a new feature, multi-value PTR records will not be forward compatible - fortunately, octoDNS will throw a validation error after rolling back to old version.