### PR TITLE
ProviderBase._process_desired_zone `strict_supports` checking of types and dynamic

### DIFF
--- a/octodns/provider/base.py
+++ b/octodns/provider/base.py
@@ -58,7 +58,8 @@ class BaseProvider(BaseSource):
                 fallback = 'omitting record'
                 self.supports_warn_or_except(msg, fallback)
                 desired.remove_record(record)
-            elif getattr(record, 'dynamic', False) and not self.SUPPORTS_DYNAMIC:
+            elif getattr(record, 'dynamic', False) and \
+                    not self.SUPPORTS_DYNAMIC:
                 msg = 'dynamic records not supported for {}'\
                     .format(record.fqdn)
                 fallback = 'falling back to simple record'
@@ -67,7 +68,7 @@ class BaseProvider(BaseSource):
                 record.dynamic = None
                 desired.add_record(record, replace=True)
             elif record._type == 'PTR' and len(record.values) > 1 and \
-               not self.SUPPORTS_MUTLIVALUE_PTR:
+                    not self.SUPPORTS_MUTLIVALUE_PTR:
                 # replace with a single-value copy
                 msg = 'multi-value PTR records not supported for {}' \
                     .format(record.fqdn)

--- a/octodns/provider/base.py
+++ b/octodns/provider/base.py
@@ -50,12 +50,24 @@ class BaseProvider(BaseSource):
           that are made to have them logged or throw errors depending on the
           provider configuration.
         '''
-        if self.SUPPORTS_MUTLIVALUE_PTR:
-            # nothing do here
-            return desired
 
         for record in desired.records:
-            if record._type == 'PTR' and len(record.values) > 1:
+            if record._type not in self.SUPPORTS:
+                msg = '{} records not supported for {}'.format(record._type,
+                                                               record.fqdn)
+                fallback = 'omitting record'
+                self.supports_warn_or_except(msg, fallback)
+                desired.remove_record(record)
+            elif getattr(record, 'dynamic', False) and not self.SUPPORTS_DYNAMIC:
+                msg = 'dynamic records not supported for {}'\
+                    .format(record.fqdn)
+                fallback = 'falling back to simple record'
+                self.supports_warn_or_except(msg, fallback)
+                record = record.copy()
+                record.dynamic = None
+                desired.add_record(record, replace=True)
+            elif record._type == 'PTR' and len(record.values) > 1 and \
+               not self.SUPPORTS_MUTLIVALUE_PTR:
                 # replace with a single-value copy
                 msg = 'multi-value PTR records not supported for {}' \
                     .format(record.fqdn)

--- a/octodns/provider/transip.py
+++ b/octodns/provider/transip.py
@@ -145,16 +145,14 @@ class TransipProvider(BaseProvider):
 
         _dns_entries = []
         for record in plan.desired.records:
-            if record._type in self.SUPPORTS:
-                entries_for = getattr(self,
-                                      '_entries_for_{}'.format(record._type))
+            entries_for = getattr(self, '_entries_for_{}'.format(record._type))
 
-                # Root records have '@' as name
-                name = record.name
-                if name == '':
-                    name = self.ROOT_RECORD
+            # Root records have '@' as name
+            name = record.name
+            if name == '':
+                name = self.ROOT_RECORD
 
-                _dns_entries.extend(entries_for(name, record))
+            _dns_entries.extend(entries_for(name, record))
 
         try:
             self._client.set_dns_entries(plan.desired.name[:-1], _dns_entries)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -107,7 +107,7 @@ class PlannableProvider(BaseProvider):
 
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
-    SUPPORTS = set(('A',))
+    SUPPORTS = set(('A', 'AAAA', 'TXT'))
 
     def __init__(self, *args, **kwargs):
         super(PlannableProvider, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Fairly simple PR that implements `_type` checking and `dynamic` supports in `ProviderBase._process_desired_zone` so that we get the new `supports_warn_or_except` behavior when a provider is asked to create records it doesn't support.

This is the big one in terms of getting the most common case for all providers to warn or error when they can't create records they're being asked to.

There will likely be some more detail PRs, but this gets the 90% case.

/cc @viranch @yzguy 