### PR TITLE
Cache NS1 zones and records for faster re-retrival

### DIFF
--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -240,7 +240,6 @@ class Ns1Client(object):
     def zones_retrieve(self, name):
         if name not in self._zones_cache:
             self._zones_cache[name] = self._try(self._zones.retrieve, name)
-            print(f'insert {name} to cache with val {self._zones_cache[name]}')
         return self._zones_cache[name]
 
     def _try(self, method, *args, **kwargs):

--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -96,6 +96,7 @@ class Ns1Client(object):
                 # remove record's zone from cache
                 del self._zones_cache[zone]
 
+            # write to (or delete) record cache
             cached = self._records_cache.setdefault(zone, {}) \
                 .setdefault(domain, {})
             new_record = func(self, zone, domain, _type, **params)

--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -205,10 +205,11 @@ class Ns1Client(object):
 
     def records_delete(self, zone, domain, _type):
         try:
-            # remove record from cache
-            del self._records_cache[zone][domain][_type]
             # remove record's zone from cache
             del self._zones_cache[zone]
+            # remove record from cache, after zone since we may not have
+            # fetched the record details
+            del self._records_cache[zone][domain][_type]
         except KeyError:
             # never mind if record is not found in cache
             pass
@@ -224,10 +225,11 @@ class Ns1Client(object):
 
     def records_update(self, zone, domain, _type, **params):
         try:
-            # remove record from cache
-            del self._records_cache[zone][domain][_type]
             # remove record's zone from cache
             del self._zones_cache[zone]
+            # remove record from cache, after zone since we may not have
+            # fetched the record details
+            del self._records_cache[zone][domain][_type]
         except KeyError:
             # never mind if record is not found in cache
             pass

--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -197,7 +197,11 @@ class Ns1Client(object):
         return self._try(self._notifylists.list)
 
     def records_create(self, zone, domain, _type, **params):
-        return self._try(self._records.create, zone, domain, _type, **params)
+        cached = self._records_cache.setdefault(zone, {}) \
+            .setdefault(domain, {})
+        cached[_type] = self._try(self._records.create, zone, domain, _type,
+                                  **params)
+        return cached[_type]
 
     def records_delete(self, zone, domain, _type):
         try:
@@ -230,7 +234,8 @@ class Ns1Client(object):
         return self._try(self._records.update, zone, domain, _type, **params)
 
     def zones_create(self, name):
-        return self._try(self._zones.create, name)
+        self._zones_cache[name] = self._try(self._zones.create, name)
+        return self._zones_cache[name]
 
     def zones_retrieve(self, name):
         if name not in self._zones_cache:

--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -96,16 +96,17 @@ class Ns1Client(object):
                 # remove record's zone from cache
                 del self._zones_cache[zone]
 
-            # write to (or delete) record cache
             cached = self._records_cache.setdefault(zone, {}) \
                 .setdefault(domain, {})
+
+            if _type in cached:
+                # remove record from cache
+                del cached[_type]
+
+            # write record to cache if its not a delete
             new_record = func(self, zone, domain, _type, **params)
             if new_record:
-                # record is created/updated
                 cached[_type] = new_record
-            elif _type in cached:
-                # record is deleted
-                del cached[_type]
 
             return new_record
 

--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -224,16 +224,20 @@ class Ns1Client(object):
         return cached[_type]
 
     def records_update(self, zone, domain, _type, **params):
+        cached = self._records_cache.setdefault(zone, {}) \
+            .setdefault(domain, {})
         try:
             # remove record's zone from cache
             del self._zones_cache[zone]
             # remove record from cache, after zone since we may not have
             # fetched the record details
-            del self._records_cache[zone][domain][_type]
+            del cached[_type]
         except KeyError:
             # never mind if record is not found in cache
             pass
-        return self._try(self._records.update, zone, domain, _type, **params)
+        cached[_type] = self._try(self._records.update, zone, domain, _type,
+                                  **params)
+        return cached[_type]
 
     def zones_create(self, name):
         self._zones_cache[name] = self._try(self._zones.create, name)

--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -80,8 +80,10 @@ class Ns1Client(object):
         self._datasource = client.datasource()
         self._datafeed = client.datafeed()
 
-        self._datasource_id = None
+        self.reset_caches()
 
+    def reset_caches(self):
+        self._datasource_id = None
         self._feeds_for_monitors = None
         self._monitors_cache = None
         self._notifylists_cache = None

