### PR TITLE
Normalize IP addresses

### DIFF
--- a/octodns/provider/constellix.py
+++ b/octodns/provider/constellix.py
@@ -8,7 +8,6 @@ from __future__ import absolute_import, division, print_function, \
 from collections import defaultdict
 from requests import Session
 from base64 import b64encode
-from ipaddress import ip_address
 from six import string_types
 import hashlib
 import hmac
@@ -137,11 +136,6 @@ class ConstellixClient(object):
                     for v in value:
                         v['value'] = self._absolutize_value(v['value'],
                                                             zone_name)
-
-            # compress IPv6 addresses
-            if record['type'] == 'AAAA':
-                for i, v in enumerate(value):
-                    value[i] = str(ip_address(v))
 
         return resp
 

--- a/octodns/provider/route53.py
+++ b/octodns/provider/route53.py
@@ -1090,10 +1090,11 @@ class Route53Provider(BaseProvider):
                                  health_check, value=None):
         config = health_check['HealthCheckConfig']
 
-        # So interestingly Route53 normalizes IPAddress which will cause us to
-        # fail to find see things as equivalent. To work around this we'll
-        # ip_address's returned object for equivalence
-        # E.g 2001:4860:4860::8842 -> 2001:4860:4860:0:0:0:0:8842
+        # So interestingly Route53 normalizes IPv6 addresses to a funky, but
+        # valid, form which will cause us to fail to find see things as
+        # equivalent. To work around this we'll ip_address's returned objects
+        # for equivalence.
+        # E.g 2001:4860:4860:0:0:0:0:8842 -> 2001:4860:4860::8842
         if value:
             value = ip_address(text_type(value))
             config_ip_address = ip_address(text_type(config['IPAddress']))

--- a/octodns/provider/ultra.py
+++ b/octodns/provider/ultra.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from ipaddress import ip_address
 from logging import getLogger
 from requests import Session
 
@@ -196,8 +195,6 @@ class UltraProvider(BaseProvider):
         }
 
     def _data_for_AAAA(self, _type, records):
-        for i, v in enumerate(records['rdata']):
-            records['rdata'][i] = str(ip_address(v))
         return {
             'ttl': records['ttl'],
             'type': _type,

--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -749,8 +749,13 @@ class _IpList(object):
 
     @classmethod
     def process(cls, values):
-        # Translating None into '' so that the list will be sortable in python3
-        return [v if v is not None else '' for v in values]
+        # Translating None into '' so that the list will be sortable in
+        # python3, get everything to str first
+        values = [text_type(v) if v is not None else '' for v in values]
+        # Now round trip all non-'' through the address type and back to a str
+        # to normalize the address representation.
+        return [text_type(cls._address_type(v)) if v != '' else ''
+                for v in values]
 
 
 class Ipv4List(_IpList):

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -259,10 +259,20 @@ class TestRecord(TestCase):
         self.assertEquals(b_data, b.data)
 
     def test_aaaa(self):
-        a_values = ['2001:0db8:3c4d:0015:0000:0000:1a2f:1a2b',
-                    '2001:0db8:3c4d:0015:0000:0000:1a2f:1a3b']
-        b_value = '2001:0db8:3c4d:0015:0000:0000:1a2f:1a4b'
+        a_values = ['2001:db8:3c4d:15::1a2f:1a2b',
+                    '2001:db8:3c4d:15::1a2f:1a3b']
+        b_value = '2001:db8:3c4d:15::1a2f:1a4b'
         self.assertMultipleValues(AaaaRecord, a_values, b_value)
+
+        # Specifically validate that we normalize IPv6 addresses
+        values = ['2001:db8:3c4d:15:0000:0000:1a2f:1a2b',
+                  '2001:0db8:3c4d:0015::1a2f:1a3b']
+        data = {
+            'ttl': 30,
+            'values': values,
+        }
+        record = AaaaRecord(self.zone, 'aaaa', data)
+        self.assertEquals(a_values, record.values)
 
     def assertSingleValue(self, _type, a_value, b_value):
         a_data = {'ttl': 30, 'value': a_value}


### PR DESCRIPTION

This prevents issues with providers which normalize IP addresses resulting in false changes. All records from all sources/providers will come through this so it won't matter what's in yaml config files or what comes back from provider apis, they'll all be normalized by the same code. 

By normalize I mean `2001:0db8:3c4d:0015:0000:0000:1a2f:1a2b` -> `2001:db8:3c4d:15::1a2f:1a2b`, zero removal and `::` where appropriate. 

/cc Replaces https://github.com/octodns/octodns/pull/758 
/cc @meghashyamps 