### PR TITLE
Test improvements: no network access allowed & speed ups

### DIFF
--- a/octodns/provider/easydns.py
+++ b/octodns/provider/easydns.py
@@ -48,19 +48,19 @@ class EasyDNSClient(object):
     # Domain Portfolio
     domain_portfolio = 'myport'
 
-    def __init__(self, token, api_key, currency, portfolio, sandbox):
+    def __init__(self, token, api_key, currency, portfolio, sandbox,
+                 domain_create_sleep):
         self.log = logging.getLogger('EasyDNSProvider[{}]'.format(id))
-        self.token = token
-        self.api_key = api_key
         self.default_currency = currency
         self.domain_portfolio = portfolio
-        self.apienv = 'sandbox' if sandbox else 'live'
-        auth_key = '{}:{}'.format(self.token, self.api_key)
-        self.auth_key = base64.b64encode(auth_key.encode("utf-8"))
+        self.domain_create_sleep = domain_create_sleep
+
+        auth_key = '{}:{}'.format(token, api_key)
+        auth_key = base64.b64encode(auth_key.encode("utf-8"))
         self.base_path = self.SANDBOX if sandbox else self.LIVE
         sess = Session()
         sess.headers.update({'Authorization': 'Basic {}'
-                             .format(self.auth_key.decode('utf-8'))})
+                             .format(auth_key.decode('utf-8'))})
         sess.headers.update({'accept': 'application/json'})
         self._sess = sess
 
@@ -99,7 +99,7 @@ class EasyDNSClient(object):
         # we need to delete those default record so we can sync with the source
         # records, first we'll sleep for a second before gathering new records
         # We also create default NS records, but they won't be deleted
-        sleep(1)
+        sleep(self.domain_create_sleep)
         records = self.records(name, True)
         for record in records:
             if record['host'] in ('', 'www') \
@@ -163,12 +163,12 @@ class EasyDNSProvider(BaseProvider):
                     'SRV', 'NAPTR'))
 
     def __init__(self, id, token, api_key, currency='CAD', portfolio='myport',
-                 sandbox=False, *args, **kwargs):
+                 sandbox=False, domain_create_sleep=1, *args, **kwargs):
         self.log = logging.getLogger('EasyDNSProvider[{}]'.format(id))
         self.log.debug('__init__: id=%s, token=***', id)
         super(EasyDNSProvider, self).__init__(id, *args, **kwargs)
         self._client = EasyDNSClient(token, api_key, currency, portfolio,
-                                     sandbox)
+                                     sandbox, domain_create_sleep)
         self._zone_records = {}
 
     def _data_for_multiple(self, _type, records):

--- a/octodns/provider/transip.py
+++ b/octodns/provider/transip.py
@@ -57,25 +57,37 @@ class TransipProvider(BaseProvider):
     TIMEOUT = 15
     ROOT_RECORD = '@'
 
-    def __init__(self, id, account, key=None, key_file=None,  *args, **kwargs):
+    def __init__(self, id, account, key=None, key_file=None, *args, **kwargs):
         self.log = getLogger('TransipProvider[{}]'.format(id))
         self.log.debug('__init__: id=%s, account=%s, token=***', id,
                        account)
         super(TransipProvider, self).__init__(id, *args, **kwargs)
 
-        if key_file is not None:
-            self._client = DomainService(account, private_key_file=key_file)
-        elif key is not None:
-            self._client = DomainService(account, private_key=key)
-        else:
+        if key is None and key_file is None:
             raise TransipConfigException(
-                'Missing `key` of `key_file` parameter in config'
+                'Missing `key` or `key_file` parameter in config'
             )
 
         self.account = account
         self.key = key
+        self.key_file = key_file
 
+        self._client = None
         self._currentZone = {}
+
+    @property
+    def client(self):
+        # This can't happen in __init__ b/c it makes network calls during the
+        # construction of the object and that before the tests have had a
+        # chance to install the mock client
+        if self._client is None:
+            if self.key_file is not None:
+                self._client = DomainService(self.account,
+                                             private_key_file=self.key_file)
+            else:  # we checked key in __init__ so can assume it's not None
+                self._client = DomainService(self.account,
+                                             private_key=self.key)
+        return self._client
 
     def populate(self, zone, target=False, lenient=False):
 
@@ -86,7 +98,7 @@ class TransipProvider(BaseProvider):
 
         before = len(zone.records)
         try:
-            zoneInfo = self._client.get_info(zone.name[:-1])
+            zoneInfo = self.client.get_info(zone.name[:-1])
         except WebFault as e:
             if e.fault.faultcode == '102' and target is False:
                 # Zone not found in account, and not a target so just
@@ -136,7 +148,7 @@ class TransipProvider(BaseProvider):
 
         self._currentZone = plan.desired
         try:
