### PR TITLE
Route53 weight support

### DIFF
--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -45,6 +45,13 @@ class _AggregateTarget(object):
                 return False
         return True
 
+    @property
+    def SUPPORTS_WEIGHTED(self):
+        for target in self.targets:
+            if not target.SUPPORTS_WEIGHTED:
+                return False
+        return True
+
 
 class MakeThreadFuture(object):
 

--- a/octodns/provider/azuredns.py
+++ b/octodns/provider/azuredns.py
@@ -470,6 +470,7 @@ class AzureProvider(BaseProvider):
     '''
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = True
+    SUPPORTS_WEIGHTED = False
     SUPPORTS_POOL_VALUE_STATUS = True
     SUPPORTS_MULTIVALUE_PTR = True
     SUPPORTS = set(('A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NS', 'PTR', 'SRV',

--- a/octodns/provider/base.py
+++ b/octodns/provider/base.py
@@ -76,10 +76,6 @@ class BaseProvider(BaseSource):
                     for pool in record.dynamic.pools.values():
                         for value in pool.data['values']:
                             value['status'] = 'obey'
-
-                    print("_1_____JJJOOWOOWOWOWOWOOWOWOWOWO")
-                    print(record)
-                    print("_1_____JJJOOWOOWOWOWOWOOWOWOWOWO")
                     desired.add_record(record, replace=True)
                 else:
                     msg = f'dynamic records not supported for {record.fqdn}'
@@ -87,15 +83,13 @@ class BaseProvider(BaseSource):
                     self.supports_warn_or_except(msg, fallback)
                     record = record.copy()
                     record.dynamic = None
-                    print("_2_____JJJOOWOOWOWOWOWOOWOWOWOWO")
-                    print(record)
-                    print("_2_____JJJOOWOOWOWOWOWOOWOWOWOWO")
                     desired.add_record(record, replace=True)
             # elif getattr(record, 'weighted', False):
             #     if self.SUPPORTS_WEIGHTED:
             #         if record._type in self.SUPPORTS_WEIGHTED_TYPES:
             #             print("# BASEPROVIDER")
             #             print(record._type)
+            #             print(record.weighted)
             #             print("# BASEPROVIDER")
             #     else:
             #         msg = f'weighted records not supported for {record.fqdn}'
@@ -161,14 +155,10 @@ class BaseProvider(BaseSource):
         before = len(changes)
         changes = [c for c in changes if self._include_change(c)]
         after = len(changes)
+
         if before != after:
             self.log.info('plan:   filtered out %s changes', before - after)
 
-        # allow the provider to add extra changes it needs
-        for c in changes:
-            print(c)
-            print(dir(c))
-            print()
         extra = self._extra_changes(existing=existing, desired=desired,
                                     changes=changes)
         if extra:

--- a/octodns/provider/base.py
+++ b/octodns/provider/base.py
@@ -76,6 +76,10 @@ class BaseProvider(BaseSource):
                     for pool in record.dynamic.pools.values():
                         for value in pool.data['values']:
                             value['status'] = 'obey'
+
+                    print("_1_____JJJOOWOOWOWOWOWOOWOWOWOWO")
+                    print(record)
+                    print("_1_____JJJOOWOOWOWOWOWOOWOWOWOWO")
                     desired.add_record(record, replace=True)
                 else:
                     msg = f'dynamic records not supported for {record.fqdn}'
@@ -83,7 +87,19 @@ class BaseProvider(BaseSource):
                     self.supports_warn_or_except(msg, fallback)
                     record = record.copy()
                     record.dynamic = None
+                    print("_2_____JJJOOWOOWOWOWOWOOWOWOWOWO")
+                    print(record)
+                    print("_2_____JJJOOWOOWOWOWOWOOWOWOWOWO")
                     desired.add_record(record, replace=True)
+            # elif getattr(record, 'weighted', False):
+            #     if self.SUPPORTS_WEIGHTED:
+            #         if record._type in self.SUPPORTS_WEIGHTED_TYPES:
+            #             print("# BASEPROVIDER")
+            #             print(record._type)
+            #             print("# BASEPROVIDER")
+            #     else:
+            #         msg = f'weighted records not supported for {record.fqdn}'
+
             elif record._type == 'PTR' and len(record.values) > 1 and \
                     not self.SUPPORTS_MULTIVALUE_PTR:
                 # replace with a single-value copy
@@ -149,6 +165,10 @@ class BaseProvider(BaseSource):
             self.log.info('plan:   filtered out %s changes', before - after)
 
         # allow the provider to add extra changes it needs
+        for c in changes:
+            print(c)
+            print(dir(c))
+            print()
         extra = self._extra_changes(existing=existing, desired=desired,
                                     changes=changes)
         if extra:

--- a/octodns/provider/cloudflare.py
+++ b/octodns/provider/cloudflare.py
@@ -77,6 +77,7 @@ class CloudflareProvider(BaseProvider):
     '''
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
+    SUPPORTS_WEIGHTED = False
     SUPPORTS = set(('ALIAS', 'A', 'AAAA', 'CAA', 'CNAME', 'LOC', 'MX', 'NS',
                     'PTR', 'SRV', 'SPF', 'TXT', 'URLFWD'))
 

