### PR TITLE
compare ipv6 addresses properly

### DIFF
--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -304,7 +304,14 @@ class _ValuesMixin(object):
         self.values = sorted(self._value_type.process(values))
 
     def changes(self, other, target):
-        if self.values != other.values:
+        self_values = self.values
+        other_values = other.values
+        # compare IPv6 addresses separately since they could be
+        # in short/long format
+        if self._type == 'AAAA':
+            self_values = [IPv6Address(x) for x in self_values]
+            other_values = [IPv6Address(x) for x in other_values]
+        if self_values != other_values:
             return Update(self, other)
         return super(_ValuesMixin, self).changes(other, target)
 


### PR DESCRIPTION
Octo thinks there is a diff when it sees the same IPv6 address in short vs long form:

**sham-test1.com.yaml**
```
---
'':
  - type: AAAA
    ttl: 86400
    values:
    - 2620:109:c002::6cae:a7e

```


**NS1:**
![image](https://user-images.githubusercontent.com/13583698/130131491-03c90889-ab25-4b35-a7b9-b737a3b4237b.png)



**Octo dry run**
```
********************************************************************************
* sham-test1.com.
********************************************************************************
* ns1 (Ns1Provider)
*   Update
*     <AaaaRecord AAAA 86400, sham-test1.com., ['2620:0109:c002:0000:0000:0000:6cae:0a7e']> ->
*     <AaaaRecord AAAA 86400, sham-test1.com., ['2620:109:c002::6cae:a7e']> (config)
*   Summary: Creates=0, Updates=1, Deletes=0, Existing Records=2
********************************************************************************
```

The PR compares IPv6 addresses as IPv6address objects instead of string compare. 