-            self._client.get_info(plan.desired.name[:-1])
+            self.client.get_info(plan.desired.name[:-1])
         except WebFault as e:
             self.log.exception('_apply: get_info failed')
             raise e
@@ -155,7 +167,7 @@ class TransipProvider(BaseProvider):
                 _dns_entries.extend(entries_for(name, record))
 
         try:
-            self._client.set_dns_entries(plan.desired.name[:-1], _dns_entries)
+            self.client.set_dns_entries(plan.desired.name[:-1], _dns_entries)
         except WebFault as e:
             self.log.warning(('_apply: Set DNS returned ' +
                               'one or more errors: {}').format(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,8 @@
 coverage
 mock
 nose
+nose-no-network
+nose-timer
 pycodestyle==2.6.0
 pyflakes==2.2.0
 readme_renderer[md]==26.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,9 @@ pyflakes==2.2.0
 readme_renderer[md]==26.0
 requests_mock
 twine==3.2.0; python_version >= '3.2'
+
+# Profiling tests...
+# nose-cprof
+# snakeviz
+# ./script/test --with-cprof --cprofile-stats-erase
+# snakeviz stats.dat

--- a/script/coverage
+++ b/script/coverage
@@ -36,7 +36,7 @@ grep -r -I --line-number "# pragma: +no.*cover" octodns && {
   exit 1
 }
 
-coverage run --branch --source=octodns --omit=octodns/cmds/* "$(command -v nosetests)" --with-xunit "$@"
+coverage run --branch --source=octodns --omit=octodns/cmds/* "$(command -v nosetests)" --with-no-network --with-xunit "$@"
 coverage html
 coverage xml
 coverage report --show-missing

--- a/script/test
+++ b/script/test
@@ -30,4 +30,4 @@ export ARM_CLIENT_SECRET=
 export ARM_TENANT_ID=
 export ARM_SUBSCRIPTION_ID=
 
-nosetests "$@"
+nosetests --with-no-network "$@"

--- a/tests/test_octodns_provider_easydns.py
+++ b/tests/test_octodns_provider_easydns.py
@@ -107,7 +107,8 @@ class TestEasyDNSProvider(TestCase):
             self.assertEquals('Not Found', text_type(ctx.exception))
 
     def test_apply_not_found(self):
-        provider = EasyDNSProvider('test', 'token', 'apikey')
+        provider = EasyDNSProvider('test', 'token', 'apikey',
+                                   domain_create_sleep=0)
 
         wanted = Zone('unit.tests.', [])
         wanted.add_record(Record.new(wanted, 'test1', {
@@ -143,7 +144,8 @@ class TestEasyDNSProvider(TestCase):
             self.assertEquals('Not Found', text_type(ctx.exception))
 
     def test_domain_create(self):
-        provider = EasyDNSProvider('test', 'token', 'apikey')
+        provider = EasyDNSProvider('test', 'token', 'apikey',
+                                   domain_create_sleep=0)
         domain_after_creation = {
             "tm": 1000000000,
             "data": [{

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -394,8 +394,12 @@ class TestRoute53Provider(TestCase):
 
         return (provider, stubber)
 
-    def test_process_desired_zone(self):
+    # with fallback boto makes an unstubbed call to the 169. metadata api, this
+    # stubs that bit out
+    @patch('botocore.credentials.CredentialResolver.load_credentials')
+    def test_process_desired_zone(self, fetch_metadata_token_mock):
         provider, stubber = self._get_stubbed_fallback_auth_provider()
+        fetch_metadata_token_mock.side_effect = [None]
 
         # No records, essentially a no-op
         desired = Zone('unit.tests.', [])
@@ -527,8 +531,12 @@ class TestRoute53Provider(TestCase):
                           list(got.records)[0].dynamic.rules[0].data['geos'])
         self.assertFalse('geos' in list(got.records)[0].dynamic.rules[1].data)
 
-    def test_populate_with_fallback(self):
+    # with fallback boto makes an unstubbed call to the 169. metadata api, this
+    # stubs that bit out
+    @patch('botocore.credentials.CredentialResolver.load_credentials')
+    def test_populate_with_fallback(self, fetch_metadata_token_mock):
         provider, stubber = self._get_stubbed_fallback_auth_provider()
+        fetch_metadata_token_mock.side_effect = [None]
 
         got = Zone('unit.tests.', [])
         with self.assertRaises(ClientError):


### PR DESCRIPTION
…overage

Was looking into some slow tests and discovered that they're making network calls. Looked around for the best way to disable network access completely during tests and found a couple old broken nose plugins that do so in non-trivial ways. I created https://github.com/ross/nose-no-network which is dirt simple and just breaks `socket.socket`. That plugin is now installed and will be used by `./script/test` & `./script/coverage`.

* [x] Fix existing tests that are making network calls
* [x] Use `./script/test --with-timer` to see if there are any remaining slow tests, 1s+, and look at speeding them up if possible