### PR TITLE
Provider.process_desired_zone with warning & exception support

### DIFF
--- a/octodns/provider/__init__.py
+++ b/octodns/provider/__init__.py
@@ -4,3 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
+
+
+class ProviderException(Exception):
+    pass

--- a/octodns/provider/base.py
+++ b/octodns/provider/base.py
@@ -12,6 +12,10 @@ from ..zone import Zone
 from .plan import Plan
 
 
+class ProviderException(Exception):
+    pass
+
+
 class BaseProvider(BaseSource):
 
     def __init__(self, id, apply_disabled=False,
@@ -43,6 +47,12 @@ class BaseProvider(BaseSource):
         base NS records.
         '''
         return []
+
+    def supports_warn_or_except(self, msg):
+        # TODO: base class param to control warn vs except
+        if False:
+            raise ProviderException(msg)
+        self.log.warning(msg)
 
     def process_desired_zone(self, desired):
         return desired

--- a/octodns/provider/base.py
+++ b/octodns/provider/base.py
@@ -52,10 +52,11 @@ class BaseProvider(BaseSource):
         for record in desired.records:
             if record._type == 'PTR' and len(record.values) > 1:
                 # replace with a single-value copy
-                self.supports_warn_or_except('does not support multi-value '
-                                             'PTR records; will use only {} '
-                                             'for {}'.format(record.value,
-                                                             record.fqdn))
+                msg = 'multi-value PTR records not supported for {}' \
+                    .format(record.fqdn)
+                fallback = 'falling back to single value, {}' \
+                    .format(record.value)
+                self.supports_warn_or_except(msg, fallback)
                 record = record.copy()
                 record.values = [record.value]
 
@@ -78,10 +79,10 @@ class BaseProvider(BaseSource):
         '''
         return []
 
-    def supports_warn_or_except(self, msg):
+    def supports_warn_or_except(self, msg, fallback):
         if self.strict_supports:
             raise ProviderException('{}: {}'.format(self.id, msg))
-        self.log.warning(msg)
+        self.log.warning('{}; {}'.format(msg, fallback))
 
     def plan(self, desired, processors=[]):
         self.log.info('plan: desired=%s', desired.name)

--- a/octodns/provider/base.py
+++ b/octodns/provider/base.py
@@ -44,8 +44,13 @@ class BaseProvider(BaseSource):
         '''
         return []
 
+    def process_desired_zone(self, desired):
+        return desired
+
     def plan(self, desired, processors=[]):
         self.log.info('plan: desired=%s', desired.name)
+
+        desired = self.process_desired_zone(desired)
 
         existing = Zone(desired.name, desired.sub_zones)
         exists = self.populate(existing, target=True, lenient=True)

--- a/octodns/provider/base.py
+++ b/octodns/provider/base.py
@@ -52,9 +52,10 @@ class BaseProvider(BaseSource):
         for record in desired.records:
             if record._type == 'PTR' and len(record.values) > 1:
                 # replace with a single-value copy
-                self.log.warn('does not support multi-value PTR records; '
-                              'will use only %s for %s', record.value,
-                              record.fqdn)
+                self.supports_warn_or_except('does not support multi-value '
+                                             'PTR records; will use only {} '
+                                             'for {}'.format(record.value,
+                                                             record.fqdn))
                 record = record.copy()
                 record.values = [record.value]
 

--- a/octodns/provider/route53.py
+++ b/octodns/provider/route53.py
@@ -942,14 +942,18 @@ class Route53Provider(BaseProvider):
                                      if not g.startswith('NA-CA-')]
                     if not filtered_geos:
                         # We've removed all geos, we'll have to skip this rule
-                        msg = 'NA-CA-* not supported resulting in ' \
-                            'empty geo target, skipping rule {}'.format(i)
-                        self.supports_warn_or_except(msg)
+                        msg = 'NA-CA-* not supported for {}' \
+                            .format(record.fqdn)
+                        fallback = 'skipping rule {}'.format(i)
+                        self.supports_warn_or_except(msg, fallback)
                         continue
                     elif geos != filtered_geos:
-                        msg = 'NA-CA-* not supported resulting in ' \
-                            'empty geo target, skipping rule {}'.format(i)
-                        self.supports_warn_or_except(msg)
+                        msg = 'NA-CA-* not supported for {}' \
+                            .format(record.fqdn)
+                        fallback = 'filtering rule {} from ({}) to ({})' \
+                            .format(i, ', '.join(geos),
+                                    ', '.join(filtered_geos))
+                        self.supports_warn_or_except(msg, fallback)
                         rule.data['geos'] = filtered_geos
                     rules.append(rule)
 

--- a/octodns/provider/route53.py
+++ b/octodns/provider/route53.py
@@ -925,7 +925,7 @@ class Route53Provider(BaseProvider):
 
         return data
 
-    def process_desired_zone(self, desired):
+    def _process_desired_zone(self, desired):
         ret = Zone(desired.name, desired.sub_zones)
         for record in desired.records:
             if getattr(record, 'dynamic', False):
@@ -957,7 +957,7 @@ class Route53Provider(BaseProvider):
 
             ret.add_record(record)
 
-        return super(Route53Provider, self).process_desired_zone(ret)
+        return super(Route53Provider, self)._process_desired_zone(ret)
 
     def populate(self, zone, target=False, lenient=False):
         self.log.debug('populate: name=%s, target=%s, lenient=%s', zone.name,

--- a/octodns/provider/route53.py
+++ b/octodns/provider/route53.py
@@ -931,8 +931,6 @@ class Route53Provider(BaseProvider):
             if getattr(record, 'dynamic', False):
                 # Make a copy of the record in case we have to muck with it
                 record = record.copy()
-                from pprint import pprint
-                pprint((record, record.data))
                 dynamic = record.dynamic
                 rules = []
                 for i, rule in enumerate(dynamic.rules):
@@ -956,8 +954,6 @@ class Route53Provider(BaseProvider):
                     rules.append(rule)
 
                 dynamic.rules = rules
-
-                pprint((record, record.data))
 
             ret.add_record(record)
 

--- a/tests/test_octodns_provider_base.py
+++ b/tests/test_octodns_provider_base.py
@@ -6,11 +6,12 @@ from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
 from logging import getLogger
+from mock import MagicMock, call
 from six import text_type
 from unittest import TestCase
 
 from octodns.processor.base import BaseProcessor
-from octodns.provider.base import BaseProvider
+from octodns.provider.base import BaseProvider, ProviderException
 from octodns.provider.plan import Plan, UnsafePlan
 from octodns.record import Create, Delete, Record, Update
 from octodns.zone import Zone
@@ -429,3 +430,27 @@ class TestBaseProvider(TestCase):
                  delete_pcent_threshold=safe_pcent).raise_if_unsafe()
 
         self.assertTrue('Too many deletes' in text_type(ctx.exception))
+
+    def test_supports_warn_or_except(self):
+        class MinimalProvider(BaseProvider):
+            SUPPORTS = set()
+            SUPPORTS_GEO = False
+
+            def __init__(self, **kwargs):
+                self.log = MagicMock()
+                super(MinimalProvider, self).__init__('minimal', **kwargs)
+
+        normal = MinimalProvider(strict_supports=False)
+        # Should log and not expect
+        normal.supports_warn_or_except('Hello World!')
+        normal.log.warning.assert_called_once()
+        normal.log.warning.assert_has_calls([
+            call('Hello World!')
+        ])
+
+        strict = MinimalProvider(strict_supports=True)
+        # Should log and not expect
+        with self.assertRaises(ProviderException) as ctx:
+            strict.supports_warn_or_except('Hello World!')
+        self.assertEquals('minimal: Hello World!', text_type(ctx.exception))
+        strict.log.warning.assert_not_called()

--- a/tests/test_octodns_provider_base.py
+++ b/tests/test_octodns_provider_base.py
@@ -22,6 +22,7 @@ class HelperProvider(BaseProvider):
 
     SUPPORTS = set(('A',))
     id = 'test'
+    strict_supports = False
 
     def __init__(self, extra_changes=[], apply_disabled=False,
                  include_change_callback=None):

--- a/tests/test_octodns_provider_base.py
+++ b/tests/test_octodns_provider_base.py
@@ -457,15 +457,15 @@ class TestBaseProvider(TestCase):
 
         normal = MinimalProvider(strict_supports=False)
         # Should log and not expect
-        normal.supports_warn_or_except('Hello World!')
+        normal.supports_warn_or_except('Hello World!', 'Goodbye')
         normal.log.warning.assert_called_once()
         normal.log.warning.assert_has_calls([
-            call('Hello World!')
+            call('Hello World!; Goodbye')
         ])
 
         strict = MinimalProvider(strict_supports=True)
         # Should log and not expect
         with self.assertRaises(ProviderException) as ctx:
-            strict.supports_warn_or_except('Hello World!')
+            strict.supports_warn_or_except('Hello World!', 'Will not see')
         self.assertEquals('minimal: Hello World!', text_type(ctx.exception))
         strict.log.warning.assert_not_called()

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -399,7 +399,7 @@ class TestRoute53Provider(TestCase):
 
         # No records, essentially a no-op
         desired = Zone('unit.tests.', [])
-        got = provider.process_desired_zone(desired)
+        got = provider._process_desired_zone(desired)
         self.assertEquals(desired.records, got.records)
 
         # Record without any geos
@@ -422,7 +422,7 @@ class TestRoute53Provider(TestCase):
             },
         })
         desired.add_record(record)
-        got = provider.process_desired_zone(desired)
+        got = provider._process_desired_zone(desired)
         self.assertEquals(desired.records, got.records)
         self.assertEquals(1, len(list(got.records)[0].dynamic.rules))
         self.assertFalse('geos' in list(got.records)[0].dynamic.rules[0].data)
@@ -455,7 +455,7 @@ class TestRoute53Provider(TestCase):
             },
         })
         desired.add_record(record)
-        got = provider.process_desired_zone(desired)
+        got = provider._process_desired_zone(desired)
         self.assertEquals(2, len(list(got.records)[0].dynamic.rules))
         self.assertEquals(['EU', 'NA-US-OR'],
                           list(got.records)[0].dynamic.rules[0].data['geos'])
@@ -489,7 +489,7 @@ class TestRoute53Provider(TestCase):
             },
         })
         desired.add_record(record)
-        got = provider.process_desired_zone(desired)
+        got = provider._process_desired_zone(desired)
         self.assertEquals(1, len(list(got.records)[0].dynamic.rules))
         self.assertFalse('geos' in list(got.records)[0].dynamic.rules[0].data)
 
@@ -521,7 +521,7 @@ class TestRoute53Provider(TestCase):
             },
         })
         desired.add_record(record)
-        got = provider.process_desired_zone(desired)
+        got = provider._process_desired_zone(desired)
         self.assertEquals(2, len(list(got.records)[0].dynamic.rules))
         self.assertEquals(['EU', 'NA-US-OR'],
                           list(got.records)[0].dynamic.rules[0].data['geos'])


### PR DESCRIPTION
Liking the way this shaped up. This implements a place for providers to hook into the plan process in order to modify the desired state based on what they're able to support and documents what they can do and how they need to go about it. 

As a working/testing example `Route53Provider` implements filtering of `NA-CA-*` geos adhering to the process guidlines. This is a likely replacement for https://github.com/octodns/octodns/pull/756

It's similar to discussion in https://github.com/octodns/octodns/pull/754 and providers a potential platform on which to implement multi-value PTR support on top of cleanly. 

/cc @viranch lmk what you think