### PR TITLE
Skip explicit countries when converting continent to countries in NS1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 * NS1 provider has received improvements to the dynamic record implementation.
   As a result, if octoDNS is downgraded from this version, any dynamic records
   created or updated using this version will show an update.
+* An edge-case bug related to geo rules involving continents in NS1 provider
+  has been fixed in this version. However, it will not show/fix the records that
+  match this edge-case. See https://github.com/octodns/octodns/pull/809 for
+  more information. If octoDNS is downgraded from this version, any dynamic
+  records created or updated using this version and matching the said edge-case
+  will not be read/parsed correctly by the older version and will show a diff.
 
 ## v0.9.14 - 2021-10-10 - A new supports system
 


### PR DESCRIPTION
`NS1Provider` converts `NA` and `OC` to individual list of countries. This creates a problem when a subset of those countries are already defined in another rule pointing to a different pool. This may lead to an undefined behavior as those countries point to two different DNS responses in NS1 record. 

This PR skips over the explicitly listed countries when expanding continents to countries; and uses region notes to parse the incomplete list of continent countries back to the continent in octoDNS record. 