### PR TITLE
Route53Provider needs to skip and warn when it sees NA-CA-* geos

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ The above command pulled the existing data out of Route53 and placed the results
 | [OVH](/octodns/provider/ovh.py) | ovh | A, AAAA, CAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, SSHFP, TXT, DKIM | No | |
 | [PowerDnsProvider](/octodns/provider/powerdns.py) | | All | No | |
 | [Rackspace](/octodns/provider/rackspace.py) | | A, AAAA, ALIAS, CNAME, MX, NS, PTR, SPF, TXT | No |  |
-| [Route53](/octodns/provider/route53.py) | boto3 | A, AAAA, CAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, TXT | Both | CNAME health checks don't support a Host header |
+| [Route53](/octodns/provider/route53.py) | boto3 | A, AAAA, CAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, TXT | Both | CNAME health checks don't support a Host header, NA-CA-* geos not supported |
 | [Selectel](/octodns/provider/selectel.py) | | A, AAAA, CNAME, MX, NS, SPF, SRV, TXT | No | |
 | [Transip](/octodns/provider/transip.py) | transip | A, AAAA, CNAME, MX, NS, SRV, SPF, TXT, SSHFP, CAA | No | |
 | [UltraDns](/octodns/provider/ultra.py) | | A, AAAA, CAA, CNAME, MX, NS, PTR, SPF, SRV, TXT | No | |


### PR DESCRIPTION
Having it ignore and warn is more in line with how octoDNS handles the lack of support for other things, e.g. record types. I have and always have had mixed feelings about that behavior since if people aren't paying attention to the warnings they could miss why something their expecting to happen isn't. I may revisit that as an option at some point, but for now this turns a partial apply failure into a more consistent behavior.

/cc https://github.com/octodns/octodns/pull/755#pullrequestreview-730311028 which lead to discovering this issue
