### PR TITLE
properly return and cache none replies for get_zone_by_name in route53

### DIFF
--- a/octodns/provider/route53.py
+++ b/octodns/provider/route53.py
@@ -682,11 +682,11 @@ class Route53Provider(BaseProvider):
     def _get_zone_id(self, name, create=False):
         self.log.debug('_get_zone_id: name=%s', name)
         self.update_r53_zones(name)
+        id = None
         if name in self._r53_zones:
             id = self._r53_zones[name]
             self.log.debug('_get_zone_id:   id=%s', id)
-            return id
-        if create:
+        if create and not id:
             ref = uuid4().hex
             del_set = self.delegation_set_id
             self.log.debug('_get_zone_id:   no matching zone, creating, '
@@ -699,8 +699,7 @@ class Route53Provider(BaseProvider):
                 resp = self._conn.create_hosted_zone(Name=name,
                                                      CallerReference=ref)
             self._r53_zones[name] = id = resp['HostedZone']['Id']
-            return id
-        return None
+        return id
 
     def _parse_geo(self, rrset):
         try:


### PR DESCRIPTION
Followup to an earlier PR, during testing additional testing it was found that when a zone id did not exist it was returning a None back when attempting to create a zone.

Adding additional tests to catch this condition as well.