--- a/tests/test_octodns_processor_acme.py
+++ b/tests/test_octodns_processor_acme.py
@@ -71,7 +71,6 @@ class TestAcmeMangingProcessor(TestCase):
         ], sorted([r.name for r in got.records]))
         managed = None
         for record in got.records:
-            print(record.name)
             if record.name.endswith('managed'):
                 managed = record
                 break

--- a/tests/test_octodns_provider_ns1.py
+++ b/tests/test_octodns_provider_ns1.py
@@ -2597,10 +2597,10 @@ class TestNs1Client(TestCase):
 
         # Record delete removes from cache and removes zone
         reset()
-        record_delete_mock.side_effect = ['hoo']
-        self.assertEquals('hoo', client.records_delete('unit.tests',
-                                                       'aaaa.unit.tests',
-                                                       'AAAA'))
+        record_delete_mock.side_effect = [{}]
+        self.assertEquals({}, client.records_delete('unit.tests',
+                                                    'aaaa.unit.tests',
+                                                    'AAAA'))
         record_delete_mock.assert_has_calls([call('unit.tests',
                                                   'aaaa.unit.tests', 'AAAA')])
         self.assertEquals({

--- a/tests/test_octodns_provider_ns1.py
+++ b/tests/test_octodns_provider_ns1.py
@@ -2614,3 +2614,26 @@ class TestNs1Client(TestCase):
         self.assertEquals({
             'sub.unit.tests': 'bar',
         }, client._zones_cache)
+
+        # Record update removes zone and caches result
+        record_update_mock.side_effect = ['done']
+        self.assertEquals('done', client.records_update('sub.unit.tests',
+                                                        'aaaa.sub.unit.tests',
+                                                        'AAAA', key='val'))
+        record_update_mock.assert_has_calls([call('sub.unit.tests',
+                                                  'aaaa.sub.unit.tests',
+                                                  'AAAA', key='val')])
+        self.assertEquals({
+            'unit.tests': {
+                'a.unit.tests': {
+                    'A': 'baz'
+                },
+                'aaaa.unit.tests': {},
+            },
+            'sub.unit.tests': {
+                'aaaa.sub.unit.tests': {
+                    'AAAA': 'done',
+                },
+            }
+        }, client._records_cache)
+        self.assertEquals({}, client._zones_cache)

--- a/tests/test_octodns_provider_ns1.py
+++ b/tests/test_octodns_provider_ns1.py
@@ -2615,6 +2615,24 @@ class TestNs1Client(TestCase):
             'sub.unit.tests': 'bar',
         }, client._zones_cache)
 
+        # Delete the other record, no zone this time, record should still go
+        # away
+        reset()
+        record_delete_mock.side_effect = [{}]
+        self.assertEquals({}, client.records_delete('unit.tests',
+                                                    'a.unit.tests', 'A'))
+        record_delete_mock.assert_has_calls([call('unit.tests', 'a.unit.tests',
+                                                  'A')])
+        self.assertEquals({
+            'unit.tests': {
+                'a.unit.tests': {},
+                'aaaa.unit.tests': {},
+            }
+        }, client._records_cache)
+        self.assertEquals({
+            'sub.unit.tests': 'bar',
+        }, client._zones_cache)
+
         # Record update removes zone and caches result
         record_update_mock.side_effect = ['done']
         self.assertEquals('done', client.records_update('sub.unit.tests',
@@ -2625,9 +2643,7 @@ class TestNs1Client(TestCase):
                                                   'AAAA', key='val')])
         self.assertEquals({
             'unit.tests': {
-                'a.unit.tests': {
-                    'A': 'baz'
-                },
+                'a.unit.tests': {},
                 'aaaa.unit.tests': {},
             },
             'sub.unit.tests': {

--- a/tests/test_octodns_provider_ns1.py
+++ b/tests/test_octodns_provider_ns1.py
@@ -198,6 +198,7 @@ class TestNs1Provider(TestCase):
         provider = Ns1Provider('test', 'api-key')
 
         # Bad auth
+        provider._client.reset_caches()
         zone_retrieve_mock.side_effect = AuthException('unauthorized')
         zone = Zone('unit.tests.', [])
         with self.assertRaises(AuthException) as ctx:
@@ -205,6 +206,7 @@ class TestNs1Provider(TestCase):
         self.assertEquals(zone_retrieve_mock.side_effect, ctx.exception)
 
         # General error
+        provider._client.reset_caches()
         zone_retrieve_mock.reset_mock()
         zone_retrieve_mock.side_effect = ResourceException('boom')
         zone = Zone('unit.tests.', [])
@@ -214,6 +216,7 @@ class TestNs1Provider(TestCase):
         self.assertEquals(('unit.tests',), zone_retrieve_mock.call_args[0])
 
         # Non-existent zone doesn't populate anything
+        provider._client.reset_caches()
         zone_retrieve_mock.reset_mock()
         zone_retrieve_mock.side_effect = \
             ResourceException('server error: zone not found')
@@ -224,6 +227,7 @@ class TestNs1Provider(TestCase):
         self.assertFalse(exists)
 
         # Existing zone w/o records
+        provider._client.reset_caches()
         zone_retrieve_mock.reset_mock()
         record_retrieve_mock.reset_mock()
         ns1_zone = {
@@ -255,6 +259,7 @@ class TestNs1Provider(TestCase):
                                                     'geo.unit.tests', 'A')])
 
         # Existing zone w/records
+        provider._client.reset_caches()
         zone_retrieve_mock.reset_mock()
         record_retrieve_mock.reset_mock()
         ns1_zone = {
@@ -286,6 +291,7 @@ class TestNs1Provider(TestCase):
                                                     'geo.unit.tests', 'A')])
 
         # Test skipping unsupported record type
