### PR TITLE
Remove temporary file write from setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ code](https://en.wikipedia.org/wiki/Infrastructure_as_Code) OctoDNS provides a s
 
 The architecture is pluggable and the tooling is flexible to make it applicable to a wide variety of use-cases. Effort has been made to make adding new providers as easy as possible. In the simple case that involves writing of a single `class` and a couple hundred lines of code, most of which is translating between the provider's schema and OctoDNS's. More on some of the ways we use it and how to go about extending it below and in the [/docs directory](/docs).
 
-It is similar to [Netflix/denominator](https://github.com/Netflix/denominator).
-
 ## Table of Contents
 
 - [DNS as code - Tools for managing DNS across multiple providers](#dns-as-code---tools-for-managing-dns-across-multiple-providers)

--- a/setup.py
+++ b/setup.py
@@ -52,10 +52,7 @@ def long_description():
                 supported_providers = True
                 continue
             buf.write(line)
-    buf = buf.getvalue()
-    with open('/tmp/mod', 'w') as fh:
-        fh.write(buf)
-    return buf
+    return buf.getvalue()
 
 
 setup(


### PR DESCRIPTION

Guessing it was there for debugging and was accidentally left in place. 

This also removes a line from the README about the netflix tool that isn't really relevant. 

/cc Fixes https://github.com/octodns/octodns/issues/812
/cc @guicai-private 