### PR TITLE
Record.copy with data param using deep_merge

### DIFF
--- a/octodns/processor/acme.py
+++ b/octodns/processor/acme.py
@@ -38,9 +38,9 @@ class AcmeMangingProcessor(BaseProcessor):
                record.name.startswith('_acme-challenge'):
                 # We have a managed acme challenge record (owned by octoDNS) so
                 # we should mark it as such
-                record = record.copy()
-                record.values.append('*octoDNS*')
-                record.values.sort()
+                record = record.copy(data={
+                    'values': sorted(record.values + ['*octoDNS*']),
+                })
                 # This assumes we'll see things as sources before targets,
                 # which is the case...
                 self._owned.add(record)

--- a/octodns/provider/base.py
+++ b/octodns/provider/base.py
@@ -62,8 +62,9 @@ class BaseProvider(BaseSource):
                 fallback = 'falling back to single value, {}' \
                     .format(record.value)
                 self.supports_warn_or_except(msg, fallback)
-                record = record.copy()
-                record.values = [record.value]
+                record = record.copy(data={
+                    'values': [record.value],
+                })
                 desired.add_record(record, replace=True)
 
         return desired

--- a/octodns/provider/route53.py
+++ b/octodns/provider/route53.py
@@ -956,8 +956,11 @@ class Route53Provider(BaseProvider):
                     rules.append(rule)
 
                 if rules != dynamic.rules:
-                    record = record.copy()
-                    record.dynamic.rules = rules
+                    record = record.copy(data={
+                        'dynamic': {
+                            'rules': [r.data for r in rules],
+                        }
+                    })
                     desired.add_record(record, replace=True)
 
         return super(Route53Provider, self)._process_desired_zone(desired)

--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
+from deep_merge import merge as deep_merge
 from ipaddress import IPv4Address, IPv6Address
 from logging import getLogger
 import re
@@ -219,14 +220,15 @@ class Record(EqualityTupleMixin):
         if self.ttl != other.ttl:
             return Update(self, other)
 
-    def copy(self, zone=None):
-        data = self.data
-        data['type'] = self._type
+    def copy(self, zone=None, data={}):
+        merged = self.data
+        deep_merge(merged, data)
+        merged['type'] = self._type
 
         return Record.new(
             zone if zone else self.zone,
             self.name,
-            data,
+            merged,
             self.source,
             lenient=True
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ azure-mgmt-dns==8.0.0
 azure-mgmt-trafficmanager==0.51.0
 boto3==1.15.9
 botocore==1.18.9
+deep_merge==0.0.4
 dnspython==1.16.0
 docutils==0.16
 dyn==1.8.1


### PR DESCRIPTION

This allows copies of records with modifications in a single call. The old way of mucking with them after the fact would still work, but this way seems cleaner. Went ahead and converted existing `Record.copy`s to use it.

/cc https://github.com/octodns/octodns/pull/761#discussion_r694323825 for discussion that lead to this implementation