--- a/octodns/provider/constellix.py
+++ b/octodns/provider/constellix.py
@@ -441,6 +441,7 @@ class ConstellixProvider(BaseProvider):
     '''
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = True
+    SUPPORTS_WEIGHTED = False
     SUPPORTS = set(('A', 'AAAA', 'ALIAS', 'CAA', 'CNAME', 'MX',
                     'NS', 'PTR', 'SPF', 'SRV', 'TXT'))
 

--- a/octodns/provider/digitalocean.py
+++ b/octodns/provider/digitalocean.py
@@ -118,6 +118,7 @@ class DigitalOceanProvider(BaseProvider):
     '''
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
+    SUPPORTS_WEIGHTED = False
     SUPPORTS = set(('A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NS', 'TXT', 'SRV'))
 
     def __init__(self, id, token, *args, **kwargs):

--- a/octodns/provider/dnsimple.py
+++ b/octodns/provider/dnsimple.py
@@ -98,6 +98,7 @@ class DnsimpleProvider(BaseProvider):
     '''
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
+    SUPPORTS_WEIGHTED = False
     SUPPORTS = set(('A', 'AAAA', 'ALIAS', 'CAA', 'CNAME', 'MX', 'NAPTR', 'NS',
                     'PTR', 'SPF', 'SRV', 'SSHFP', 'TXT'))
 

--- a/octodns/provider/dnsmadeeasy.py
+++ b/octodns/provider/dnsmadeeasy.py
@@ -159,6 +159,7 @@ class DnsMadeEasyProvider(BaseProvider):
     '''
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
+    SUPPORTS_WEIGHTED = False
     SUPPORTS = set(('A', 'AAAA', 'ALIAS', 'CAA', 'CNAME', 'MX',
                     'NS', 'PTR', 'SPF', 'SRV', 'TXT'))
 

--- a/octodns/provider/dyn.py
+++ b/octodns/provider/dyn.py
@@ -270,6 +270,10 @@ class DynProvider(BaseProvider):
     def SUPPORTS_DYNAMIC(self):
         return self.traffic_directors_enabled
 
+    @property
+    def SUPPORTS_WEIGHTED(self):
+        return False
+
     def _check_dyn_sess(self):
         # We don't have to worry about locking for the check since the
         # underlying pieces are pre-thread. We can check to see if this thread

--- a/octodns/provider/easydns.py
+++ b/octodns/provider/easydns.py
@@ -159,6 +159,7 @@ class EasyDNSProvider(BaseProvider):
     '''
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
+    SUPPORTS_WEIGHTED = False
     SUPPORTS = set(('A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NS', 'TXT',
                     'SRV', 'NAPTR'))
 

--- a/octodns/provider/edgedns.py
+++ b/octodns/provider/edgedns.py
@@ -160,6 +160,7 @@ class AkamaiProvider(BaseProvider):
 
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
+    SUPPORTS_WEIGHTED = False
 
     SUPPORTS = set(('A', 'AAAA', 'CNAME', 'MX', 'NAPTR', 'NS', 'PTR', 'SPF',
                     'SRV', 'SSHFP', 'TXT'))

--- a/octodns/provider/etc_hosts.py
+++ b/octodns/provider/etc_hosts.py
@@ -26,6 +26,7 @@ class EtcHostsProvider(BaseProvider):
     '''
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
+    SUPPORTS_WEIGHTED = False
     SUPPORTS = set(('A', 'AAAA', 'ALIAS', 'CNAME'))
 
     def __init__(self, id, directory, *args, **kwargs):