+        provider._client.reset_caches()
         zone_retrieve_mock.reset_mock()
         record_retrieve_mock.reset_mock()
         ns1_zone = {
@@ -341,6 +347,7 @@ class TestNs1Provider(TestCase):
         self.assertTrue(plan.exists)
 
         # Fails, general error
+        provider._client.reset_caches()
         zone_retrieve_mock.reset_mock()
         record_retrieve_mock.reset_mock()
         zone_create_mock.reset_mock()
@@ -350,6 +357,7 @@ class TestNs1Provider(TestCase):
         self.assertEquals(zone_retrieve_mock.side_effect, ctx.exception)
 
         # Fails, bad auth
+        provider._client.reset_caches()
         zone_retrieve_mock.reset_mock()
         record_retrieve_mock.reset_mock()
         zone_create_mock.reset_mock()
@@ -361,6 +369,7 @@ class TestNs1Provider(TestCase):
         self.assertEquals(zone_create_mock.side_effect, ctx.exception)
 
         # non-existent zone, create
+        provider._client.reset_caches()
         zone_retrieve_mock.reset_mock()
         record_retrieve_mock.reset_mock()
         zone_create_mock.reset_mock()
@@ -395,6 +404,7 @@ class TestNs1Provider(TestCase):
         ])
 
         # Update & delete
+        provider._client.reset_caches()
         zone_retrieve_mock.reset_mock()
         record_retrieve_mock.reset_mock()
         zone_create_mock.reset_mock()
@@ -1304,6 +1314,7 @@ class TestNs1ProviderDynamic(TestCase):
         # provider._params_for_A() calls provider._monitors_for() and
         # provider._monitor_sync(). Mock their return values so that we don't
         # make NS1 API calls during tests
