### PR TITLE
Add a validation to catch name=@ and suggest name='' instead

### DIFF
--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -124,6 +124,8 @@ class Record(EqualityTupleMixin):
     @classmethod
     def validate(cls, name, fqdn, data):
         reasons = []
+        if name == '@':
+            reasons.append('invalid name "@", use "" instead')
         n = len(fqdn)
         if n > 253:
             reasons.append(f'invalid fqdn, "{fqdn}" is too long at {n} '

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -1643,6 +1643,17 @@ class TestRecordValidation(TestCase):
     zone = Zone('unit.tests.', [])
 
     def test_base(self):
+        # name = '@'
+        with self.assertRaises(ValidationError) as ctx:
+            name = '@'
+            Record.new(self.zone, name, {
+                'ttl': 300,
+                'type': 'A',
+                'value': '1.2.3.4',
+            })
+        reason = ctx.exception.reasons[0]
+        self.assertTrue(reason.startswith('invalid name "@", use "" instead'))
+
         # fqdn length, DNS defins max as 253
         with self.assertRaises(ValidationError) as ctx:
             # The . will put this over the edge


### PR DESCRIPTION
Some providers use '@' as the name and users who are familiar with that pattern may try to do so in octoDNS. octoDNS uses the empty string for root/apex records. Many octoDNS providers that have to deal with `@` will run into syncing problems if one is configured in its sources. This prevents that issue from arising and provides the correct option.

/cc Fixes https://github.com/octodns/octodns/issues/824#issuecomment-1003162795