### PR TITLE
Bump ns1-python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ ipaddress==1.0.23; python_version < '3.3'
 jmespath==0.10.0
 msrestazure==0.6.4
 natsort==6.2.1
-ns1-python==0.16.0
+ns1-python==0.16.1
 ovh==0.5.0
 pycountry-convert==0.7.2
 pycountry==20.7.3


### PR DESCRIPTION
The new ns1-python release includes optimizations with connection pooling so that every API call re-uses the TCP connection from previous calls if any.

Some timings from my very unscientific local testing on a zone with ~35 dynamic records (which comprise of the majority of API calls):

Before:
```
$ time octodns-sync --config-file=./config/test.yaml exampled.com. --target ns1
...
2.88s user 0.12s system 16% cpu 18.421 total
```
After:
```
$ time octodns-sync --config-file=./config/test.yaml exampled.com. --target ns1
...
2.62s user 0.09s system 34% cpu 7.800 total
```