--- a/octodns/provider/gandi.py
+++ b/octodns/provider/gandi.py
@@ -117,6 +117,7 @@ class GandiProvider(BaseProvider):
 
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
+    SUPPORTS_WEIGHTED = False
     SUPPORTS = set((['A', 'AAAA', 'ALIAS', 'CAA', 'CNAME', 'DNAME',
                      'MX', 'NS', 'PTR', 'SPF', 'SRV', 'SSHFP', 'TXT']))
 

--- a/octodns/provider/gcore.py
+++ b/octodns/provider/gcore.py
@@ -158,6 +158,7 @@ class GCoreProvider(BaseProvider):
 
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = True
+    SUPPORTS_WEIGHTED = False
     SUPPORTS = set(("A", "AAAA", "NS", "MX", "TXT", "SRV", "CNAME", "PTR"))
 
     def __init__(self, id, *args, **kwargs):

--- a/octodns/provider/googlecloud.py
+++ b/octodns/provider/googlecloud.py
@@ -41,6 +41,7 @@ class GoogleCloudProvider(BaseProvider):
                     'NS', 'PTR', 'SPF', 'SRV', 'TXT'))
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
+    SUPPORTS_WEIGHTED = False
 
     CHANGE_LOOP_WAIT = 5
 

--- a/octodns/provider/hetzner.py
+++ b/octodns/provider/hetzner.py
@@ -87,6 +87,7 @@ class HetznerProvider(BaseProvider):
     '''
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
+    SUPPORTS_WEIGHTED = False
     SUPPORTS = set(('A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NS', 'SRV', 'TXT'))
 
     def __init__(self, id, token, *args, **kwargs):

--- a/octodns/provider/mythicbeasts.py
+++ b/octodns/provider/mythicbeasts.py
@@ -99,6 +99,7 @@ class MythicBeastsProvider(BaseProvider):
 
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
+    SUPPORTS_WEIGHTED = False
     SUPPORTS = set(('A', 'AAAA', 'ALIAS', 'CNAME', 'MX', 'NS',
                     'SRV', 'SSHFP', 'CAA', 'TXT'))
     BASE = 'https://dnsapi.mythic-beasts.com/'

--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -304,6 +304,7 @@ class Ns1Provider(BaseProvider):
     '''
     SUPPORTS_GEO = True
     SUPPORTS_DYNAMIC = True
