### PR TITLE
Requirements and release process updates

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ pycodestyle==2.6.0
 pyflakes==2.2.0
 readme_renderer[md]==26.0
 requests_mock
-twine==3.2.0; python_version >= '3.2'
+twine==3.4.2
 
 # Profiling tests...
 # nose-cprof

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+build==0.7.0
 coverage
 mock
 nose

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,10 +10,8 @@ docutils==0.16
 dyn==1.8.1
 edgegrid-python==1.1.1
 fqdn==1.5.0
-futures==3.2.0; python_version < '3.2'
 google-cloud-core==1.4.1
 google-cloud-dns==0.32.0
-ipaddress==1.0.23; python_version < '3.3'
 jmespath==0.10.0
 msrestazure==0.6.4
 natsort==6.2.1

--- a/script/changelog
+++ b/script/changelog
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+VERSION=v$(grep __VERSION__ octodns/__init__.py | sed -e "s/^[^']*'//" -e "s/'$//")
+echo $VERSION
+git log --pretty="%h - %cr - %s (%an)" "${VERSION}..HEAD"

--- a/script/release
+++ b/script/release
@@ -21,7 +21,7 @@ VERSION="$(grep __VERSION__ "$ROOT/octodns/__init__.py" | sed -e "s/.* = '//" -e
 git tag -s "v$VERSION" -m "Release $VERSION"
 git push origin "v$VERSION"
 echo "Tagged and pushed v$VERSION"
-python setup.py sdist
-twine check dist/*$VERSION.tar.gz
-twine upload dist/*$VERSION.tar.gz
+python -m build --sdist --wheel
+twine check dist/*$VERSION.tar.gz dist/*$VERSION*.whl
+twine upload dist/*$VERSION.tar.gz dist/*$VERSION*.whl
 echo "Uploaded $VERSION"

--- a/setup.py
+++ b/setup.py
@@ -68,9 +68,7 @@ setup(
     install_requires=[
         'PyYaml>=4.2b1',
         'dnspython>=1.15.0',
-        'futures>=3.2.0; python_version<"3.2"',
         'fqdn>=1.5.0',
-        'ipaddress>=1.0.22; python_version<"3.3"',
         'natsort>=5.5.0',
         'pycountry>=19.8.18',
         'pycountry-convert>=0.7.2',


### PR DESCRIPTION
* Remove python version gates on requirements now that we're all python 3
* use new `build` module to create both sdist and wheel packages and upload both
* add changelog helper scriopt, bascially dumps all the commit logs since the last release for summarizing 