### PR TITLE
TransIP: Update to REST API

### DIFF
--- a/octodns/provider/transip.py
+++ b/octodns/provider/transip.py
@@ -264,12 +264,6 @@ class TransipProvider(BaseProvider):
 
         return _entries
 
-    def _get_lowest_ttl(self, records):
-        _ttl = 100000
-        for record in records:
-            _ttl = min(_ttl, record.expire)
-        return _ttl
-
     def _data_for_multiple(self, _type, records):
 
         _values = []
@@ -277,7 +271,7 @@ class TransipProvider(BaseProvider):
             _values.append(record.content)
 
         return {
-            "ttl": self._get_lowest_ttl(records),
+            "ttl": _get_lowest_ttl(records),
             "type": _type,
             "values": _values,
         }
@@ -305,7 +299,7 @@ class TransipProvider(BaseProvider):
                 }
             )
         return {
-            "ttl": self._get_lowest_ttl(records),
+            "ttl": _get_lowest_ttl(records),
             "type": _type,
             "values": _values,
         }
@@ -325,7 +319,7 @@ class TransipProvider(BaseProvider):
 
         return {
             "type": _type,
-            "ttl": self._get_lowest_ttl(records),
+            "ttl": _get_lowest_ttl(records),
             "values": _values,
         }
 
@@ -343,7 +337,7 @@ class TransipProvider(BaseProvider):
 
         return {
             "type": _type,
-            "ttl": self._get_lowest_ttl(records),
+            "ttl": _get_lowest_ttl(records),
             "values": _values,
         }
 
@@ -355,7 +349,7 @@ class TransipProvider(BaseProvider):
 
         return {
             "type": _type,
-            "ttl": self._get_lowest_ttl(records),
+            "ttl": _get_lowest_ttl(records),
             "values": _values,
         }
 
@@ -366,7 +360,7 @@ class TransipProvider(BaseProvider):
 
         return {
             "type": _type,
-            "ttl": self._get_lowest_ttl(records),
+            "ttl": _get_lowest_ttl(records),
             "values": _values,
         }
 
@@ -378,8 +372,9 @@ def parse_to_fqdn(value, current_zone):
         value = current_zone.name
 
     if value[-1] != ".":
-        # self.log.debug('parseToFQDN: changed %s to %s', value,
-        #                 '{}.{}'.format(value, current_zone.name))
         value = "{}.{}".format(value, current_zone.name)
 
     return value
+
+def _get_lowest_ttl(records):
+    return min([r.expire for r in records] + [100000])

--- a/octodns/provider/transip.py
+++ b/octodns/provider/transip.py
@@ -1,18 +1,17 @@
-#
-#
-#
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
-from suds import WebFault
-
-from collections import defaultdict
-from .base import BaseProvider
+from collections import defaultdict, namedtuple
 from logging import getLogger
+
+from transip import TransIP
+from transip.exceptions import TransIPHTTPError
+from transip.v6.objects import DnsEntry
+
 from ..record import Record
-from transip.service.domain import DomainService
-from transip.service.objects import DnsEntry
+from .base import BaseProvider
+
+DNSEntry = namedtuple("DNSEntry", ("name", "expire", "type", "content"))
 
 
 class TransipException(Exception):
@@ -28,7 +27,7 @@ class TransipNewZoneException(TransipException):
 
 
 class TransipProvider(BaseProvider):
-    '''
+    """
     Transip DNS provider
 
     transip:
@@ -39,141 +38,171 @@ class TransipProvider(BaseProvider):
         key_file: /path/to/file
         # The api key as string (required if key_file is not used)
         key: |
-            \'''
+            '''
             -----BEGIN PRIVATE KEY-----
             ...
             -----END PRIVATE KEY-----
-            \'''
+            '''
         # if both `key_file` and `key` are presented `key_file` is used
 
