### PR TITLE
Retain octodns settings on record copy

### DIFF
--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -222,6 +222,7 @@ class Record(EqualityTupleMixin):
     def copy(self, zone=None):
         data = self.data
         data['type'] = self._type
+        data['octodns'] = self._octodns
 
         return Record.new(
             zone if zone else self.zone,

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -1055,6 +1055,37 @@ class TestRecord(TestCase):
         d.copy()
         self.assertEquals('TXT', d._type)
 
+    def test_dynamic_record_copy(self):
+        a_data = {
+            'dynamic': {
+                'pools': {
+                    'one': {
+                        'values': [{
+                            'value': '3.3.3.3',
+                        }],
+                    },
+                },
+                'rules': [{
+                    'pool': 'one',
+                }],
+            },
+            'octodns': {
+                'healthcheck': {
+                    'protocol': 'TCP',
+                    'port': 80,
+                },
+            },
+            'ttl': 60,
+            'type': 'A',
+            'values': [
+                '1.1.1.1',
+                '2.2.2.2',
+            ],
+        }
+        record1 = Record.new(self.zone, 'a', a_data)
+        record2 = record1.copy()
+        self.assertEqual(record1._octodns, record2._octodns)
+
     def test_change(self):
         existing = Record.new(self.zone, 'txt', {
             'ttl': 44,


### PR DESCRIPTION
I realized copying dynamic records loses the healthcheck settings. Here's a fix to retain the `octodns` block on copy.