+        provider._client.reset_caches()
         monitors_for_mock.reset_mock()
         monitor_sync_mock.reset_mock()
         monitors_for_mock.side_effect = [{
@@ -1944,6 +1955,7 @@ class TestNs1ProviderDynamic(TestCase):
         monitors_for_mock.assert_not_called()
 
         # Non-existent zone. No changes
+        provider._client.reset_caches()
         monitors_for_mock.reset_mock()
         zones_retrieve_mock.side_effect = \
             ResourceException('server error: zone not found')
@@ -1952,6 +1964,7 @@ class TestNs1ProviderDynamic(TestCase):
         self.assertFalse(extra)
 
         # Unexpected exception message
+        provider._client.reset_caches()
         zones_retrieve_mock.reset_mock()
         zones_retrieve_mock.side_effect = ResourceException('boom')
         with self.assertRaises(ResourceException) as ctx:
@@ -1959,6 +1972,7 @@ class TestNs1ProviderDynamic(TestCase):
         self.assertEquals(zones_retrieve_mock.side_effect, ctx.exception)
 
         # Simple record, ignored, filter update lookups ignored
+        provider._client.reset_caches()
         monitors_for_mock.reset_mock()
         zones_retrieve_mock.reset_mock()
         records_retrieve_mock.reset_mock()
@@ -2006,6 +2020,7 @@ class TestNs1ProviderDynamic(TestCase):
         desired.add_record(dynamic)
 
         # untouched, but everything in sync so no change needed
+        provider._client.reset_caches()
         monitors_for_mock.reset_mock()
         zones_retrieve_mock.reset_mock()
         records_retrieve_mock.reset_mock()
@@ -2026,6 +2041,7 @@ class TestNs1ProviderDynamic(TestCase):
 
         # If we don't have a notify list we're broken and we'll expect to see
         # an Update
+        provider._client.reset_caches()
         monitors_for_mock.reset_mock()
         zones_retrieve_mock.reset_mock()
         records_retrieve_mock.reset_mock()
@@ -2042,6 +2058,7 @@ class TestNs1ProviderDynamic(TestCase):
 
         # Add notify_list back and change the healthcheck protocol, we'll still
         # expect to see an update
+        provider._client.reset_caches()
         monitors_for_mock.reset_mock()
         zones_retrieve_mock.reset_mock()
         records_retrieve_mock.reset_mock()
@@ -2059,6 +2076,7 @@ class TestNs1ProviderDynamic(TestCase):
         monitors_for_mock.assert_has_calls([call(dynamic)])
 
         # If it's in the changed list, it'll be ignored
+        provider._client.reset_caches()
         monitors_for_mock.reset_mock()
         zones_retrieve_mock.reset_mock()
         records_retrieve_mock.reset_mock()
@@ -2069,6 +2087,7 @@ class TestNs1ProviderDynamic(TestCase):
         # Test changes in filters
 
         # No change in filters
+        provider._client.reset_caches()
         monitors_for_mock.reset_mock()
         zones_retrieve_mock.reset_mock()
         records_retrieve_mock.reset_mock()
@@ -2088,6 +2107,7 @@ class TestNs1ProviderDynamic(TestCase):
         self.assertFalse(extra)
 
         # filters need an update
+        provider._client.reset_caches()
         monitors_for_mock.reset_mock()
         zones_retrieve_mock.reset_mock()
         records_retrieve_mock.reset_mock()
@@ -2107,6 +2127,7 @@ class TestNs1ProviderDynamic(TestCase):
         self.assertTrue(extra)
 
         # Mixed disabled in filters. Raise Ns1Exception
+        provider._client.reset_caches()
         monitors_for_mock.reset_mock()
         zones_retrieve_mock.reset_mock()
         records_retrieve_mock.reset_mock()
@@ -2234,12 +2255,14 @@ class TestNs1Client(TestCase):
         client = Ns1Client('dummy-key')
 
         # No retry required, just calls and is returned
+        client.reset_caches()
         zone_retrieve_mock.reset_mock()
         zone_retrieve_mock.side_effect = ['foo']
         self.assertEquals('foo', client.zones_retrieve('unit.tests'))
         zone_retrieve_mock.assert_has_calls([call('unit.tests')])
 
         # One retry required
+        client.reset_caches()
         zone_retrieve_mock.reset_mock()
         zone_retrieve_mock.side_effect = [
             RateLimitException('boo', period=0),
@@ -2249,6 +2272,7 @@ class TestNs1Client(TestCase):
         zone_retrieve_mock.assert_has_calls([call('unit.tests')])
 
         # Two retries required
+        client.reset_caches()
         zone_retrieve_mock.reset_mock()
         zone_retrieve_mock.side_effect = [
             RateLimitException('boo', period=0),
@@ -2258,6 +2282,7 @@ class TestNs1Client(TestCase):
         zone_retrieve_mock.assert_has_calls([call('unit.tests')])
 
         # Exhaust our retries
+        client.reset_caches()
         zone_retrieve_mock.reset_mock()
         zone_retrieve_mock.side_effect = [
             RateLimitException('first', period=0),


### PR DESCRIPTION
`NS1Provider` retrieves every zone and dynamic record more than once. This makes octoDNS slow down for zones with large number of dynamic records.

Adding zone and record caches to `NS1Client` resolves this slow down. API calls will speed up further when https://github.com/ns1/ns1-python/pull/77 gets merged and we bump ns1-python version.

Will add tests if implementation looks good.