-    '''
+    """
+
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
-    SUPPORTS = set(('A', 'AAAA', 'CNAME', 'MX', 'NS', 'SRV', 'SPF', 'TXT',
-                    'SSHFP', 'CAA'))
+    SUPPORTS = set(
+        ("A", "AAAA", "CNAME", "MX", "NS", "SRV", "SPF", "TXT", "SSHFP", "CAA")
+    )
     # unsupported by OctoDNS: 'TLSA'
     MIN_TTL = 120
     TIMEOUT = 15
-    ROOT_RECORD = '@'
+    ROOT_RECORD = "@"
 
-    def __init__(self, id, account, key=None, key_file=None,  *args, **kwargs):
-        self.log = getLogger('TransipProvider[{}]'.format(id))
-        self.log.debug('__init__: id=%s, account=%s, token=***', id,
-                       account)
+    def __init__(self, id, account, key=None, key_file=None, *args, **kwargs):
+        self.log = getLogger("TransipProvider[{}]".format(id))
+        self.log.debug("__init__: id=%s, account=%s, token=***", id, account)
         super(TransipProvider, self).__init__(id, *args, **kwargs)
 
         if key_file is not None:
-            self._client = DomainService(account, private_key_file=key_file)
+            self._client = TransIP(login=account, private_key_file=key_file)
         elif key is not None:
-            self._client = DomainService(account, private_key=key)
+            self._client = TransIP(login=account, private_key=key)
         else:
             raise TransipConfigException(
-                'Missing `key` of `key_file` parameter in config'
+                "Missing `key` of `key_file` parameter in config"
             )
 
-        self.account = account
-        self.key = key
-
-        self._currentZone = {}
+        self._currentZone = {}  # TODO: Remove
 
     def populate(self, zone, target=False, lenient=False):
-
-        exists = False
+        """
+        Populate the zone with records in-place.
+        """
         self._currentZone = zone
-        self.log.debug('populate: name=%s, target=%s, lenient=%s', zone.name,
-                       target, lenient)
+        self.log.debug(
+            "populate: name=%s, target=%s, lenient=%s",
+            zone.name,
+            target,
+            lenient,
+        )
 
         before = len(zone.records)
+
         try:
-            zoneInfo = self._client.get_info(zone.name[:-1])
-        except WebFault as e:
-            if e.fault.faultcode == '102' and target is False:
+            domain = self._client.domains.get(zone.name.strip("."))
+            records = domain.dns.list()
+        except TransIPHTTPError as e:
+            if e.response_code == 404 and target is False:
                 # Zone not found in account, and not a target so just
                 # leave an empty zone.
-                return exists
-            elif e.fault.faultcode == '102' and target is True:
-                self.log.warning('populate: Transip can\'t create new zones')
+                return False
+            elif e.response_code == 404 and target is True:
+                self.log.warning("populate: Transip can't create new zones")
                 raise TransipNewZoneException(
-                    ('populate: ({}) Transip used ' +
-                     'as target for non-existing zone: {}').format(
-                        e.fault.faultcode, zone.name))
+                    (
+                        "populate: ({}) Transip used as target for "
+                        "non-existing zone: {}"
+                    ).format(e.response_code, zone.name)
+                )
             else:
-                self.log.error('populate: (%s) %s ', e.fault.faultcode,
-                               e.fault.faultstring)
-                raise e
+                self.log.error(
+                    "populate: (%s) %s ", e.response_code, e.message
+                )
+                raise TransipException(
+                    "Unhandled error: ({}) {}".format(
+                        e.response_code, e.message
+                    )
+                )
 
-        self.log.debug('populate: found %s records for zone %s',
-                       len(zoneInfo.dnsEntries), zone.name)
-        exists = True
-        if zoneInfo.dnsEntries:
+        self.log.debug(
+            "populate: found %s records for zone %s", len(records), zone.name
+        )
+        if records:
             values = defaultdict(lambda: defaultdict(list))
-            for record in zoneInfo.dnsEntries:
-                name = zone.hostname_from_fqdn(record['name'])
+            for record in records:
+                name = zone.hostname_from_fqdn(record.name)
                 if name == self.ROOT_RECORD:
-                    name = ''
+                    name = ""
 
-                if record['type'] in self.SUPPORTS:
-                    values[name][record['type']].append(record)
+                if record.type in self.SUPPORTS:
+                    values[name][record.type].append(record)
 
             for name, types in values.items():
                 for _type, records in types.items():
-                    data_for = getattr(self, '_data_for_{}'.format(_type))
-                    record = Record.new(zone, name, data_for(_type, records),
-                                        source=self, lenient=lenient)
+                    data_for = getattr(self, "_data_for_{}".format(_type))
+                    record = Record.new(
+                        zone,
+                        name,
+                        data_for(_type, records),
+                        source=self,
+                        lenient=lenient,
+                    )
                     zone.add_record(record, lenient=lenient)
-        self.log.info('populate:   found %s records, exists = %s',
-                      len(zone.records) - before, exists)
+        self.log.info(
+            "populate: found %s records, exists = true",
+            len(zone.records) - before,
+        )
 
         self._currentZone = {}
-        return exists
+        return True
 
     def _apply(self, plan):
         desired = plan.desired
         changes = plan.changes
-        self.log.debug('apply: zone=%s, changes=%d', desired.name,
-                       len(changes))
+        self.log.debug(
+            "apply: zone=%s, changes=%d", desired.name, len(changes)
+        )
 
         self._currentZone = plan.desired
         try:
-            self._client.get_info(plan.desired.name[:-1])
-        except WebFault as e:
-            self.log.exception('_apply: get_info failed')
-            raise e
+            domain = self._client.domains.get(plan.desired.name[:-1])
+        except TransIPHTTPError as e:
+            self.log.exception("_apply: getting the domain failed")
+            raise TransipException(
+                "Unhandled error: ({}) {}".format(e.response_code, e.message)
+            )
 
-        _dns_entries = []
+        records = []
         for record in plan.desired.records:
             if record._type in self.SUPPORTS:
-                entries_for = getattr(self,
-                                      '_entries_for_{}'.format(record._type))
+                entries_for = getattr(
+                    self, "_entries_for_{}".format(record._type)
+                )
 
                 # Root records have '@' as name
                 name = record.name
-                if name == '':
+                if name == "":
                     name = self.ROOT_RECORD
 
-                _dns_entries.extend(entries_for(name, record))
+                records.extend(entries_for(name, record))
 
+        # Transform DNSEntry namedtuples into transip.v6.objects.DnsEntry
+        # objects, which is a bit ugly because it's quite a magical object.
+        api_records = [DnsEntry(domain.dns, r._asdict()) for r in records]
         try:
-            self._client.set_dns_entries(plan.desired.name[:-1], _dns_entries)
-        except WebFault as e:
-            self.log.warning(('_apply: Set DNS returned ' +
-                              'one or more errors: {}').format(
-                e.fault.faultstring))
-            raise TransipException(200, e.fault.faultstring)
+            domain.dns.replace(api_records)
+        except TransIPHTTPError as e:
+            self.log.warning(
+                "_apply: Set DNS returned one or more errors: {}".format(e)
+            )
+            raise TransipException(
+                "Unhandled error: ({}) {}".format(e.response_code, e.message)
+            )
 
         self._currentZone = {}
 
-    def _entries_for_multiple(self, name, record):
+    @classmethod
+    def _entries_for_multiple(cls, name, record):
         _entries = []
 
         for value in record.values:
-            _entries.append(DnsEntry(name, record.ttl, record._type, value))
+            _entries.append(DNSEntry(name, record.ttl, record._type, value))
 
         return _entries
 
-    def _entries_for_single(self, name, record):
+    @classmethod
+    def _entries_for_single(cls, name, record):
 
-        return [DnsEntry(name, record.ttl, record._type, record.value)]
+        return [DNSEntry(name, record.ttl, record._type, record.value)]
 
     _entries_for_A = _entries_for_multiple
     _entries_for_AAAA = _entries_for_multiple
@@ -181,89 +210,76 @@ class TransipProvider(BaseProvider):
     _entries_for_SPF = _entries_for_multiple
     _entries_for_CNAME = _entries_for_single
 
-    def _entries_for_MX(self, name, record):
+    @classmethod
+    def _entries_for_MX(cls, name, record):
         _entries = []
 
         for value in record.values:
             content = "{} {}".format(value.preference, value.exchange)
-            _entries.append(DnsEntry(name, record.ttl, record._type, content))
+            _entries.append(DNSEntry(name, record.ttl, record._type, content))
 
         return _entries
 
-    def _entries_for_SRV(self, name, record):
+    @classmethod
+    def _entries_for_SRV(cls, name, record):
         _entries = []
 
         for value in record.values:
-            content = "{} {} {} {}".format(value.priority, value.weight,
-                                           value.port, value.target)
-            _entries.append(DnsEntry(name, record.ttl, record._type, content))
+            content = "{} {} {} {}".format(
+                value.priority, value.weight, value.port, value.target
+            )
+            _entries.append(DNSEntry(name, record.ttl, record._type, content))
 
         return _entries
 
-    def _entries_for_SSHFP(self, name, record):
+    @classmethod
+    def _entries_for_SSHFP(cls, name, record):
         _entries = []
 
         for value in record.values:
-            content = "{} {} {}".format(value.algorithm,
-                                        value.fingerprint_type,
-                                        value.fingerprint)
-            _entries.append(DnsEntry(name, record.ttl, record._type, content))
+            content = "{} {} {}".format(
+                value.algorithm, value.fingerprint_type, value.fingerprint
+            )
+            _entries.append(DNSEntry(name, record.ttl, record._type, content))
 
         return _entries
 
-    def _entries_for_CAA(self, name, record):
+    @classmethod
+    def _entries_for_CAA(cls, name, record):
         _entries = []
 
         for value in record.values:
-            content = "{} {} {}".format(value.flags, value.tag,
-                                        value.value)
-            _entries.append(DnsEntry(name, record.ttl, record._type, content))
+            content = "{} {} {}".format(value.flags, value.tag, value.value)
+            _entries.append(DNSEntry(name, record.ttl, record._type, content))
 
         return _entries
 
-    def _entries_for_TXT(self, name, record):
+    @classmethod
+    def _entries_for_TXT(cls, name, record):
         _entries = []
 
         for value in record.values:
-            value = value.replace('\\;', ';')
-            _entries.append(DnsEntry(name, record.ttl, record._type, value))
+            value = value.replace("\\;", ";")
+            _entries.append(DNSEntry(name, record.ttl, record._type, value))
 
         return _entries
-
-    def _parse_to_fqdn(self, value):
-
-        # Enforce switch from suds.sax.text.Text to string
-        value = str(value)
-
-        # TransIP allows '@' as value to alias the root record.
-        # this provider won't set an '@' value, but can be an existing record
-        if value == self.ROOT_RECORD:
-            value = self._currentZone.name
-
-        if value[-1] != '.':
-            self.log.debug('parseToFQDN: changed %s to %s', value,
-                           '{}.{}'.format(value, self._currentZone.name))
-            value = '{}.{}'.format(value, self._currentZone.name)
-
-        return value
 
     def _get_lowest_ttl(self, records):
         _ttl = 100000
         for record in records:
-            _ttl = min(_ttl, record['expire'])
+            _ttl = min(_ttl, record.expire)
         return _ttl
 
     def _data_for_multiple(self, _type, records):
 
         _values = []
         for record in records:
-            # Enforce switch from suds.sax.text.Text to string
-            _values.append(str(record['content']))
+            _values.append(record.content)
 
         return {
-            'ttl': self._get_lowest_ttl(records),
-            'type': _type,
-            'values': _values
+            "ttl": self._get_lowest_ttl(records),
+            "type": _type,
+            "values": _values,
         }
 
     _data_for_A = _data_for_multiple
@@ -273,81 +289,97 @@ class TransipProvider(BaseProvider):
 
     def _data_for_CNAME(self, _type, records):
         return {
-            'ttl': records[0]['expire'],
-            'type': _type,
-            'value': self._parse_to_fqdn(records[0]['content'])
+            "ttl": records[0].expire,
+            "type": _type,
+            "value": parse_to_fqdn(records[0].content, self._currentZone),
         }
 
     def _data_for_MX(self, _type, records):
         _values = []
         for record in records:
-            preference, exchange = record['content'].split(" ", 1)
-            _values.append({
-                'preference': preference,
-                'exchange': self._parse_to_fqdn(exchange)
-            })
+            preference, exchange = record.content.split(" ", 1)
+            _values.append(
+                {
+                    "preference": preference,
+                    "exchange": parse_to_fqdn(exchange, self._currentZone),
+                }
+            )
         return {
-            'ttl': self._get_lowest_ttl(records),
-            'type': _type,
-            'values': _values
+            "ttl": self._get_lowest_ttl(records),
+            "type": _type,
+            "values": _values,
         }
 
     def _data_for_SRV(self, _type, records):
         _values = []
         for record in records:
-            priority, weight, port, target = record['content'].split(' ', 3)
-            _values.append({
-                'port': port,
-                'priority': priority,
-                'target': self._parse_to_fqdn(target),
-                'weight': weight
-            })
+            priority, weight, port, target = record.content.split(" ", 3)
+            _values.append(
+                {
+                    "port": port,
+                    "priority": priority,
+                    "target": parse_to_fqdn(target, self._currentZone),
+                    "weight": weight,
+                }
+            )
 
         return {
-            'type': _type,
-            'ttl': self._get_lowest_ttl(records),
-            'values': _values
+            "type": _type,
+            "ttl": self._get_lowest_ttl(records),
+            "values": _values,
         }
 
     def _data_for_SSHFP(self, _type, records):
         _values = []
         for record in records:
-            algorithm, fp_type, fingerprint = record['content'].split(' ', 2)
-            _values.append({
-                'algorithm': algorithm,
-                'fingerprint': fingerprint.lower(),
-                'fingerprint_type': fp_type
-            })
+            algorithm, fp_type, fingerprint = record.content.split(" ", 2)
+            _values.append(
+                {
+                    "algorithm": algorithm,
+                    "fingerprint": fingerprint.lower(),
+                    "fingerprint_type": fp_type,
+                }
+            )
 
         return {
-            'type': _type,
-            'ttl': self._get_lowest_ttl(records),
-            'values': _values
+            "type": _type,
+            "ttl": self._get_lowest_ttl(records),
+            "values": _values,
         }
 
     def _data_for_CAA(self, _type, records):
         _values = []
         for record in records:
-            flags, tag, value = record['content'].split(' ', 2)
-            _values.append({
-                'flags': flags,
-                'tag': tag,
-                'value': value
-            })
+            flags, tag, value = record.content.split(" ", 2)
+            _values.append({"flags": flags, "tag": tag, "value": value})
 
         return {
-            'type': _type,
-            'ttl': self._get_lowest_ttl(records),
-            'values': _values
+            "type": _type,
+            "ttl": self._get_lowest_ttl(records),
+            "values": _values,
         }
 
     def _data_for_TXT(self, _type, records):
         _values = []
         for record in records:
-            _values.append(record['content'].replace(';', '\\;'))
+            _values.append(record.content.replace(";", "\\;"))
 
         return {
-            'type': _type,
-            'ttl': self._get_lowest_ttl(records),
-            'values': _values
+            "type": _type,
+            "ttl": self._get_lowest_ttl(records),
+            "values": _values,
         }
+
+
+def parse_to_fqdn(value, current_zone):
+    # TransIP allows '@' as value to alias the root record.
+    # this provider won't set an '@' value, but can be an existing record
+    if value == TransipProvider.ROOT_RECORD:
+        value = current_zone.name
+
+    if value[-1] != ".":
+        # self.log.debug('parseToFQDN: changed %s to %s', value,
+        #                 '{}.{}'.format(value, current_zone.name))
+        value = "{}.{}".format(value, current_zone.name)
+
+    return value

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,8 +22,8 @@ ovh==0.5.0
 pycountry-convert==0.7.2
 pycountry==20.7.3
 python-dateutil==2.8.1
+python-transip==0.5.0
 requests==2.24.0
 s3transfer==0.3.3
 setuptools==44.1.1
 six==1.15.0
-transip==2.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ pycountry-convert==0.7.2
 pycountry==20.7.3
 python-dateutil==2.8.1
 python-transip==0.5.0
-requests==2.24.0
+requests==2.26.0
 s3transfer==0.3.3
 setuptools==44.1.1
 six==1.15.0

--- a/tests/test_octodns_provider_transip.py
+++ b/tests/test_octodns_provider_transip.py
@@ -1,277 +1,216 @@
-#
-#
-#
-
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 from os.path import dirname, join
-from six import text_type
-
-from suds import WebFault
-
 from unittest import TestCase
+from unittest.mock import Mock, patch
 
-from octodns.provider.transip import TransipProvider
+from octodns.provider.transip import (DNSEntry, TransipConfigException,
+                                      TransipException,
+                                      TransipNewZoneException, TransipProvider,
+                                      parse_to_fqdn)
 from octodns.provider.yaml import YamlProvider
 from octodns.zone import Zone
-from transip.service.domain import DomainService
-from transip.service.objects import DnsEntry
+from transip.exceptions import TransIPHTTPError
 
 
-class MockFault(object):
-    faultstring = ""
-    faultcode = ""
+def make_mock():
+    expected = Zone("unit.tests.", [])
+    source = YamlProvider("test", join(dirname(__file__), "config"))
+    source.populate(expected)
 
-    def __init__(self, code, string, *args, **kwargs):
-        self.faultstring = string
-        self.faultcode = code
+    dns_entries = []
+    for record in expected.records:
+        if record._type in TransipProvider.SUPPORTS:
+            entries_for = getattr(
+                TransipProvider, "_entries_for_{}".format(record._type)
+            )
+
+            # Root records have '@' as name
+            name = record.name
+            if name == "":
+                name = TransipProvider.ROOT_RECORD
+
+            dns_entries.extend(entries_for(name, record))
+
+            # Add a non-supported type
+            # so it triggers the "is supported" (transip.py:115) check and
+            # give 100% code coverage
+            dns_entries.append(
+                DNSEntry("@", "3600", "BOGUS", "ns01.transip.nl.")
+            )
+
+    mock = Mock()
+    mock.return_value.domains.get.return_value.dns.list.return_value = (
+        dns_entries
+    )
+    return mock
 
 
-class MockResponse(object):
-    dnsEntries = []
+def make_mock_empty():
+    mock = Mock()
+    mock.return_value.domains.get.return_value.dns.list.return_value = []
+    return mock
 
 
-class MockDomainService(DomainService):
-
-    def __init__(self, *args, **kwargs):
-        super(MockDomainService, self).__init__('MockDomainService', *args,
-                                                **kwargs)
-        self.mockupEntries = []
-
-    def mockup(self, records):
-
-        provider = TransipProvider('', '', '')
-
-        _dns_entries = []
-        for record in records:
-            if record._type in provider.SUPPORTS:
-                entries_for = getattr(provider,
-                                      '_entries_for_{}'.format(record._type))
-
-                # Root records have '@' as name
-                name = record.name
-                if name == '':
-                    name = provider.ROOT_RECORD
-
-                _dns_entries.extend(entries_for(name, record))
-
-                # Add a non-supported type
-                # so it triggers the "is supported" (transip.py:115) check and
-                # give 100% code coverage
-                _dns_entries.append(
-                    DnsEntry('@', '3600', 'BOGUS', 'ns01.transip.nl.'))
-
-        self.mockupEntries = _dns_entries
-
-    # Skips authentication layer and returns the entries loaded by "Mockup"
-    def get_info(self, domain_name):
-
-        # Special 'domain' to trigger error
-        if str(domain_name) == str('notfound.unit.tests'):
-            self.raiseZoneNotFound()
-
-        result = MockResponse()
-        result.dnsEntries = self.mockupEntries
-        return result
-
-    def set_dns_entries(self, domain_name, dns_entries):
-
-        # Special 'domain' to trigger error
-        if str(domain_name) == str('failsetdns.unit.tests'):
-            self.raiseSaveError()
-
-        return True
-
-    def raiseZoneNotFound(self):
-        fault = MockFault(str('102'),  '102 is zone not found')
-        document = {}
-        raise WebFault(fault, document)
-
-    def raiseInvalidAuth(self):
-        fault = MockFault(str('200'),  '200 is invalid auth')
-        document = {}
-        raise WebFault(fault, document)
-
-    def raiseSaveError(self):
-        fault = MockFault(str('200'),  '202 random error')
-        document = {}
-        raise WebFault(fault, document)
+def make_failing_mock(response_code):
+    mock = Mock()
+    mock.return_value.domains.get.side_effect = [
+        TransIPHTTPError(str(response_code), response_code)
+    ]
+    return mock
 
 
 class TestTransipProvider(TestCase):
 
-    bogus_key = str("""-----BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEA0U5HGCkLrz423IyUf3u4cKN2WrNz1x5KNr6PvH2M/zxas+zB
-elbxkdT3AQ+wmfcIvOuTmFRTHv35q2um1aBrPxVw+2s+lWo28VwIRttwIB1vIeWu
-lSBnkEZQRLyPI2tH0i5QoMX4CVPf9rvij3Uslimi84jdzDfPFIh6jZ6C8nLipOTG
-0IMhge1ofVfB0oSy5H+7PYS2858QLAf5ruYbzbAxZRivS402wGmQ0d0Lc1KxraAj
-kiMM5yj/CkH/Vm2w9I6+tLFeASE4ub5HCP5G/ig4dbYtqZMQMpqyAbGxd5SOVtyn
-UHagAJUxf8DT3I8PyjEHjxdOPUsxNyRtepO/7QIDAQABAoIBAQC7fiZ7gxE/ezjD
-2n6PsHFpHVTBLS2gzzZl0dCKZeFvJk6ODJDImaeuHhrh7X8ifMNsEI9XjnojMhl8
-MGPzy88mZHugDNK0H8B19x5G8v1/Fz7dG5WHas660/HFkS+b59cfdXOugYiOOn9O
-08HBBpLZNRUOmVUuQfQTjapSwGLG8PocgpyRD4zx0LnldnJcqYCxwCdev+AAsPnq
-ibNtOd/MYD37w9MEGcaxLE8wGgkv8yd97aTjkgE+tp4zsM4QE4Rag133tsLLNznT
-4Qr/of15M3NW/DXq/fgctyRcJjZpU66eCXLCz2iRTnLyyxxDC2nwlxKbubV+lcS0
-S4hbfd/BAoGBAO8jXxEaiybR0aIhhSR5esEc3ymo8R8vBN3ZMJ+vr5jEPXr/ZuFj
-/R4cZ2XV3VoQJG0pvIOYVPZ5DpJM7W+zSXtJ/7bLXy4Bnmh/rc+YYgC+AXQoLSil
-iD2OuB2xAzRAK71DVSO0kv8gEEXCersPT2i6+vC2GIlJvLcYbOdRKWGxAoGBAOAQ
-aJbRLtKujH+kMdoMI7tRlL8XwI+SZf0FcieEu//nFyerTePUhVgEtcE+7eQ7hyhG
-fIXUFx/wALySoqFzdJDLc8U8pTLhbUaoLOTjkwnCTKQVprhnISqQqqh/0U5u47IE
-RWzWKN6OHb0CezNTq80Dr6HoxmPCnJHBHn5LinT9AoGAQSpvZpbIIqz8pmTiBl2A
-QQ2gFpcuFeRXPClKYcmbXVLkuhbNL1BzEniFCLAt4LQTaRf9ghLJ3FyCxwVlkpHV
-zV4N6/8hkcTpKOraL38D/dXJSaEFJVVuee/hZl3tVJjEEpA9rDwx7ooLRSdJEJ6M
-ciq55UyKBSdt4KssSiDI2RECgYBL3mJ7xuLy5bWfNsrGiVvD/rC+L928/5ZXIXPw
-26oI0Yfun7ulDH4GOroMcDF/GYT/Zzac3h7iapLlR0WYI47xxGI0A//wBZLJ3QIu
-krxkDo2C9e3Y/NqnHgsbOQR3aWbiDT4wxydZjIeXS3LKA2fl6Hyc90PN3cTEOb8I
-hq2gRQKBgEt0SxhhtyB93SjgTzmUZZ7PiEf0YJatfM6cevmjWHexrZH+x31PB72s
-fH2BQyTKKzoCLB1k/6HRaMnZdrWyWSZ7JKz3AHJ8+58d0Hr8LTrzDM1L6BbjeDct
-N4OiVz1I3rbZGYa396lpxO6ku8yCglisL1yrSP6DdEUp66ntpKVd
------END RSA PRIVATE KEY-----""")
+    bogus_key = "-----BEGIN RSA PRIVATE KEY-----Z-----END RSA PRIVATE KEY-----"
 
     def make_expected(self):
-        expected = Zone('unit.tests.', [])
-        source = YamlProvider('test', join(dirname(__file__), 'config'))
+        expected = Zone("unit.tests.", [])
+        source = YamlProvider("test", join(dirname(__file__), "config"))
         source.populate(expected)
         return expected
 
+    @patch("octodns.provider.transip.TransIP", make_mock())
     def test_init(self):
-        with self.assertRaises(Exception) as ctx:
-            TransipProvider('test', 'unittest')
+        with self.assertRaises(TransipConfigException) as ctx:
+            TransipProvider("test", "unittest")
 
         self.assertEquals(
-            str('Missing `key` of `key_file` parameter in config'),
-            str(ctx.exception))
+            "Missing `key` of `key_file` parameter in config",
+            str(ctx.exception),
+        )
 
-        TransipProvider('test', 'unittest', key=self.bogus_key)
+        TransipProvider("test", "unittest", key=self.bogus_key)
 
         # Existence and content of the key is tested in the SDK on client call
-        TransipProvider('test', 'unittest', key_file='/fake/path')
+        TransipProvider("test", "unittest", key_file="/fake/path")
 
-    def test_populate(self):
-        _expected = self.make_expected()
-
+    @patch("octodns.provider.transip.TransIP", make_failing_mock(401))
+    def test_populate_unauthenticated(self):
         # Unhappy Plan - Not authenticated
         # Live test against API, will fail in an unauthorized error
-        with self.assertRaises(WebFault) as ctx:
-            provider = TransipProvider('test', 'unittest', self.bogus_key)
-            zone = Zone('unit.tests.', [])
+        with self.assertRaises(TransipException):
+            provider = TransipProvider("test", "unittest", self.bogus_key)
+            zone = Zone("unit.tests.", [])
             provider.populate(zone, True)
 
-        self.assertEquals(str('WebFault'),
-                          str(ctx.exception.__class__.__name__))
-
-        self.assertEquals(str('200'), ctx.exception.fault.faultcode)
-
+    @patch("octodns.provider.transip.TransIP", make_failing_mock(404))
+    def test_populate_new_zone_as_target(self):
         # Unhappy Plan - Zone does not exists
         # Will trigger an exception if provider is used as a target for a
         # non-existing zone
-        with self.assertRaises(Exception) as ctx:
-            provider = TransipProvider('test', 'unittest', self.bogus_key)
-            provider._client = MockDomainService('unittest', self.bogus_key)
-            zone = Zone('notfound.unit.tests.', [])
+        with self.assertRaises(TransipNewZoneException):
+            provider = TransipProvider("test", "unittest", self.bogus_key)
+            zone = Zone("notfound.unit.tests.", [])
             provider.populate(zone, True)
 
-        self.assertEquals(str('TransipNewZoneException'),
-                          str(ctx.exception.__class__.__name__))
-
-        self.assertEquals(
-            'populate: (102) Transip used as target' +
-            ' for non-existing zone: notfound.unit.tests.',
-            text_type(ctx.exception))
-
+    @patch("octodns.provider.transip.TransIP", make_mock())
+    def test_populate_new_zone_not_target(self):
         # Happy Plan - Zone does not exists
         # Won't trigger an exception if provider is NOT used as a target for a
         # non-existing zone.
-        provider = TransipProvider('test', 'unittest', self.bogus_key)
-        provider._client = MockDomainService('unittest', self.bogus_key)
-        zone = Zone('notfound.unit.tests.', [])
+        provider = TransipProvider("test", "unittest", self.bogus_key)
+        zone = Zone("notfound.unit.tests.", [])
         provider.populate(zone, False)
 
+    @patch("octodns.provider.transip.TransIP", make_failing_mock(404))
+    def test_populate_zone_does_not_exist(self):
+        # Happy Plan - Zone does not exists
+        # Won't trigger an exception if provider is NOT used as a target for a
+        # non-existing zone.
+        provider = TransipProvider("test", "unittest", self.bogus_key)
+        zone = Zone("notfound.unit.tests.", [])
+        provider.populate(zone, False)
+
+    @patch("octodns.provider.transip.TransIP", make_mock())
+    def test_populate_zone_exists_not_target(self):
         # Happy Plan - Populate with mockup records
-        provider = TransipProvider('test', 'unittest', self.bogus_key)
-        provider._client = MockDomainService('unittest', self.bogus_key)
-        provider._client.mockup(_expected.records)
-        zone = Zone('unit.tests.', [])
-        provider.populate(zone, False)
+        provider = TransipProvider("test", "unittest", self.bogus_key)
+        zone = Zone("unit.tests.", [])
+        exists = provider.populate(zone, False)
+        self.assertTrue(exists, "populate should return True")
 
-        # Transip allows relative values for types like cname, mx.
-        # Test is these are correctly appended with the domain
-        provider._currentZone = zone
-        self.assertEquals("www.unit.tests.", provider._parse_to_fqdn("www"))
-        self.assertEquals("www.unit.tests.",
-                          provider._parse_to_fqdn("www.unit.tests."))
-        self.assertEquals("www.sub.sub.sub.unit.tests.",
-                          provider._parse_to_fqdn("www.sub.sub.sub"))
-        self.assertEquals("unit.tests.",
-                          provider._parse_to_fqdn("@"))
-
+    @patch("octodns.provider.transip.TransIP", make_mock())
+    def test_populate_zone_exists_as_target(self):
         # Happy Plan - Even if the zone has no records the zone should exist
-        provider = TransipProvider('test', 'unittest', self.bogus_key)
-        provider._client = MockDomainService('unittest', self.bogus_key)
-        zone = Zone('unit.tests.', [])
+        provider = TransipProvider("test", "unittest", self.bogus_key)
+        zone = Zone("unit.tests.", [])
         exists = provider.populate(zone, True)
-        self.assertTrue(exists, 'populate should return true')
+        self.assertTrue(exists, "populate should return True")
 
-        return
-
+    @patch("octodns.provider.transip.TransIP", make_mock_empty())
     def test_plan(self):
         _expected = self.make_expected()
 
-        # Test Happy plan, only create
-        provider = TransipProvider('test', 'unittest', self.bogus_key)
-        provider._client = MockDomainService('unittest', self.bogus_key)
+        # Test happy plan, only create
+        provider = TransipProvider("test", "unittest", self.bogus_key)
+
         plan = provider.plan(_expected)
 
-        self.assertEqual(15, plan.change_counts['Create'])
-        self.assertEqual(0, plan.change_counts['Update'])
-        self.assertEqual(0, plan.change_counts['Delete'])
+        self.assertIsNotNone(plan)
+        self.assertEqual(15, plan.change_counts["Create"])
+        self.assertEqual(0, plan.change_counts["Update"])
+        self.assertEqual(0, plan.change_counts["Delete"])
 
-        return
+    @patch("octodns.provider.transip.TransIP")
+    def test_apply(self, client_mock):
+        # Test happy flow. Create all supported records
+        domain_mock = Mock()
+        client_mock.return_value.domains.get.return_value = domain_mock
+        domain_mock.dns.list.return_value = []
+        provider = TransipProvider("test", "unittest", self.bogus_key)
 
-    def test_apply(self):
-        _expected = self.make_expected()
+        plan = provider.plan(self.make_expected())
+        self.assertIsNotNone(plan)
+        provider.apply(plan)
 
-        # Test happy flow. Create all supoorted records
-        provider = TransipProvider('test', 'unittest', self.bogus_key)
-        provider._client = MockDomainService('unittest', self.bogus_key)
-        plan = provider.plan(_expected)
-        self.assertEqual(15, len(plan.changes))
-        changes = provider.apply(plan)
-        self.assertEqual(changes, len(plan.changes))
+        domain_mock.dns.replace.assert_called_once()  # TODO: assert payload
 
+    @patch("octodns.provider.transip.TransIP")
+    def test_apply_failure_on_not_found(self, client_mock):
         # Test unhappy flow. Trigger 'not found error' in apply stage
         # This should normally not happen as populate will capture it first
         # but just in case.
-        changes = []  # reset changes
-        with self.assertRaises(Exception) as ctx:
-            provider = TransipProvider('test', 'unittest', self.bogus_key)
-            provider._client = MockDomainService('unittest', self.bogus_key)
-            plan = provider.plan(_expected)
-            plan.desired.name = 'notfound.unit.tests.'
-            changes = provider.apply(plan)
+        domain_mock = Mock()
+        domain_mock.dns.list.return_value = []
+        client_mock.return_value.domains.get.side_effect = [
+            domain_mock,
+            TransIPHTTPError("Not Found", 404),
+        ]
+        provider = TransipProvider("test", "unittest", self.bogus_key)
 
-        # Changes should not be set due to an Exception
-        self.assertEqual([], changes)
+        plan = provider.plan(self.make_expected())
 
-        self.assertEquals(str('WebFault'),
-                          str(ctx.exception.__class__.__name__))
+        with self.assertRaises(TransipException):
+            provider.apply(plan)
 
-        self.assertEquals(str('102'), ctx.exception.fault.faultcode)
-
+    @patch("octodns.provider.transip.TransIP")
+    def test_apply_failure_on_error(self, client_mock):
         # Test unhappy flow. Trigger a unrecoverable error while saving
-        _expected = self.make_expected()  # reset expected
-        changes = []  # reset changes
+        domain_mock = Mock()
+        domain_mock.dns.list.return_value = []
+        domain_mock.dns.replace.side_effect = [
+            TransIPHTTPError("Not Found", 500)
+        ]
+        client_mock.return_value.domains.get.return_value = domain_mock
+        provider = TransipProvider("test", "unittest", self.bogus_key)
 
-        with self.assertRaises(Exception) as ctx:
-            provider = TransipProvider('test', 'unittest', self.bogus_key)
-            provider._client = MockDomainService('unittest', self.bogus_key)
-            plan = provider.plan(_expected)
-            plan.desired.name = 'failsetdns.unit.tests.'
-            changes = provider.apply(plan)
+        plan = provider.plan(self.make_expected())
 
-        # Changes should not be set due to an Exception
-        self.assertEqual([], changes)
+        with self.assertRaises(TransipException):
+            provider.apply(plan)
 
-        self.assertEquals(str('TransipException'),
-                          str(ctx.exception.__class__.__name__))
+
+class TestParseFQDN(TestCase):
+    def test_parse_fqdn(self):
+        zone = Zone("unit.tests.", [])
+        self.assertEquals("www.unit.tests.", parse_to_fqdn("www", zone))
+        self.assertEquals(
+            "www.unit.tests.", parse_to_fqdn("www.unit.tests.", zone)
+        )
+        self.assertEquals(
+            "www.sub.sub.sub.unit.tests.",
+            parse_to_fqdn("www.sub.sub.sub", zone),
+        )
+        self.assertEquals("unit.tests.", parse_to_fqdn("@", zone))

--- a/tests/test_octodns_provider_transip.py
+++ b/tests/test_octodns_provider_transip.py
@@ -6,7 +6,8 @@ from os.path import dirname, join
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
-from octodns.provider.transip import (TransipConfigException, TransipException,
+from octodns.provider.transip import (DNSEntry, TransipConfigException,
+                                      TransipException,
                                       TransipNewZoneException, TransipProvider,
                                       _entries_for, _parse_to_fqdn)
 from octodns.provider.yaml import YamlProvider
@@ -34,6 +35,10 @@ def make_mock():
                 name = TransipProvider.ROOT_RECORD
 
             api_entries.extend(_entries_for(name, record))
+
+    # Append bogus entry so test for record type not being in SUPPORTS is
+    # executed. For 100% test coverage.
+    api_entries.append(DNSEntry("@", "3600", "BOGUS", "ns.transip.nl"))
 
     return zone, api_entries
 


### PR DESCRIPTION
As mentioned here [before](https://github.com/octodns/octodns/issues/512#issuecomment-597296867), TransIP switched from a SOAP to a REST api. This uses the library github.com/roaldnefs/python-transip to make things work again.

Not fully done refactoring yet, but let's see if the CI passes.

To review it probably makes more sense to look at the files than at the diffs, given the changes required.