### PR TITLE
process_desired_zone check for non routable IPs

### DIFF
--- a/tests/test_octodns_provider_base.py
+++ b/tests/test_octodns_provider_base.py
@@ -255,10 +255,6 @@ class TestBaseProvider(TestCase):
         provider.SUPPORTS_MULTIVALUE_PTR = True
         zone2 = provider._process_desired_zone(zone1.copy())
         record2 = list(zone2.records)[0]
-        from pprint import pprint
-        pprint([
-            record1, record2
-        ])
         self.assertEqual(len(record2.values), 2)
 
         # SUPPORTS_DYNAMIC


### PR DESCRIPTION
This PR adds `process_desired_zone` supports checking for non-routable IPs in dynamic records. When found `strict: true` will error out with a message about the problem. When `false` the record(s) will have `status: up` set which avoids using health checks.

I think this is a fairly clean way to coach the needed setup for anyone who tries to use private IPs in dynamic records, e.g. for a multi-value weight setup like in https://github.com/octodns/octodns/pull/816. 

@viranch thoughts?

/cc https://github.com/octodns/octodns/pull/816 for prior discussion
/cc https://github.com/octodns/octodns/pull/819 for related work