### PR TITLE
Update README to reflect CF URLFWD record support

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ The above command pulled the existing data out of Route53 and placed the results
 |--|--|--|--|--|
 | [AzureProvider](/octodns/provider/azuredns.py) | azure-identity, azure-mgmt-dns, azure-mgmt-trafficmanager | A, AAAA, CAA, CNAME, MX, NS, PTR, SRV, TXT | Alpha (A, AAAA, CNAME) | |
 | [Akamai](/octodns/provider/edgedns.py) | edgegrid-python | A, AAAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, SSHFP, TXT | No | |
-| [CloudflareProvider](/octodns/provider/cloudflare.py) | | A, AAAA, ALIAS, CAA, CNAME, LOC, MX, NS, PTR, SPF, SRV, TXT | No | CAA tags restricted |
+| [CloudflareProvider](/octodns/provider/cloudflare.py) | | A, AAAA, ALIAS, CAA, CNAME, LOC, MX, NS, PTR, SPF, SRV, TXT, URLFWD | No | CAA tags restricted |
 | [ConstellixProvider](/octodns/provider/constellix.py) | | A, AAAA, ALIAS (ANAME), CAA, CNAME, MX, NS, PTR, SPF, SRV, TXT | Yes | CAA tags restricted |
 | [DigitalOceanProvider](/octodns/provider/digitalocean.py) | | A, AAAA, CAA, CNAME, MX, NS, TXT, SRV | No | CAA tags restricted |
 | [DnsMadeEasyProvider](/octodns/provider/dnsmadeeasy.py) | | A, AAAA, ALIAS (ANAME), CAA, CNAME, MX, NS, PTR, SPF, SRV, TXT | No | CAA tags restricted |


### PR DESCRIPTION
In [this PR](https://github.com/octodns/octodns/pull/722) URLFWD record support was added to the NS1, YAML, and Cloudflare providers. All the correct `SUPPORTS` sets were updated, and [docs/records.md](https://github.com/octodns/octodns/blob/master/docs/records.md) added the `URLFWD` in its list of supported tags. 

For **NS1** and **YAML** the `README.md` table already has **Record Support = all**  so no changes were needed here, but for Cloudflare, the list was hardcoded, and URLFWD should have been added here. It's a very minor thing, but without looking at the code, it looks like Cloudflare URLFWDs are not supported.