### PR TITLE
Adds awsacm processor that completely ignores AWS ACM validation CNAME records at source and destination

### DIFF
--- a/octodns/processor/awsacm.py
+++ b/octodns/processor/awsacm.py
@@ -1,0 +1,46 @@
+#
+# Ignores AWS ACM validation CNAME records.
+#
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
+from logging import getLogger
+
+from .base import BaseProcessor
+
+
+class AwsAcmMangingProcessor(BaseProcessor):
+    log = getLogger('AwsAcmMangingProcessor')
+
+    def __init__(self, name):
+        '''
+        processors:
+          awsacm:
+            class: octodns.processor.acme.AwsAcmMangingProcessor
+
+        ...
+
+        zones:
+          something.com.:
+          ...
+          processors:
+            - awsacm
+          ...
+        '''
+        super(AwsAcmMangingProcessor, self).__init__(name)
+
+    def _ignore_awsacm_cnames(self, zone):
+        for r in zone.records:
+            if r._type == 'CNAME' and \
+                r.name.startswith('_') \
+                    and r.value.endswith('.acm-validations.aws.'):
+                self.log.info('_process: ignoring %s', r.fqdn)
+                zone.remove_record(r)
+        return zone
+
+    def process_source_zone(self, desired, *args, **kwargs):
+        return self._ignore_awsacm_cnames(desired)
+
+    def process_target_zone(self, existing, *args, **kwargs):
+        return self._ignore_awsacm_cnames(existing)

--- a/octodns/processor/awsacm.py
+++ b/octodns/processor/awsacm.py
@@ -11,24 +11,22 @@ from .base import BaseProcessor
 
 
 class AwsAcmMangingProcessor(BaseProcessor):
-    log = getLogger('AwsAcmMangingProcessor')
+    '''
+    processors:
+        awsacm:
+        class: octodns.processor.acme.AwsAcmMangingProcessor
 
-    def __init__(self, name):
-        '''
-        processors:
-          awsacm:
-            class: octodns.processor.acme.AwsAcmMangingProcessor
+    ...
 
+    zones:
+        something.com.:
         ...
+        processors:
+        - awsacm
+        ...
+    '''
 
-        zones:
-          something.com.:
-          ...
-          processors:
-            - awsacm
-          ...
-        '''
-        super(AwsAcmMangingProcessor, self).__init__(name)
+    log = getLogger('AwsAcmMangingProcessor')
 
     def _ignore_awsacm_cnames(self, zone):
         for r in zone.records:

--- a/tests/test_octodns_processor_awsacm.py
+++ b/tests/test_octodns_processor_awsacm.py
@@ -1,0 +1,70 @@
+#
+#
+#
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
+from unittest import TestCase
+
+from octodns.processor.awsacm import AwsAcmMangingProcessor
+from octodns.record import Record
+from octodns.zone import Zone
+
+zone = Zone('unit.tests.', [])
+records = {
+    'root': Record.new(zone, '_deadbeef', {
+        'ttl': 30,
+        'type': 'CNAME',
+        'value': '_0123456789abcdef.acm-validations.aws.',
+    }),
+    'sub': Record.new(zone, '_deadbeef.sub', {
+        'ttl': 30,
+        'type': 'CNAME',
+        'value': '_0123456789abcdef.acm-validations.aws.',
+    }),
+    'not-cname': Record.new(zone, '_deadbeef.not-cname', {
+        'ttl': 30,
+        'type': 'AAAA',
+        'value': '::1',
+    }),
+    'not-acm': Record.new(zone, '_not-acm', {
+        'ttl': 30,
+        'type': 'CNAME',
+        'value': 'localhost.unit.tests.',
+    }),
+}
+
+
+class TestAwsAcmMangingProcessor(TestCase):
+
+    def test_process_zones(self):
+        acm = AwsAcmMangingProcessor('acm')
+
+        source = Zone(zone.name, [])
+        # Unrelated stuff that should be untouched
+        source.add_record(records['not-cname'])
+        source.add_record(records['not-acm'])
+        # ACM records that should be ignored
+        source.add_record(records['root'])
+        source.add_record(records['sub'])
+
+        got = acm.process_source_zone(source)
+        self.assertEqual([
+            '_deadbeef.not-cname',
+            '_not-acm',
+        ], sorted([r.name for r in got.records]))
+
+        existing = Zone(zone.name, [])
+        # Unrelated stuff that should be untouched
+        existing.add_record(records['not-cname'])
+        existing.add_record(records['not-acm'])
+        # Stuff that will be ignored
+        existing.add_record(records['root'])
+        existing.add_record(records['sub'])
+
+        got = acm.process_target_zone(existing)
+        self.assertEqual([
+            '_deadbeef.not-cname',
+            '_not-acm'
+        ], sorted([r.name for r in got.records]))


### PR DESCRIPTION
Adds awsacm processor that completely ignores AWS ACM validation CNAME records at source and destination