+    SUPPORTS_WEIGHTED = False
     SUPPORTS_POOL_VALUE_STATUS = True
     SUPPORTS_MULTIVALUE_PTR = True
     SUPPORTS = set(('A', 'AAAA', 'ALIAS', 'CAA', 'CNAME', 'MX', 'NAPTR',

--- a/octodns/provider/ovh.py
+++ b/octodns/provider/ovh.py
@@ -35,6 +35,7 @@ class OvhProvider(BaseProvider):
 
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
+    SUPPORTS_WEIGHTED = False
     ZONE_NOT_FOUND_MESSAGE = 'This service does not exist'
 
     # This variable is also used in populate method to filter which OVH record

--- a/octodns/provider/powerdns.py
+++ b/octodns/provider/powerdns.py
@@ -16,6 +16,7 @@ from .base import BaseProvider
 class PowerDnsBaseProvider(BaseProvider):
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
+    SUPPORTS_WEIGHTED = False
     SUPPORTS = set(('A', 'AAAA', 'ALIAS', 'CAA', 'CNAME', 'LOC', 'MX', 'NAPTR',
                     'NS', 'PTR', 'SPF', 'SSHFP', 'SRV', 'TXT'))
     TIMEOUT = 5

--- a/octodns/provider/rackspace.py
+++ b/octodns/provider/rackspace.py
@@ -42,6 +42,7 @@ def unescape_semicolon(s):
 class RackspaceProvider(BaseProvider):
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
+    SUPPORTS_WEIGHTED = False
     SUPPORTS = set(('A', 'AAAA', 'ALIAS', 'CNAME', 'MX', 'NS', 'PTR', 'SPF',
                     'TXT'))
     TIMEOUT = 5

--- a/octodns/provider/route53.py
+++ b/octodns/provider/route53.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
-
+import json
 from boto3 import client
 from botocore.config import Config
 from collections import defaultdict
@@ -117,6 +117,18 @@ class _Route53Record(EqualityTupleMixin):
         return ret
 
     @classmethod
+    def _new_weighted(cls, provider, record, creating):
+        # Creates the RRSets that correspond to the given weighted record
+        ret = set()
+
+        # ret.add(_Route53WeightedDefault(provider, record, creating))
+        for ident, weighted in record.weighted.items():
+            ret.add(_Route53WeightedRecord(provider, record, ident,
+                                           weighted, creating))
+
+        return ret
+
+    @classmethod
     def new(cls, provider, record, hosted_zone_id, creating):
         # Creates the RRSets that correspond to the given record
 
@@ -125,6 +137,8 @@ class _Route53Record(EqualityTupleMixin):
             return ret
         elif getattr(record, 'geo', False):
             return cls._new_geo(provider, record, creating)
+        elif getattr(record, 'weighted', False):
+            return cls._new_weighted(provider, record, creating)
 
         # Its a simple record that translates into a single RRSet
         return set((_Route53Record(provider, record, creating),))
@@ -437,6 +451,96 @@ class _Route53GeoRecord(_Route53Record):
 
     def mod(self, action, existing_rrsets):
         geo = self.geo
+        set_identifier = geo.code
+        fqdn = self.fqdn
+
+        if action == 'DELETE':
+            # When deleting records try and find the original rrset so that
+            # we're 100% sure to have the complete & accurate data (this mostly
+            # ensures we have the right health check id when there's multiple
+            # potential matches)
+            for existing in existing_rrsets:
+                if fqdn == existing.get('Name') and \
+                   set_identifier == existing.get('SetIdentifier', None):
+                    return {
+                        'Action': action,
+                        'ResourceRecordSet': existing,
+                    }
+
+        rrset = {
+            'Name': self.fqdn,
+            'GeoLocation': {
+                'CountryCode': '*'
+            },
+            'ResourceRecords': [{'Value': v} for v in geo.values],
+            'SetIdentifier': set_identifier,
+            'TTL': self.ttl,
+            'Type': self._type,
+        }
+
+        if self.health_check_id:
+            rrset['HealthCheckId'] = self.health_check_id
+
+        if geo.subdivision_code:
+            rrset['GeoLocation'] = {
+                'CountryCode': geo.country_code,
+                'SubdivisionCode': geo.subdivision_code
+            }
+        elif geo.country_code:
+            rrset['GeoLocation'] = {
+                'CountryCode': geo.country_code
+            }
+        else:
+            rrset['GeoLocation'] = {
+                'ContinentCode': geo.continent_code
+            }
+
+        return {
+            'Action': action,
+            'ResourceRecordSet': rrset,
+        }
+
+    def __hash__(self):
+        return f'{self.fqdn}:{self._type}:{self.geo.code}'.__hash__()
+
+    def _equality_tuple(self):
+        return super(_Route53GeoRecord, self)._equality_tuple() + \
+            (self.geo.code,)
+
+    def __repr__(self):
+        return f'_Route53GeoRecord<{self.fqdn} {self._type} {self.ttl} ' \
+            f'{self.geo.code} {self.values}>'
+
+
+# class _Route53WeightedDefault(_Route53Record):
+
+#     def mod(self, action, existing_rrsets):
+#         return {
+#             'Action': action,
+#             'ResourceRecordSet': {
+#                 'Name': self.fqdn,
+#                 'ResourceRecords': [{'Value': v} for v in self.values],
+#                 'SetIdentifier': 'default',
+#                 'TTL': self.ttl,
+#                 'Type': self._type,
+#             }
+#         }
+
+#     def __hash__(self):
+#         return f'{self.fqdn}:{self._type}:default'.__hash__()
+
+#     def __repr__(self):
+#         return f'_Route53WeightedDefault<{self.fqdn} {self._type} {self.ttl} ' \
+#             f'{self.values}>'
+
+
+class _Route53WeightedRecord(_Route53Record):
+
+    def __init__(self, provider, record, ident, weighted, creating):
+        super(_Route53WeightedRecord, self).__init__(provider, record, creating)
+        self.weighted = weighted
+
+    def mod(self, action, existing_rrsets):
         set_identifier = geo.code
         fqdn = self.fqdn
 
@@ -932,6 +1036,11 @@ class Route53Provider(BaseProvider):
 
         return data
 
+    def _data_for_weighted(self, name, _type, rrsets):
+        # This converts a bunch of RRSets into their corrosponding weighted
+        # Record. It's used by populate.
+
+
     def _process_desired_zone(self, desired):
         for record in desired.records:
             if getattr(record, 'dynamic', False):
@@ -980,11 +1089,14 @@ class Route53Provider(BaseProvider):
             exists = True
             records = defaultdict(lambda: defaultdict(list))
             dynamic = defaultdict(lambda: defaultdict(list))
+            weighted = defaultdict(lambda: defaultdict(list))
 
             for rrset in self._load_records(zone_id):
                 record_name = zone.hostname_from_fqdn(rrset['Name'])
                 record_name = _octal_replace(record_name)
                 record_type = rrset['Type']
+
+                self.log.info('################## %s' % json.dumps(rrset))
                 if record_type not in self.SUPPORTS:
                     # Skip stuff we don't support
                     continue
@@ -1006,8 +1118,10 @@ class Route53Provider(BaseProvider):
                         self.log.warning("%s is an Alias record. Skipping..."
                                          % rrset['Name'])
                     continue
+
                 # A basic record (potentially including geo)
                 data = getattr(self, f'_data_for_{record_type}')(rrset)
+                self.log.info('DATA             %s' % json.dumps(data))
                 records[record_name][record_type].append(data)
 
             # Convert the dynamic rrsets to Records
@@ -1018,9 +1132,17 @@ class Route53Provider(BaseProvider):
                                         lenient=lenient)
                     zone.add_record(record, lenient=lenient)
 
+            # Convert the weighted rrsets to Records
+            for name, types in weighted.items():
+                for _type, rrsets in types.items():
+                    data = self._data_for_weighted(name, _type, rrsets)
+                    record = Record.new(zone, name, data, source=self
+                                        lenient=lenient)
+
             # Convert the basic (potentially with geo) rrsets to records
             for name, types in records.items():
                 for _type, data in types.items():
+                    self.log.info("########### %s" % data)
                     if len(data) > 1:
                         # Multiple data indicates a record with GeoDNS, convert
                         # them data into the format we need

--- a/octodns/provider/transip.py
+++ b/octodns/provider/transip.py
@@ -50,6 +50,7 @@ class TransipProvider(BaseProvider):
 
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
+    SUPPORTS_WEIGHTED = False
     SUPPORTS = set(('A', 'AAAA', 'CNAME', 'MX', 'NS', 'SRV', 'SPF', 'TXT',
                     'SSHFP', 'CAA'))
     # unsupported by OctoDNS: 'TLSA'

--- a/octodns/provider/ultra.py
+++ b/octodns/provider/ultra.py
@@ -72,6 +72,7 @@ class UltraProvider(BaseProvider):
 
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
+    SUPPORTS_WEIGHTED = False
     TIMEOUT = 5
     ZONE_REQUEST_LIMIT = 100
 

--- a/octodns/provider/yaml.py
+++ b/octodns/provider/yaml.py
@@ -134,8 +134,10 @@ class YamlProvider(BaseProvider):
                     for d in data:
                         if 'ttl' not in d:
                             d['ttl'] = self.default_ttl
+                        print("yaml: 137: ", d)
                         record = Record.new(zone, name, d, source=self,
                                             lenient=lenient)
+                        print("yaml: 140: ", record)
                         zone.add_record(record, lenient=lenient,
                                         replace=self.populate_should_replace)
             self.log.debug('_populate_from_file: successfully loaded "%s"',
@@ -149,7 +151,6 @@ class YamlProvider(BaseProvider):
             # When acting as a target we ignore any existing records so that we
             # create a completely new copy
             return False
-
         before = len(zone.records)
         filename = join(self.directory, f'{zone.name}yaml')
         self._populate_from_file(filename, zone, lenient)

--- a/octodns/source/axfr.py
+++ b/octodns/source/axfr.py
@@ -25,6 +25,7 @@ class AxfrBaseSource(BaseSource):
 
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
+    SUPPORTS_WEIGHTED = False
     SUPPORTS = set(('A', 'AAAA', 'CAA', 'CNAME', 'LOC', 'MX', 'NS', 'PTR',
                     'SPF', 'SRV', 'TXT'))
 

--- a/octodns/source/base.py
+++ b/octodns/source/base.py
@@ -27,6 +27,10 @@ class BaseSource(object):
     def SUPPORTS_DYNAMIC(self):
         return False
 
+    @property
+    def SUPPORTS_WEIGHTED(self):
+        return False
+
     def populate(self, zone, target=False, lenient=False):
         '''
         Loads all records the provider knows about for the provided zone

--- a/octodns/source/envvar.py
+++ b/octodns/source/envvar.py
@@ -58,6 +58,7 @@ class EnvVarSource(BaseSource):
     '''
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
+    SUPPORTS_WEIGHTED = False
     SUPPORTS = set(('TXT'))
 
     DEFAULT_TTL = 60

--- a/octodns/source/tinydns.py
+++ b/octodns/source/tinydns.py
@@ -21,6 +21,7 @@ from .base import BaseSource
 class TinyDnsBaseSource(BaseSource):
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
+    SUPPORTS_WEIGHTED = False
     SUPPORTS = set(('A', 'CNAME', 'MX', 'NS', 'TXT', 'AAAA'))
 
     split_re = re.compile(r':+')

--- a/octodns/zone.py
+++ b/octodns/zone.py
@@ -11,6 +11,9 @@ import re
 
 from .record import Create, Delete
 
+def dump(obj):
+  for attr in dir(obj):
+    print("obj.%s = %r" % (attr, getattr(obj, attr)))
 
 class SubzoneRecordException(Exception):
     pass
@@ -68,7 +71,15 @@ class Zone(object):
 
         name = record.name
         last = name.split('.')[-1]
-
+        # self.log.debug("zone.add_record: record=%s replace=%s, lenient=%s", record, replace, lenient)
+        # if record.name == 'test-weighted-a':
+        #     print()
+        #     print()
+        #     dump(record)
+        #     print()
+        #     print()
+        #     print()
+        #     print()
         if not lenient and last in self.sub_zones:
             if name != last:
                 # it's a record for something under a sub-zone
@@ -86,10 +97,10 @@ class Zone(object):
 
         node = self._records[name]
         if record in node:
-            if not getattr(record, 'weighted', False):
-                # We already have a record at this node of this type
-                raise DuplicateRecordException(f'Duplicate record {record.fqdn}, '
-                                            f'type {record._type}')
+            # We already have a record at this node of this type
+            raise DuplicateRecordException('Duplicate record '
+                                            f'{record.fqdn}, type '
+                                            f'{record._type}')
         elif not lenient and ((record._type == 'CNAME' and len(node) > 0) or
                               ('CNAME' in [r._type for r in node])):
             # We're adding a CNAME to existing records or adding to an existing

--- a/octodns/zone.py
+++ b/octodns/zone.py
@@ -86,9 +86,10 @@ class Zone(object):
 
         node = self._records[name]
         if record in node:
-            # We already have a record at this node of this type
-            raise DuplicateRecordException(f'Duplicate record {record.fqdn}, '
-                                           f'type {record._type}')
+            if not getattr(record, 'weighted', False):
+                # We already have a record at this node of this type
+                raise DuplicateRecordException(f'Duplicate record {record.fqdn}, '
+                                            f'type {record._type}')
         elif not lenient and ((record._type == 'CNAME' and len(node) > 0) or
                               ('CNAME' in [r._type for r in node])):
             # We're adding a CNAME to existing records or adding to an existing
@@ -190,7 +191,6 @@ class Zone(object):
                 continue
             self.log.debug('changes: zone=%s, create record=%s', self, record)
             changes.append(Create(record))
-
         return changes
 
     def hydrate(self):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -22,6 +22,7 @@ class SimpleSource(object):
 class SimpleProvider(object):
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
+    SUPPORTS_WEIGHTED = False
     SUPPORTS = set(('A',))
     id = 'test'
 
@@ -41,6 +42,7 @@ class SimpleProvider(object):
 class GeoProvider(object):
     SUPPORTS_GEO = True
     SUPPORTS_DYNAMIC = False
+    SUPPORTS_WEIGHTED = False
     id = 'test'
 
     def __init__(self, id='test'):
@@ -59,6 +61,7 @@ class GeoProvider(object):
 class DynamicProvider(object):
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = True
+    SUPPORTS_WEIGHTED = False
     id = 'test'
 
     def __init__(self, id='test'):
@@ -73,6 +76,24 @@ class DynamicProvider(object):
     def __repr__(self):
         return self.__class__.__name__
 
+
+class WeightedProvider(object):
+    SUPPORTS_GEO = False
+    SUPPORTS_DYNAMIC = False
+    SUPPORTS_WEIGHTED = True
+    id = 'test'
+
+    def __init__(self, id='test'):
+        pass
+
+    def populate(self, zone, source=False, lenient=False):
+        pass
+
+    def supports(self, record):
+        return True
+
+    def __repr__(self):
+        return self.__class__.__name__
 
 class NoSshFpProvider(SimpleProvider):
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -95,6 +95,7 @@ class WeightedProvider(object):
     def __repr__(self):
         return self.__class__.__name__
 
+
 class NoSshFpProvider(SimpleProvider):
 
     def supports(self, record):

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -18,7 +18,7 @@ from octodns.zone import Zone
 from mock import MagicMock, patch
 from unittest import TestCase
 
-from helpers import DynamicProvider, GeoProvider, NoSshFpProvider, \
+from helpers import WeightedProvider, DynamicProvider, GeoProvider, NoSshFpProvider, \
     PlannableProvider, SimpleProvider, TemporaryDirectory
 
 config_dir = join(dirname(__file__), 'config')
@@ -233,6 +233,7 @@ class TestManager(TestCase):
         simple = SimpleProvider()
         geo = GeoProvider()
         dynamic = DynamicProvider()
+        weighted = WeightedProvider()
         nosshfp = NoSshFpProvider()
 
         self.assertFalse(_AggregateTarget([simple, simple]).SUPPORTS_GEO)
@@ -244,6 +245,11 @@ class TestManager(TestCase):
         self.assertFalse(_AggregateTarget([simple, dynamic]).SUPPORTS_DYNAMIC)
         self.assertFalse(_AggregateTarget([dynamic, simple]).SUPPORTS_DYNAMIC)
         self.assertTrue(_AggregateTarget([dynamic, dynamic]).SUPPORTS_DYNAMIC)
+
+        self.assertFalse(_AggregateTarget([simple, simple]).SUPPORTS_WEIGHTED)
+        self.assertFalse(_AggregateTarget([simple, weighted]).SUPPORTS_WEIGHTED)
+        self.assertFalse(_AggregateTarget([weighted, simple]).SUPPORTS_WEIGHTED)
+        self.assertTrue(_AggregateTarget([weighted, weighted]).SUPPORTS_WEIGHTED)
 
         zone = Zone('unit.tests.', [])
         record = Record.new(zone, 'sshfp', {

--- a/tests/test_octodns_zone.py
+++ b/tests/test_octodns_zone.py
@@ -42,10 +42,16 @@ class TestZone(TestCase):
         c = ARecord(zone, 'a', {'ttl': 43, 'value': '2.2.2.2'})
 
         zone.add_record(a)
+        print("___________________")
+        print(zone.records)
+        print("---")
+        print(set([a]))
+        print("___________________")
         self.assertEquals(zone.records, set([a]))
         # Can't add record with same name & type
         with self.assertRaises(DuplicateRecordException) as ctx:
             zone.add_record(a)
+        print(str(ctx.exception))
         self.assertEquals('Duplicate record a.unit.tests., type A',
                           str(ctx.exception))
         self.assertEquals(zone.records, set([a]))


### PR DESCRIPTION
Tried to build in some basic support for weighted records in Route53. Reason behind this is because dynamic-records is not what we are searching for and is somewhat depending on health checks. 

Python Tests etc still need to be added. but it works like follows:

```yaml
test:
  weighted:
    test-1:
      value: test1.example.com.
      weight: 200
    test-2:
      value: test2.example.com.
      weight: 100
    test-3:
      value: test3.example.com.
      weight: 100
  ttl: 60
  type: CNAME  # or A
  # fallback with weight: 0
  # identifier: _octodns_default
  value: test0.example.com.
  ```