### PR TITLE
Quell all python warnings, mostly *Equals -> Equal and warn -> warning

### DIFF
--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -260,8 +260,8 @@ class Manager(object):
                     if ("unexpected keyword argument 'lenient'"
                             not in str(e)):
                         raise
-                    self.log.warn('provider %s does not accept lenient '
-                                  'param', source.__class__.__name__)
+                    self.log.warning('provider %s does not accept lenient '
+                                     'param', source.__class__.__name__)
                     source.populate(zone)
 
         for processor in processors:
@@ -283,8 +283,8 @@ class Manager(object):
             except TypeError as e:
                 if "keyword argument 'processors'" not in str(e):
                     raise
-                self.log.warn('provider.plan %s does not accept processors '
-                              'param', target.__class__.__name__)
+                self.log.warning('provider.plan %s does not accept processors '
+                                 'param', target.__class__.__name__)
                 plan = target.plan(zone)
 
             for processor in processors:

--- a/octodns/processor/awsacm.py
+++ b/octodns/processor/awsacm.py
@@ -9,9 +9,9 @@ from logging import getLogger
 
 logger = getLogger('Route53')
 try:
-    logger.warn('octodns_route53 shimmed. Update your processor class to '
-                'octodns_route53.processor.AwsAcmMangingProcessor. '
-                'Shim will be removed in 1.0')
+    logger.warning('octodns_route53 shimmed. Update your processor class to '
+                   'octodns_route53.processor.AwsAcmMangingProcessor. '
+                   'Shim will be removed in 1.0')
     from octodns_route53.processor import AwsAcmMangingProcessor
     AwsAcmMangingProcessor  # pragma: no cover
 except ModuleNotFoundError:

--- a/octodns/provider/azuredns.py
+++ b/octodns/provider/azuredns.py
@@ -9,9 +9,9 @@ from logging import getLogger
 
 logger = getLogger('Azure')
 try:
-    logger.warn('octodns_azure shimmed. Update your provider class to '
-                'octodns_azure.AzureProvider. '
-                'Shim will be removed in 1.0')
+    logger.warning('octodns_azure shimmed. Update your provider class to '
+                   'octodns_azure.AzureProvider. '
+                   'Shim will be removed in 1.0')
     from octodns_azure import AzureProvider
     AzureProvider  # pragma: no cover
 except ModuleNotFoundError:

--- a/octodns/provider/base.py
+++ b/octodns/provider/base.py
@@ -132,8 +132,8 @@ class BaseProvider(BaseSource):
         if exists is None:
             # If your code gets this warning see Source.populate for more
             # information
-            self.log.warn('Provider %s used in target mode did not return '
-                          'exists', self.id)
+            self.log.warning('Provider %s used in target mode did not return '
+                             'exists', self.id)
 
         for processor in processors:
             existing = processor.process_target_zone(existing, target=self)

--- a/octodns/provider/cloudflare.py
+++ b/octodns/provider/cloudflare.py
@@ -9,9 +9,9 @@ from logging import getLogger
 
 logger = getLogger('Cloudflare')
 try:
-    logger.warn('octodns_cloudflare shimmed. Update your provider class to '
-                'octodns_cloudflare.CloudflareProvider. '
-                'Shim will be removed in 1.0')
+    logger.warning('octodns_cloudflare shimmed. Update your provider class to '
+                   'octodns_cloudflare.CloudflareProvider. '
+                   'Shim will be removed in 1.0')
     from octodns_cloudflare import CloudflareProvider
     CloudflareProvider  # pragma: no cover
 except ModuleNotFoundError:

--- a/octodns/provider/constellix.py
+++ b/octodns/provider/constellix.py
@@ -9,9 +9,9 @@ from logging import getLogger
 
 logger = getLogger('Constellix')
 try:
-    logger.warn('octodns_constellix shimmed. Update your provider class to '
-                'octodns_constellix.ConstellixProvider. '
-                'Shim will be removed in 1.0')
+    logger.warning('octodns_constellix shimmed. Update your provider class to '
+                   'octodns_constellix.ConstellixProvider. '
+                   'Shim will be removed in 1.0')
     from octodns_constellix import ConstellixProvider
     ConstellixProvider  # pragma: no cover
 except ModuleNotFoundError:

--- a/octodns/provider/digitalocean.py
+++ b/octodns/provider/digitalocean.py
@@ -9,9 +9,9 @@ from logging import getLogger
 
 logger = getLogger('DigitalOcean')
 try:
-    logger.warn('octodns_digitalocean shimmed. Update your provider class to '
-                'octodns_digitalocean.DigitalOceanProvider. '
-                'Shim will be removed in 1.0')
+    logger.warning('octodns_digitalocean shimmed. Update your provider class '
+                   'to octodns_digitalocean.DigitalOceanProvider. Shim will '
+                   'be removed in 1.0')
     from octodns_digitalocean import DigitalOceanProvider
     DigitalOceanProvider  # pragma: no cover
 except ModuleNotFoundError:

--- a/octodns/provider/dnsimple.py
+++ b/octodns/provider/dnsimple.py
@@ -9,9 +9,9 @@ from logging import getLogger
 
 logger = getLogger('Dnsimple')
 try:
-    logger.warn('octodns_dnsimple shimmed. Update your provider class to '
-                'octodns_dnsimple.DnsimpleProvider. '
-                'Shim will be removed in 1.0')
+    logger.warning('octodns_dnsimple shimmed. Update your provider class to '
+                   'octodns_dnsimple.DnsimpleProvider. '
+                   'Shim will be removed in 1.0')
     from octodns_dnsimple import DnsimpleProvider
     DnsimpleProvider  # pragma: no cover
 except ModuleNotFoundError:

--- a/octodns/provider/dnsmadeeasy.py
+++ b/octodns/provider/dnsmadeeasy.py
@@ -9,9 +9,9 @@ from logging import getLogger
 
 logger = getLogger('DnsMadeEasy')
 try:
-    logger.warn('octodns_dnsmadeeasy shimmed. Update your provider class to '
-                'octodns_dnsmadeeasy.DnsMadeEasyProvider. '
-                'Shim will be removed in 1.0')
+    logger.warning('octodns_dnsmadeeasy shimmed. Update your provider class '
+                   'to octodns_dnsmadeeasy.DnsMadeEasyProvider. '
+                   'Shim will be removed in 1.0')
     from octodns_dnsmadeeasy import DnsMadeEasyProvider
     DnsMadeEasyProvider  # pragma: no cover
 except ModuleNotFoundError:

--- a/octodns/provider/dyn.py
+++ b/octodns/provider/dyn.py
@@ -9,9 +9,9 @@ from logging import getLogger
 
 logger = getLogger('Dyn')
 try:
-    logger.warn('octodns_dyn shimmed. Update your provider class to '
-                'octodns_dyn.DynProvider. '
-                'Shim will be removed in 1.0')
+    logger.warning('octodns_dyn shimmed. Update your provider class to '
+                   'octodns_dyn.DynProvider. '
+                   'Shim will be removed in 1.0')
     from octodns_dyn import DynProvider
     DynProvider  # pragma: no cover
 except ModuleNotFoundError:

--- a/octodns/provider/easydns.py
+++ b/octodns/provider/easydns.py
@@ -9,9 +9,9 @@ from logging import getLogger
 
 logger = getLogger('EasyDns')
 try:
-    logger.warn('octodns_easydns shimmed. Update your provider class to '
-                'octodns_easydns.EasyDnsProvider. '
-                'Shim will be removed in 1.0')
+    logger.warning('octodns_easydns shimmed. Update your provider class to '
+                   'octodns_easydns.EasyDnsProvider. '
+                   'Shim will be removed in 1.0')
     from octodns_easydns import EasyDnsProvider, EasyDNSProvider
     EasyDnsProvider  # pragma: no cover
     EasyDNSProvider  # pragma: no cover

--- a/octodns/provider/edgedns.py
+++ b/octodns/provider/edgedns.py
@@ -9,9 +9,9 @@ from logging import getLogger
 
 logger = getLogger('Akamai')
 try:
-    logger.warn('octodns_edgedns shimmed. Update your provider class to '
-                'octodns_edgedns.AkamaiProvider. '
-                'Shim will be removed in 1.0')
+    logger.warning('octodns_edgedns shimmed. Update your provider class to '
+                   'octodns_edgedns.AkamaiProvider. '
+                   'Shim will be removed in 1.0')
     from octodns_edgedns import AkamaiProvider
     AkamaiProvider  # pragma: no cover
 except ModuleNotFoundError:

--- a/octodns/provider/etc_hosts.py
+++ b/octodns/provider/etc_hosts.py
@@ -9,9 +9,9 @@ from logging import getLogger
 
 logger = getLogger('EtcHosts')
 try:
-    logger.warn('octodns_etchosts shimmed. Update your provider class to '
-                'octodns_etchosts.EtcHostsProvider. '
-                'Shim will be removed in 1.0')
+    logger.warning('octodns_etchosts shimmed. Update your provider class to '
+                   'octodns_etchosts.EtcHostsProvider. '
+                   'Shim will be removed in 1.0')
     from octodns_etchosts import EtcHostsProvider
     EtcHostsProvider  # pragma: no cover
 except ModuleNotFoundError:

--- a/octodns/provider/fastdns.py
+++ b/octodns/provider/fastdns.py
@@ -8,8 +8,8 @@ from __future__ import absolute_import, division, print_function, \
 from logging import getLogger
 
 logger = getLogger('Akamai')
-logger.warn('AkamaiProvider has been moved into a seperate module, '
-            'octodns_edgedns is now required. Provider class should '
-            'be updated to octodns_edgedns.AkamaiProvider. See '
-            'https://github.com/octodns/octodns/README.md#updating-'
-            'to-use-extracted-providers for more information.')
+logger.warning('AkamaiProvider has been moved into a seperate module, '
+               'octodns_edgedns is now required. Provider class should '
+               'be updated to octodns_edgedns.AkamaiProvider. See '
+               'https://github.com/octodns/octodns/README.md#updating-'
+               'to-use-extracted-providers for more information.')

--- a/octodns/provider/gandi.py
+++ b/octodns/provider/gandi.py
@@ -9,9 +9,9 @@ from logging import getLogger
 
 logger = getLogger('Gandi')
 try:
-    logger.warn('octodns_gandi shimmed. Update your provider class to '
-                'octodns_gandi.GandiProvider. '
-                'Shim will be removed in 1.0')
+    logger.warning('octodns_gandi shimmed. Update your provider class to '
+                   'octodns_gandi.GandiProvider. '
+                   'Shim will be removed in 1.0')
     from octodns_gandi import GandiProvider
     GandiProvider  # pragma: no cover
 except ModuleNotFoundError:

--- a/octodns/provider/gcore.py
+++ b/octodns/provider/gcore.py
@@ -9,9 +9,9 @@ from logging import getLogger
 
 logger = getLogger('GCore')
 try:
-    logger.warn('octodns_gcore shimmed. Update your provider class to '
-                'octodns_gcore.GCoreProvider. '
-                'Shim will be removed in 1.0')
+    logger.warning('octodns_gcore shimmed. Update your provider class to '
+                   'octodns_gcore.GCoreProvider. '
+                   'Shim will be removed in 1.0')
     from octodns_gcore import GCoreProvider
     GCoreProvider  # pragma: no cover
 except ModuleNotFoundError:

--- a/octodns/provider/googlecloud.py
+++ b/octodns/provider/googlecloud.py
@@ -9,9 +9,9 @@ from logging import getLogger
 
 logger = getLogger('GoogleCloud')
 try:
-    logger.warn('octodns_googlecloud shimmed. Update your provider class to '
-                'octodns_googlecloud.GoogleCloudProvider. '
-                'Shim will be removed in 1.0')
+    logger.warning('octodns_googlecloud shimmed. Update your provider class '
+                   'to octodns_googlecloud.GoogleCloudProvider. '
+                   'Shim will be removed in 1.0')
     from octodns_googlecloud import GoogleCloudProvider
     GoogleCloudProvider  # pragma: no cover
 except ModuleNotFoundError:

--- a/octodns/provider/hetzner.py
+++ b/octodns/provider/hetzner.py
@@ -9,9 +9,9 @@ from logging import getLogger
 
 logger = getLogger('Hetzner')
 try:
-    logger.warn('octodns_hetzner shimmed. Update your provider class to '
-                'octodns_hetzner.HetznerProvider. '
-                'Shim will be removed in 1.0')
+    logger.warning('octodns_hetzner shimmed. Update your provider class to '
+                   'octodns_hetzner.HetznerProvider. '
+                   'Shim will be removed in 1.0')
     from octodns_hetzner import HetznerProvider
     HetznerProvider  # pragma: no cover
 except ModuleNotFoundError:

--- a/octodns/provider/mythicbeasts.py
+++ b/octodns/provider/mythicbeasts.py
@@ -9,9 +9,9 @@ from logging import getLogger
 
 logger = getLogger('MythicBeasts')
 try:
-    logger.warn('octodns_mythicbeasts shimmed. Update your provider class to '
-                'octodns_mythicbeasts.MythicBeastsProvider. '
-                'Shim will be removed in 1.0')
+    logger.warning('octodns_mythicbeasts shimmed. Update your provider class '
+                   'to octodns_mythicbeasts.MythicBeastsProvider. '
+                   'Shim will be removed in 1.0')
     from octodns_mythicbeasts import MythicBeastsProvider
     MythicBeastsProvider  # pragma: no cover
 except ModuleNotFoundError:

--- a/octodns/provider/ns1.py
+++ b/octodns/provider/ns1.py
@@ -9,9 +9,9 @@ from logging import getLogger
 
 logger = getLogger('Ns1')
 try:
-    logger.warn('octodns_ns1 shimmed. Update your provider class to '
-                'octodns_ns1.Ns1Provider. '
-                'Shim will be removed in 1.0')
+    logger.warning('octodns_ns1 shimmed. Update your provider class to '
+                   'octodns_ns1.Ns1Provider. '
+                   'Shim will be removed in 1.0')
     from octodns_ns1 import Ns1Provider
     Ns1Provider  # pragma: no cover
 except ModuleNotFoundError:

--- a/octodns/provider/powerdns.py
+++ b/octodns/provider/powerdns.py
@@ -9,9 +9,9 @@ from logging import getLogger
 
 logger = getLogger('PowerDns')
 try:
-    logger.warn('octodns_powerdns shimmed. Update your provider class to '
-                'octodns_powerdns.PowerDnsProvider. '
-                'Shim will be removed in 1.0')
+    logger.warning('octodns_powerdns shimmed. Update your provider class to '
+                   'octodns_powerdns.PowerDnsProvider. '
+                   'Shim will be removed in 1.0')
     from octodns_powerdns import PowerDnsProvider, PowerDnsBaseProvider
     PowerDnsProvider  # pragma: no cover
     PowerDnsBaseProvider  # pragma: no cover

--- a/octodns/provider/route53.py
+++ b/octodns/provider/route53.py
@@ -9,9 +9,9 @@ from logging import getLogger
 
 logger = getLogger('Route53')
 try:
-    logger.warn('octodns_route53 shimmed. Update your provider class to '
-                'octodns_route53.Route53Provider. '
-                'Shim will be removed in 1.0')
+    logger.warning('octodns_route53 shimmed. Update your provider class to '
+                   'octodns_route53.Route53Provider. '
+                   'Shim will be removed in 1.0')
     from octodns_route53 import Route53Provider
     Route53Provider  # pragma: no cover
 except ModuleNotFoundError:

--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -116,7 +116,7 @@ class Record(EqualityTupleMixin):
             pass
         if reasons:
             if lenient:
-                cls.log.warn(ValidationError.build_message(fqdn, reasons))
+                cls.log.warning(ValidationError.build_message(fqdn, reasons))
             else:
                 raise ValidationError(fqdn, reasons)
         return _class(zone, name, data, source=source)
@@ -429,7 +429,7 @@ class _DynamicPool(object):
         if len(values) == 1:
             weight = data['values'][0].get('weight', 1)
             if weight != 1:
-                self.log.warn(
+                self.log.warning(
                     'Using weight=1 instead of %s for single-value pool %s',
                     weight, _id)
                 values[0]['weight'] = 1

--- a/octodns/record/geo.py
+++ b/octodns/record/geo.py
@@ -57,7 +57,7 @@ class GeoCodes(object):
         for continent, countries in geo_data.items():
             if country in countries:
                 return f'{continent}-{country}'
-        cls.log.warn('country_to_code: unrecognized country "%s"', country)
+        cls.log.warning('country_to_code: unrecognized country "%s"', country)
         return
 
     @classmethod
@@ -66,8 +66,8 @@ class GeoCodes(object):
         # NA-US, NA-CA
         if (province not in geo_data['NA']['US']['provinces'] and
                 province not in geo_data['NA']['CA']['provinces']):
-            cls.log.warn('country_to_code: unrecognized province "%s"',
-                         province)
+            cls.log.warning('country_to_code: unrecognized province "%s"',
+                            province)
             return
         if province in geo_data['NA']['US']['provinces']:
             country = 'US'

--- a/octodns/source/tinydns.py
+++ b/octodns/source/tinydns.py
@@ -217,7 +217,9 @@ class TinyDnsBaseSource(BaseSource):
                 try:
                     zone.add_record(record, lenient=lenient)
                 except DuplicateRecordException:
-                    self.log.warn(f'Duplicate PTR record for {addr}, skipping')
+                    self.log.warning(
+                        f'Duplicate PTR record for {addr}, skipping'
+                    )
 
 
 class TinyDnsFileSource(TinyDnsBaseSource):

--- a/tests/test_octodns_equality.py
+++ b/tests/test_octodns_equality.py
@@ -30,14 +30,14 @@ class TestEqualityTupleMixin(TestCase):
         doesnt = Simple(2, 3, 4)
 
         # equality
-        self.assertEquals(one, one)
-        self.assertEquals(one, same)
-        self.assertEquals(same, one)
+        self.assertEqual(one, one)
+        self.assertEqual(one, same)
+        self.assertEqual(same, one)
         # only a & c are considered
-        self.assertEquals(one, matches)
-        self.assertEquals(matches, one)
-        self.assertNotEquals(one, doesnt)
-        self.assertNotEquals(doesnt, one)
+        self.assertEqual(one, matches)
+        self.assertEqual(matches, one)
+        self.assertNotEqual(one, doesnt)
+        self.assertNotEqual(doesnt, one)
 
         # lt
         self.assertTrue(one < doesnt)

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -91,8 +91,8 @@ class TestManager(TestCase):
         with self.assertRaises(ManagerException) as ctx:
             name = 'bad-plan-output-missing-class.yaml'
             Manager(get_config_filename(name)).sync()
-        self.assertEquals('plan_output bad is missing class',
-                          str(ctx.exception))
+        self.assertEqual('plan_output bad is missing class',
+                         str(ctx.exception))
 
     def test_bad_plan_output_config(self):
         with self.assertRaises(ManagerException) as ctx:
@@ -113,45 +113,45 @@ class TestManager(TestCase):
             tc = Manager(get_config_filename('always-dry-run.yaml')) \
                 .sync(dry_run=False)
             # only the stuff from subzone, unit.tests. is always-dry-run
-            self.assertEquals(3, tc)
+            self.assertEqual(3, tc)
 
     def test_simple(self):
         with TemporaryDirectory() as tmpdir:
             environ['YAML_TMP_DIR'] = tmpdir.dirname
             tc = Manager(get_config_filename('simple.yaml')) \
                 .sync(dry_run=False)
-            self.assertEquals(26, tc)
+            self.assertEqual(26, tc)
 
             # try with just one of the zones
             tc = Manager(get_config_filename('simple.yaml')) \
                 .sync(dry_run=False, eligible_zones=['unit.tests.'])
-            self.assertEquals(20, tc)
+            self.assertEqual(20, tc)
 
             # the subzone, with 2 targets
             tc = Manager(get_config_filename('simple.yaml')) \
                 .sync(dry_run=False, eligible_zones=['subzone.unit.tests.'])
-            self.assertEquals(6, tc)
+            self.assertEqual(6, tc)
 
             # and finally the empty zone
             tc = Manager(get_config_filename('simple.yaml')) \
                 .sync(dry_run=False, eligible_zones=['empty.'])
-            self.assertEquals(0, tc)
+            self.assertEqual(0, tc)
 
             # Again with force
             tc = Manager(get_config_filename('simple.yaml')) \
                 .sync(dry_run=False, force=True)
-            self.assertEquals(26, tc)
+            self.assertEqual(26, tc)
 
             # Again with max_workers = 1
             tc = Manager(get_config_filename('simple.yaml'), max_workers=1) \
                 .sync(dry_run=False, force=True)
-            self.assertEquals(26, tc)
+            self.assertEqual(26, tc)
 
             # Include meta
             tc = Manager(get_config_filename('simple.yaml'), max_workers=1,
                          include_meta=True) \
                 .sync(dry_run=False, force=True)
-            self.assertEquals(30, tc)
+            self.assertEqual(30, tc)
 
     def test_eligible_sources(self):
         with TemporaryDirectory() as tmpdir:
@@ -159,7 +159,7 @@ class TestManager(TestCase):
             # Only allow a target that doesn't exist
             tc = Manager(get_config_filename('simple.yaml')) \
                 .sync(eligible_sources=['foo'])
-            self.assertEquals(0, tc)
+            self.assertEqual(0, tc)
 
     def test_eligible_targets(self):
         with TemporaryDirectory() as tmpdir:
@@ -167,7 +167,7 @@ class TestManager(TestCase):
             # Only allow a target that doesn't exist
             tc = Manager(get_config_filename('simple.yaml')) \
                 .sync(eligible_targets=['foo'])
-            self.assertEquals(0, tc)
+            self.assertEqual(0, tc)
 
     def test_aliases(self):
         with TemporaryDirectory() as tmpdir:
@@ -175,31 +175,31 @@ class TestManager(TestCase):
             # Alias zones with a valid target.
             tc = Manager(get_config_filename('simple-alias-zone.yaml')) \
                 .sync()
-            self.assertEquals(0, tc)
+            self.assertEqual(0, tc)
 
             # Alias zone with an invalid target.
             with self.assertRaises(ManagerException) as ctx:
                 tc = Manager(get_config_filename('unknown-source-zone.yaml')) \
                     .sync()
-            self.assertEquals('Invalid alias zone alias.tests.: source zone '
-                              'does-not-exists.tests. does not exist',
-                              str(ctx.exception))
+            self.assertEqual('Invalid alias zone alias.tests.: source zone '
+                             'does-not-exists.tests. does not exist',
+                             str(ctx.exception))
 
             # Alias zone that points to another alias zone.
             with self.assertRaises(ManagerException) as ctx:
                 tc = Manager(get_config_filename('alias-zone-loop.yaml')) \
                     .sync()
-            self.assertEquals('Invalid alias zone alias-loop.tests.: source '
-                              'zone alias.tests. is an alias zone',
-                              str(ctx.exception))
+            self.assertEqual('Invalid alias zone alias-loop.tests.: source '
+                             'zone alias.tests. is an alias zone',
+                             str(ctx.exception))
 
             # Sync an alias without the zone it refers to
             with self.assertRaises(ManagerException) as ctx:
                 tc = Manager(get_config_filename('simple-alias-zone.yaml')) \
                     .sync(eligible_zones=["alias.tests."])
-            self.assertEquals('Zone alias.tests. cannot be sync without zone '
-                              'unit.tests. sinced it is aliased',
-                              str(ctx.exception))
+            self.assertEqual('Zone alias.tests. cannot be sync without zone '
+                             'unit.tests. sinced it is aliased',
+                             str(ctx.exception))
 
     def test_compare(self):
         with TemporaryDirectory() as tmpdir:
@@ -207,27 +207,27 @@ class TestManager(TestCase):
             manager = Manager(get_config_filename('simple.yaml'))
 
             # make sure this was pulled in from the config
-            self.assertEquals(2, manager._executor._max_workers)
+            self.assertEqual(2, manager._executor._max_workers)
 
             changes = manager.compare(['in'], ['in'], 'unit.tests.')
-            self.assertEquals([], changes)
+            self.assertEqual([], changes)
 
             # Create an empty unit.test zone config
             with open(join(tmpdir.dirname, 'unit.tests.yaml'), 'w') as fh:
                 fh.write('---\n{}')
 
             changes = manager.compare(['in'], ['dump'], 'unit.tests.')
-            self.assertEquals(20, len(changes))
+            self.assertEqual(20, len(changes))
 
             # Compound sources with varying support
             changes = manager.compare(['in', 'nosshfp'],
                                       ['dump'],
                                       'unit.tests.')
-            self.assertEquals(19, len(changes))
+            self.assertEqual(19, len(changes))
 
             with self.assertRaises(ManagerException) as ctx:
                 manager.compare(['nope'], ['dump'], 'unit.tests.')
-            self.assertEquals('Unknown source: nope', str(ctx.exception))
+            self.assertEqual('Unknown source: nope', str(ctx.exception))
 
     def test_aggregate_target(self):
         simple = SimpleProvider()
@@ -268,7 +268,7 @@ class TestManager(TestCase):
             with self.assertRaises(ManagerException) as ctx:
                 manager.dump('unit.tests.', tmpdir.dirname, False, False,
                              'nope')
-            self.assertEquals('Unknown source: nope', str(ctx.exception))
+            self.assertEqual('Unknown source: nope', str(ctx.exception))
 
             manager.dump('unit.tests.', tmpdir.dirname, False, False, 'in')
 
@@ -297,7 +297,7 @@ class TestManager(TestCase):
             with self.assertRaises(ManagerException) as ctx:
                 manager.dump('unit.tests.', tmpdir.dirname, False, True,
                              'nope')
-            self.assertEquals('Unknown source: nope', str(ctx.exception))
+            self.assertEqual('Unknown source: nope', str(ctx.exception))
 
             manager.dump('unit.tests.', tmpdir.dirname, False, True, 'in')
 
@@ -376,7 +376,7 @@ class TestManager(TestCase):
             with self.assertRaises(TypeError) as ctx:
                 manager._populate_and_plan('unit.tests.', [], [OtherType()],
                                            [])
-            self.assertEquals('something else', str(ctx.exception))
+            self.assertEqual('something else', str(ctx.exception))
 
     def test_plan_processors_fallback(self):
         with TemporaryDirectory() as tmpdir:
@@ -402,7 +402,7 @@ class TestManager(TestCase):
             with self.assertRaises(TypeError) as ctx:
                 manager._populate_and_plan('unit.tests.', [], [],
                                            [OtherType()])
-            self.assertEquals('something else', str(ctx.exception))
+            self.assertEqual('something else', str(ctx.exception))
 
     @patch('octodns.manager.Manager._get_named_class')
     def test_sync_passes_file_handle(self, mock):
@@ -425,7 +425,7 @@ class TestManager(TestCase):
     def test_processor_config(self):
         # Smoke test loading a valid config
         manager = Manager(get_config_filename('processors.yaml'))
-        self.assertEquals(['noop'], list(manager.processors.keys()))
+        self.assertEqual(['noop'], list(manager.processors.keys()))
         # This zone specifies a valid processor
         manager.sync(['unit.tests.'])
 
@@ -469,7 +469,7 @@ class TestManager(TestCase):
         plans, zone = manager._populate_and_plan('unit.tests.', [mock], [],
                                                  targets)
         # Our mock was called and added the record
-        self.assertEquals(record, list(zone.records)[0])
+        self.assertEqual(record, list(zone.records)[0])
         # We got a create for the thing added to the expected state (source)
         self.assertIsInstance(plans[0][1].changes[0], Create)
 
@@ -515,10 +515,10 @@ class TestMainThreadExecutor(TestCase):
         mte = MainThreadExecutor()
 
         future = mte.submit(self.success, 42)
-        self.assertEquals(42, future.result())
+        self.assertEqual(42, future.result())
 
         future = mte.submit(self.success, ret=43)
-        self.assertEquals(43, future.result())
+        self.assertEqual(43, future.result())
 
     def test_exception(self):
         mte = MainThreadExecutor()
@@ -527,12 +527,12 @@ class TestMainThreadExecutor(TestCase):
         future = mte.submit(self.exception, e)
         with self.assertRaises(Exception) as ctx:
             future.result()
-        self.assertEquals(e, ctx.exception)
+        self.assertEqual(e, ctx.exception)
 
         future = mte.submit(self.exception, e=e)
         with self.assertRaises(Exception) as ctx:
             future.result()
-        self.assertEquals(e, ctx.exception)
+        self.assertEqual(e, ctx.exception)
 
     def success(self, ret):
         return ret

--- a/tests/test_octodns_plan.py
+++ b/tests/test_octodns_plan.py
@@ -58,7 +58,7 @@ class TestPlanLogger(TestCase):
     def test_invalid_level(self):
         with self.assertRaises(Exception) as ctx:
             PlanLogger('invalid', 'not-a-level')
-        self.assertEquals('Unsupported level: not-a-level', str(ctx.exception))
+        self.assertEqual('Unsupported level: not-a-level', str(ctx.exception))
 
     def test_create(self):
 
@@ -83,7 +83,7 @@ class TestPlanHtml(TestCase):
     def test_empty(self):
         out = StringIO()
         PlanHtml('html').run([], fh=out)
-        self.assertEquals('<b>No changes were planned</b>', out.getvalue())
+        self.assertEqual('<b>No changes were planned</b>', out.getvalue())
 
     def test_simple(self):
         out = StringIO()
@@ -99,7 +99,7 @@ class TestPlanMarkdown(TestCase):
     def test_empty(self):
         out = StringIO()
         PlanMarkdown('markdown').run([], fh=out)
-        self.assertEquals('## No changes were planned\n', out.getvalue())
+        self.assertEqual('## No changes were planned\n', out.getvalue())
 
     def test_simple(self):
         out = StringIO()

--- a/tests/test_octodns_processor_acme.py
+++ b/tests/test_octodns_processor_acme.py
@@ -64,7 +64,7 @@ class TestAcmeMangingProcessor(TestCase):
         source.add_record(records['managed'])
 
         got = acme.process_source_zone(source)
-        self.assertEquals([
+        self.assertEqual([
             '_acme-challenge.managed',
             '_acme-challenge.not-txt',
             'not-acme',
@@ -76,7 +76,7 @@ class TestAcmeMangingProcessor(TestCase):
                 break
         self.assertTrue(managed)
         # Ownership was marked with an extra value
-        self.assertEquals(['*octoDNS*', 'magic bit'], record.values)
+        self.assertEqual(['*octoDNS*', 'magic bit'], record.values)
 
         existing = Zone(zone.name, [])
         # Unrelated stuff that should be untouched
@@ -93,7 +93,7 @@ class TestAcmeMangingProcessor(TestCase):
         existing.add_record(records['going-away'])
 
         got = acme.process_target_zone(existing)
-        self.assertEquals([
+        self.assertEqual([
             '_acme-challenge.going-away',
             '_acme-challenge.managed',
             '_acme-challenge.not-txt',

--- a/tests/test_octodns_processor_filter.py
+++ b/tests/test_octodns_processor_filter.py
@@ -48,21 +48,21 @@ class TestTypeAllowListFilter(TestCase):
         filter_a = TypeAllowlistFilter('only-a', set(('A')))
 
         got = filter_a.process_source_zone(zone.copy())
-        self.assertEquals(['a', 'a2'], sorted([r.name for r in got.records]))
+        self.assertEqual(['a', 'a2'], sorted([r.name for r in got.records]))
 
         filter_aaaa = TypeAllowlistFilter('only-aaaa', ('AAAA',))
         got = filter_aaaa.process_source_zone(zone.copy())
-        self.assertEquals(['aaaa'], sorted([r.name for r in got.records]))
+        self.assertEqual(['aaaa'], sorted([r.name for r in got.records]))
 
         filter_txt = TypeAllowlistFilter('only-txt', ['TXT'])
         got = filter_txt.process_target_zone(zone.copy())
-        self.assertEquals(['txt', 'txt2'],
-                          sorted([r.name for r in got.records]))
+        self.assertEqual(['txt', 'txt2'],
+                         sorted([r.name for r in got.records]))
 
         filter_a_aaaa = TypeAllowlistFilter('only-aaaa', set(('A', 'AAAA')))
         got = filter_a_aaaa.process_target_zone(zone.copy())
-        self.assertEquals(['a', 'a2', 'aaaa'],
-                          sorted([r.name for r in got.records]))
+        self.assertEqual(['a', 'a2', 'aaaa'],
+                         sorted([r.name for r in got.records]))
 
 
 class TestTypeRejectListFilter(TestCase):
@@ -71,20 +71,20 @@ class TestTypeRejectListFilter(TestCase):
         filter_a = TypeRejectlistFilter('not-a', set(('A')))
 
         got = filter_a.process_source_zone(zone.copy())
-        self.assertEquals(['aaaa', 'txt', 'txt2'],
-                          sorted([r.name for r in got.records]))
+        self.assertEqual(['aaaa', 'txt', 'txt2'],
+                         sorted([r.name for r in got.records]))
 
         filter_aaaa = TypeRejectlistFilter('not-aaaa', ('AAAA',))
         got = filter_aaaa.process_source_zone(zone.copy())
-        self.assertEquals(['a', 'a2', 'txt', 'txt2'],
-                          sorted([r.name for r in got.records]))
+        self.assertEqual(['a', 'a2', 'txt', 'txt2'],
+                         sorted([r.name for r in got.records]))
 
         filter_txt = TypeRejectlistFilter('not-txt', ['TXT'])
         got = filter_txt.process_target_zone(zone.copy())
-        self.assertEquals(['a', 'a2', 'aaaa'],
-                          sorted([r.name for r in got.records]))
+        self.assertEqual(['a', 'a2', 'aaaa'],
+                         sorted([r.name for r in got.records]))
 
         filter_a_aaaa = TypeRejectlistFilter('not-a-aaaa', set(('A', 'AAAA')))
         got = filter_a_aaaa.process_target_zone(zone.copy())
-        self.assertEquals(['txt', 'txt2'],
-                          sorted([r.name for r in got.records]))
+        self.assertEqual(['txt', 'txt2'],
+                         sorted([r.name for r in got.records]))

--- a/tests/test_octodns_processor_ownership.py
+++ b/tests/test_octodns_processor_ownership.py
@@ -56,7 +56,7 @@ class TestOwnershipProcessor(TestCase):
         ownership = OwnershipProcessor('ownership')
 
         got = ownership.process_source_zone(zone.copy())
-        self.assertEquals([
+        self.assertEqual([
             '',
             '*',
             '_owner.a',
@@ -72,7 +72,7 @@ class TestOwnershipProcessor(TestCase):
         found = False
         for record in got.records:
             if record.name.startswith(ownership.txt_name):
-                self.assertEquals([ownership.txt_value], record.values)
+                self.assertEqual([ownership.txt_value], record.values)
                 # test _is_ownership while we're in here
                 self.assertTrue(ownership._is_ownership(record))
                 found = True
@@ -92,12 +92,12 @@ class TestOwnershipProcessor(TestCase):
         plan = provider.plan(ownership_added)
         self.assertTrue(plan)
         # Double the number of records
-        self.assertEquals(len(records) * 2, len(plan.changes))
+        self.assertEqual(len(records) * 2, len(plan.changes))
         # Now process the plan, shouldn't make any changes, we're creating
         # everything
         got = ownership.process_plan(plan)
         self.assertTrue(got)
-        self.assertEquals(len(records) * 2, len(got.changes))
+        self.assertEqual(len(records) * 2, len(got.changes))
 
         # Something extra exists and doesn't have ownership TXT, leave it
         # alone, we don't own it.
@@ -113,7 +113,7 @@ class TestOwnershipProcessor(TestCase):
         # something we don't own
         got = ownership.process_plan(plan)
         self.assertTrue(got)
-        self.assertEquals(len(records) * 2, len(got.changes))
+        self.assertEqual(len(records) * 2, len(got.changes))
 
         # Something extra exists and does have an ownership record so we will
         # delete it...
@@ -123,7 +123,7 @@ class TestOwnershipProcessor(TestCase):
                 copy.add_record(record)
         # New ownership, without the `the-a`
         ownership_added = ownership.process_source_zone(copy)
-        self.assertEquals(len(records) * 2 - 2, len(ownership_added.records))
+        self.assertEqual(len(records) * 2 - 2, len(ownership_added.records))
         plan = provider.plan(ownership_added)
         # Fake the extra existing by adding the record, its ownership, and the
         # two delete changes.
@@ -142,5 +142,5 @@ class TestOwnershipProcessor(TestCase):
         # plan out, meaning the planned deletes were allowed to happen.
         got = ownership.process_plan(plan)
         self.assertTrue(got)
-        self.assertEquals(plan, got)
-        self.assertEquals(len(plan.changes), len(got.changes))
+        self.assertEqual(plan, got)
+        self.assertEqual(len(plan.changes), len(got.changes))

--- a/tests/test_octodns_provider_base.py
+++ b/tests/test_octodns_provider_base.py
@@ -77,16 +77,16 @@ class TestBaseProvider(TestCase):
     def test_base_provider(self):
         with self.assertRaises(NotImplementedError) as ctx:
             BaseProvider('base')
-        self.assertEquals('Abstract base class, log property missing',
-                          str(ctx.exception))
+        self.assertEqual('Abstract base class, log property missing',
+                         str(ctx.exception))
 
         class HasLog(BaseProvider):
             log = getLogger('HasLog')
 
         with self.assertRaises(NotImplementedError) as ctx:
             HasLog('haslog')
-        self.assertEquals('Abstract base class, SUPPORTS_GEO property missing',
-                          str(ctx.exception))
+        self.assertEqual('Abstract base class, SUPPORTS_GEO property missing',
+                         str(ctx.exception))
 
         class HasSupportsGeo(HasLog):
             SUPPORTS_GEO = False
@@ -94,15 +94,15 @@ class TestBaseProvider(TestCase):
         zone = Zone('unit.tests.', ['sub'])
         with self.assertRaises(NotImplementedError) as ctx:
             HasSupportsGeo('hassupportsgeo').populate(zone)
-        self.assertEquals('Abstract base class, SUPPORTS property missing',
-                          str(ctx.exception))
+        self.assertEqual('Abstract base class, SUPPORTS property missing',
+                         str(ctx.exception))
 
         class HasSupports(HasSupportsGeo):
             SUPPORTS = set(('A',))
         with self.assertRaises(NotImplementedError) as ctx:
             HasSupports('hassupports').populate(zone)
-        self.assertEquals('Abstract base class, populate method missing',
-                          str(ctx.exception))
+        self.assertEqual('Abstract base class, populate method missing',
+                         str(ctx.exception))
 
         # SUPPORTS_DYNAMIC has a default/fallback
         self.assertFalse(HasSupports('hassupports').SUPPORTS_DYNAMIC)
@@ -143,19 +143,19 @@ class TestBaseProvider(TestCase):
                         .supports(list(zone.records)[0]))
 
         plan = HasPopulate('haspopulate').plan(zone)
-        self.assertEquals(3, len(plan.changes))
+        self.assertEqual(3, len(plan.changes))
 
         with self.assertRaises(NotImplementedError) as ctx:
             HasPopulate('haspopulate').apply(plan)
-        self.assertEquals('Abstract base class, _apply method missing',
-                          str(ctx.exception))
+        self.assertEqual('Abstract base class, _apply method missing',
+                         str(ctx.exception))
 
     def test_plan(self):
         ignored = Zone('unit.tests.', [])
 
         # No change, thus no plan
         provider = HelperProvider([])
-        self.assertEquals(None, provider.plan(ignored))
+        self.assertEqual(None, provider.plan(ignored))
 
         record = Record.new(ignored, 'a', {
             'ttl': 30,
@@ -165,7 +165,7 @@ class TestBaseProvider(TestCase):
         provider = HelperProvider([Create(record)])
         plan = provider.plan(ignored)
         self.assertTrue(plan)
-        self.assertEquals(1, len(plan.changes))
+        self.assertEqual(1, len(plan.changes))
 
     def test_plan_with_processors(self):
         zone = Zone('unit.tests.', [])
@@ -181,11 +181,11 @@ class TestBaseProvider(TestCase):
         tricky = TrickyProcessor('tricky', [record])
         plan = provider.plan(zone, processors=[tricky])
         self.assertTrue(plan)
-        self.assertEquals(1, len(plan.changes))
+        self.assertEqual(1, len(plan.changes))
         self.assertIsInstance(plan.changes[0], Delete)
         # Called processor stored its params
         self.assertTrue(tricky.existing)
-        self.assertEquals(zone.name, tricky.existing.name)
+        self.assertEqual(zone.name, tricky.existing.name)
 
         # Chain of processors happen one after the other
         other = Record.new(zone, 'b', {
@@ -197,14 +197,14 @@ class TestBaseProvider(TestCase):
         another = TrickyProcessor('tricky', [other])
         plan = provider.plan(zone, processors=[tricky, another])
         self.assertTrue(plan)
-        self.assertEquals(2, len(plan.changes))
+        self.assertEqual(2, len(plan.changes))
         self.assertIsInstance(plan.changes[0], Delete)
         self.assertIsInstance(plan.changes[1], Delete)
         # 2nd processor stored its params, and we'll see the record the
         # first one added
         self.assertTrue(another.existing)
-        self.assertEquals(zone.name, another.existing.name)
-        self.assertEquals(1, len(another.existing.records))
+        self.assertEqual(zone.name, another.existing.name)
+        self.assertEqual(1, len(another.existing.records))
 
     def test_apply(self):
         ignored = Zone('unit.tests.', [])
@@ -219,7 +219,7 @@ class TestBaseProvider(TestCase):
         provider.apply(plan)
 
         provider.apply_disabled = False
-        self.assertEquals(1, provider.apply(plan))
+        self.assertEqual(1, provider.apply(plan))
 
     def test_include_change(self):
         zone = Zone('unit.tests.', [])
@@ -527,5 +527,5 @@ class TestBaseProvider(TestCase):
         # Should log and not expect
         with self.assertRaises(SupportsException) as ctx:
             strict.supports_warn_or_except('Hello World!', 'Will not see')
-        self.assertEquals('minimal: Hello World!', str(ctx.exception))
+        self.assertEqual('minimal: Hello World!', str(ctx.exception))
         strict.log.warning.assert_not_called()

--- a/tests/test_octodns_provider_ovh.py
+++ b/tests/test_octodns_provider_ovh.py
@@ -328,18 +328,18 @@ class TestOvhProvider(TestCase):
             get_mock.side_effect = ResourceNotFoundError('boom')
             with self.assertRaises(APIError) as ctx:
                 provider.populate(zone)
-            self.assertEquals(get_mock.side_effect, ctx.exception)
+            self.assertEqual(get_mock.side_effect, ctx.exception)
 
             get_mock.side_effect = InvalidCredential('boom')
             with self.assertRaises(APIError) as ctx:
                 provider.populate(zone)
-            self.assertEquals(get_mock.side_effect, ctx.exception)
+            self.assertEqual(get_mock.side_effect, ctx.exception)
 
             zone = Zone('unit.tests.', [])
             get_mock.side_effect = ResourceNotFoundError('This service does '
                                                          'not exist')
             exists = provider.populate(zone)
-            self.assertEquals(set(), zone.records)
+            self.assertEqual(set(), zone.records)
             self.assertFalse(exists)
 
             zone = Zone('unit.tests.', [])
@@ -347,7 +347,7 @@ class TestOvhProvider(TestCase):
             get_returns += self.api_record
             get_mock.side_effect = get_returns
             exists = provider.populate(zone)
-            self.assertEquals(self.expected, zone.records)
+            self.assertEqual(self.expected, zone.records)
             self.assertTrue(exists)
 
     @patch('ovh.Client')
@@ -375,7 +375,7 @@ class TestOvhProvider(TestCase):
             get_mock.side_effect = APIError('boom')
             with self.assertRaises(APIError) as ctx:
                 provider.apply(plan)
-            self.assertEquals(get_mock.side_effect, ctx.exception)
+            self.assertEqual(get_mock.side_effect, ctx.exception)
 
         # Records get by API call
         with patch.object(provider._client, 'get') as get_mock:

--- a/tests/test_octodns_provider_rackspace.py
+++ b/tests/test_octodns_provider_rackspace.py
@@ -62,7 +62,7 @@ class TestRackspaceProvider(TestCase):
             with self.assertRaises(HTTPError) as ctx:
                 zone = Zone('unit.tests.', [])
                 self.provider.populate(zone)
-            self.assertEquals(502, ctx.exception.response.status_code)
+            self.assertEqual(502, ctx.exception.response.status_code)
             self.assertTrue(mock.called_once)
 
     def test_nonexistent_zone(self):
@@ -73,7 +73,7 @@ class TestRackspaceProvider(TestCase):
 
             zone = Zone('unit.tests.', [])
             exists = self.provider.populate(zone)
-            self.assertEquals(set(), zone.records)
+            self.assertEqual(set(), zone.records)
             self.assertTrue(mock.called_once)
             self.assertFalse(exists)
 
@@ -88,7 +88,7 @@ class TestRackspaceProvider(TestCase):
 
             zone = Zone('unit.tests.', [])
             self.provider.populate(zone)
-            self.assertEquals(5, len(zone.records))
+            self.assertEqual(5, len(zone.records))
 
     def test_plan_disappearing_ns_records(self):
         expected = Zone('unit.tests.', [])
@@ -112,7 +112,7 @@ class TestRackspaceProvider(TestCase):
             self.assertTrue(plan.exists)
 
             # OctoDNS does not propagate top-level NS records.
-            self.assertEquals(1, len(plan.changes))
+            self.assertEqual(1, len(plan.changes))
 
     def test_fqdn_a_record(self):
         expected = Zone('example.com.', [])

--- a/tests/test_octodns_provider_selectel.py
+++ b/tests/test_octodns_provider_selectel.py
@@ -206,7 +206,7 @@ class TestSelectelProvider(TestCase):
         provider = SelectelProvider(123, 'secret_token')
         provider.populate(zone)
 
-        self.assertEquals(self.expected, zone.records)
+        self.assertEqual(self.expected, zone.records)
 
     @requests_mock.Mocker()
     def test_populate_invalid_record(self, fake_http):
@@ -264,8 +264,8 @@ class TestSelectelProvider(TestCase):
             zone.add_record(record)
 
         plan = provider.plan(zone)
-        self.assertEquals(8, len(plan.changes))
-        self.assertEquals(8, provider.apply(plan))
+        self.assertEqual(8, len(plan.changes))
+        self.assertEqual(8, provider.apply(plan))
 
     @requests_mock.Mocker()
     def test_domain_list(self, fake_http):
@@ -277,7 +277,7 @@ class TestSelectelProvider(TestCase):
         provider = SelectelProvider(123, 'test_token')
 
         result = provider.domain_list()
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     @requests_mock.Mocker()
     def test_authentication_fail(self, fake_http):
@@ -287,8 +287,8 @@ class TestSelectelProvider(TestCase):
 
         with self.assertRaises(Exception) as ctx:
             SelectelProvider(123, 'fail_token')
-        self.assertEquals(str(ctx.exception),
-                          'Authorization failed. Invalid or empty token.')
+        self.assertEqual(str(ctx.exception),
+                         'Authorization failed. Invalid or empty token.')
 
     @requests_mock.Mocker()
     def test_not_exist_domain(self, fake_http):
@@ -312,8 +312,8 @@ class TestSelectelProvider(TestCase):
             zone.add_record(record)
 
         plan = provider.plan(zone)
-        self.assertEquals(8, len(plan.changes))
-        self.assertEquals(8, provider.apply(plan))
+        self.assertEqual(8, len(plan.changes))
+        self.assertEqual(8, provider.apply(plan))
 
     @requests_mock.Mocker()
     def test_delete_no_exist_record(self, fake_http):
@@ -365,8 +365,8 @@ class TestSelectelProvider(TestCase):
             zone.add_record(record)
 
         plan = provider.plan(zone)
-        self.assertEquals(8, len(plan.changes))
-        self.assertEquals(8, provider.apply(plan))
+        self.assertEqual(8, len(plan.changes))
+        self.assertEqual(8, provider.apply(plan))
 
     @requests_mock.Mocker()
     def test_include_change_returns_false(self, fake_http):

--- a/tests/test_octodns_provider_transip.py
+++ b/tests/test_octodns_provider_transip.py
@@ -66,7 +66,7 @@ class TestTransipProvider(TestCase):
         with self.assertRaises(TransipConfigException) as ctx:
             TransipProvider("test", "unittest")
 
-        self.assertEquals(
+        self.assertEqual(
             "Missing `key` or `key_file` parameter in config",
             str(ctx.exception),
         )
@@ -365,7 +365,7 @@ class TestTransipProvider(TestCase):
             {"name": "@", "expire": 300, "type": "A", "content": "1.2.3.5"},
             {"name": "www", "expire": 300, "type": "A", "content": "2.2.3.6"},
         ]
-        self.assertEquals(
+        self.assertEqual(
             sorted(seen_entries, key=itemgetter("name", "type", "expire")),
             sorted(expected_entries, key=itemgetter("name", "type", "expire")),
         )
@@ -408,12 +408,12 @@ class TestTransipProvider(TestCase):
 class TestParseFQDN(TestCase):
     def test_parse_fqdn(self):
         zone = Zone("unit.tests.", [])
-        self.assertEquals("www.unit.tests.", _parse_to_fqdn("www", zone))
-        self.assertEquals(
+        self.assertEqual("www.unit.tests.", _parse_to_fqdn("www", zone))
+        self.assertEqual(
             "www.unit.tests.", _parse_to_fqdn("www.unit.tests.", zone)
         )
-        self.assertEquals(
+        self.assertEqual(
             "www.sub.sub.sub.unit.tests.",
             _parse_to_fqdn("www.sub.sub.sub", zone),
         )
-        self.assertEquals("unit.tests.", _parse_to_fqdn("@", zone))
+        self.assertEqual("unit.tests.", _parse_to_fqdn("@", zone))

--- a/tests/test_octodns_provider_ultra.py
+++ b/tests/test_octodns_provider_ultra.py
@@ -44,7 +44,7 @@ class TestUltraProvider(TestCase):
                       text='{"errorCode": 60001}')
             with self.assertRaises(Exception) as ctx:
                 UltraProvider('test', 'account', 'user', 'wrongpass')
-            self.assertEquals('Unauthorized', str(ctx.exception))
+            self.assertEqual('Unauthorized', str(ctx.exception))
 
         # Good Auth
         with requests_mock() as mock:
@@ -54,11 +54,11 @@ class TestUltraProvider(TestCase):
                       text='{"token type": "Bearer", "refresh_token": "abc", '
                       '"access_token":"123", "expires_in": "3600"}')
             UltraProvider('test', 'account', 'user', 'rightpass')
-            self.assertEquals(1, mock.call_count)
+            self.assertEqual(1, mock.call_count)
             expected_payload = "grant_type=password&username=user&"\
                                "password=rightpass"
-            self.assertEquals(parse_qs(mock.last_request.text),
-                              parse_qs(expected_payload))
+            self.assertEqual(parse_qs(mock.last_request.text),
+                             parse_qs(expected_payload))
 
     def test_get_zones(self):
         provider = _get_provider()
@@ -71,7 +71,7 @@ class TestUltraProvider(TestCase):
                            "errorMessage": "Authorization Header required"})
             with self.assertRaises(HTTPError) as ctx:
                 zones = provider.zones
-            self.assertEquals(400, ctx.exception.response.status_code)
+            self.assertEqual(400, ctx.exception.response.status_code)
 
         # Test no zones exist error
         with requests_mock() as mock:
@@ -79,8 +79,8 @@ class TestUltraProvider(TestCase):
                      headers={'Authorization': 'Bearer 123'},
                      json=self.empty_body)
             zones = provider.zones
-            self.assertEquals(1, mock.call_count)
-            self.assertEquals(list(), zones)
+            self.assertEqual(1, mock.call_count)
+            self.assertEqual(list(), zones)
 
         # Reset zone cache so they are queried again
         provider._zones = None
@@ -112,9 +112,9 @@ class TestUltraProvider(TestCase):
                      headers={'Authorization': 'Bearer 123'},
                      json=payload)
             zones = provider.zones
-            self.assertEquals(1, mock.call_count)
-            self.assertEquals(1, len(zones))
-            self.assertEquals('testzone123.com.', zones[0])
+            self.assertEqual(1, mock.call_count)
+            self.assertEqual(1, len(zones))
+            self.assertEqual('testzone123.com.', zones[0])
 
         # Test different paging behavior
         provider._zones = None
@@ -132,7 +132,7 @@ class TestUltraProvider(TestCase):
                                           "returnedCount": 5},
                            "zones": []})
             zones = provider.zones
-            self.assertEquals(2, mock.call_count)
+            self.assertEqual(2, mock.call_count)
 
     def test_request(self):
         provider = _get_provider()
@@ -144,7 +144,7 @@ class TestUltraProvider(TestCase):
                      headers={'Authorization': 'Bearer 123'}, json={})
             with self.assertRaises(Exception) as ctx:
                 provider._get(path)
-            self.assertEquals('Unauthorized', str(ctx.exception))
+            self.assertEqual('Unauthorized', str(ctx.exception))
 
         # Test all GET patterns
         with requests_mock() as mock:
@@ -227,11 +227,11 @@ class TestUltraProvider(TestCase):
 
             zone = Zone('octodns1.test.', [])
             self.assertTrue(provider.zone_records(zone))
-            self.assertEquals(mock.call_count, 2)
+            self.assertEqual(mock.call_count, 2)
 
             # Populate the same zone again and confirm cache is hit
             self.assertTrue(provider.zone_records(zone))
-            self.assertEquals(mock.call_count, 2)
+            self.assertEqual(mock.call_count, 2)
 
     def test_populate(self):
         provider = _get_provider()
@@ -242,13 +242,13 @@ class TestUltraProvider(TestCase):
 
             zone = Zone('unit.tests.', [])
             provider.populate(zone)
-            self.assertEquals(set(), zone.records)
+            self.assertEqual(set(), zone.records)
 
         # re-populating the same non-existent zone uses cache and makes no
         # calls
         again = Zone('unit.tests.', [])
         provider.populate(again)
-        self.assertEquals(set(), again.records)
+        self.assertEqual(set(), again.records)
 
         # Test zones with data
         provider._zones = None
@@ -272,9 +272,9 @@ class TestUltraProvider(TestCase):
             zone = Zone('octodns1.test.', [])
 
             self.assertTrue(provider.populate(zone))
-            self.assertEquals('octodns1.test.', zone.name)
-            self.assertEquals(12, len(zone.records))
-            self.assertEquals(4, mock.call_count)
+            self.assertEqual('octodns1.test.', zone.name)
+            self.assertEqual(12, len(zone.records))
+            self.assertEqual(4, mock.call_count)
 
     def test_apply(self):
         provider = _get_provider()
@@ -288,8 +288,8 @@ class TestUltraProvider(TestCase):
 
         # non-existent zone, create everything
         plan = provider.plan(self.expected)
-        self.assertEquals(15, len(plan.changes))
-        self.assertEquals(15, provider.apply(plan))
+        self.assertEqual(15, len(plan.changes))
+        self.assertEqual(15, provider.apply(plan))
         self.assertFalse(plan.exists)
 
         provider._request.assert_has_calls([
@@ -319,7 +319,7 @@ class TestUltraProvider(TestCase):
                                  'p=A/kinda+of/long/string+with+numb3rs']}),
         ], True)
         # expected number of total calls
-        self.assertEquals(17, provider._request.call_count)
+        self.assertEqual(17, provider._request.call_count)
 
         # Create sample rrset payload to attempt to alter
         page1 = json_load(open('tests/fixtures/ultra-records-page-1.json'))
@@ -351,8 +351,8 @@ class TestUltraProvider(TestCase):
         }))
 
         plan = provider.plan(wanted)
-        self.assertEquals(11, len(plan.changes))
-        self.assertEquals(11, provider.apply(plan))
+        self.assertEqual(11, len(plan.changes))
+        self.assertEqual(11, provider.apply(plan))
         self.assertTrue(plan.exists)
 
         provider._request.assert_has_calls([

--- a/tests/test_octodns_provider_yaml.py
+++ b/tests/test_octodns_provider_yaml.py
@@ -30,14 +30,14 @@ class TestYamlProvider(TestCase):
 
         # With target we don't add anything
         source.populate(zone, target=source)
-        self.assertEquals(0, len(zone.records))
+        self.assertEqual(0, len(zone.records))
 
         # without it we see everything
         source.populate(zone)
-        self.assertEquals(23, len(zone.records))
+        self.assertEqual(23, len(zone.records))
 
         source.populate(dynamic_zone)
-        self.assertEquals(6, len(dynamic_zone.records))
+        self.assertEqual(6, len(dynamic_zone.records))
 
         # Assumption here is that a clean round-trip means that everything
         # worked as expected, data that went in came back out and could be
@@ -57,21 +57,21 @@ class TestYamlProvider(TestCase):
 
             # We add everything
             plan = target.plan(zone)
-            self.assertEquals(20, len([c for c in plan.changes
-                                       if isinstance(c, Create)]))
+            self.assertEqual(20, len([c for c in plan.changes
+                                      if isinstance(c, Create)]))
             self.assertFalse(isfile(yaml_file))
 
             # Now actually do it
-            self.assertEquals(20, target.apply(plan))
+            self.assertEqual(20, target.apply(plan))
             self.assertTrue(isfile(yaml_file))
 
             # Dynamic plan
             plan = target.plan(dynamic_zone)
-            self.assertEquals(6, len([c for c in plan.changes
-                                      if isinstance(c, Create)]))
+            self.assertEqual(6, len([c for c in plan.changes
+                                     if isinstance(c, Create)]))
             self.assertFalse(isfile(dynamic_yaml_file))
             # Apply it
-            self.assertEquals(6, target.apply(plan))
+            self.assertEqual(6, target.apply(plan))
             self.assertTrue(isfile(dynamic_yaml_file))
 
             # There should be no changes after the round trip
@@ -86,8 +86,8 @@ class TestYamlProvider(TestCase):
 
             # A 2nd sync should still create everything
             plan = target.plan(zone)
-            self.assertEquals(20, len([c for c in plan.changes
-                                       if isinstance(c, Create)]))
+            self.assertEqual(20, len([c for c in plan.changes
+                                      if isinstance(c, Create)]))
 
             with open(yaml_file) as fh:
                 data = safe_load(fh.read())
@@ -120,7 +120,7 @@ class TestYamlProvider(TestCase):
                 self.assertTrue('value' in data.pop('www.sub'))
 
                 # make sure nothing is left
-                self.assertEquals([], list(data.keys()))
+                self.assertEqual([], list(data.keys()))
 
             with open(dynamic_yaml_file) as fh:
                 data = safe_load(fh.read())
@@ -153,7 +153,7 @@ class TestYamlProvider(TestCase):
                 # self.assertTrue('dynamic' in dyna)
 
                 # make sure nothing is left
-                self.assertEquals([], list(data.keys()))
+                self.assertEqual([], list(data.keys()))
 
     def test_empty(self):
         source = YamlProvider('test', join(dirname(__file__), 'config'))
@@ -162,7 +162,7 @@ class TestYamlProvider(TestCase):
 
         # without it we see everything
         source.populate(zone)
-        self.assertEquals(0, len(zone.records))
+        self.assertEqual(0, len(zone.records))
 
     def test_unsorted(self):
         source = YamlProvider('test', join(dirname(__file__), 'config'))
@@ -185,8 +185,8 @@ class TestYamlProvider(TestCase):
         zone = Zone('unit.tests.', ['sub'])
         with self.assertRaises(SubzoneRecordException) as ctx:
             source.populate(zone)
-        self.assertEquals('Record www.sub.unit.tests. is under a managed '
-                          'subzone', str(ctx.exception))
+        self.assertEqual('Record www.sub.unit.tests. is under a managed '
+                         'subzone', str(ctx.exception))
 
 
 class TestSplitYamlProvider(TestCase):
@@ -244,14 +244,14 @@ class TestSplitYamlProvider(TestCase):
 
         # With target we don't add anything
         source.populate(zone, target=source)
-        self.assertEquals(0, len(zone.records))
+        self.assertEqual(0, len(zone.records))
 
         # without it we see everything
         source.populate(zone)
-        self.assertEquals(20, len(zone.records))
+        self.assertEqual(20, len(zone.records))
 
         source.populate(dynamic_zone)
-        self.assertEquals(5, len(dynamic_zone.records))
+        self.assertEqual(5, len(dynamic_zone.records))
 
         with TemporaryDirectory() as td:
             # Add some subdirs to make sure that it can create them
@@ -263,20 +263,20 @@ class TestSplitYamlProvider(TestCase):
 
             # We add everything
             plan = target.plan(zone)
-            self.assertEquals(17, len([c for c in plan.changes
-                                       if isinstance(c, Create)]))
+            self.assertEqual(17, len([c for c in plan.changes
+                                      if isinstance(c, Create)]))
             self.assertFalse(isdir(zone_dir))
 
             # Now actually do it
-            self.assertEquals(17, target.apply(plan))
+            self.assertEqual(17, target.apply(plan))
 
             # Dynamic plan
             plan = target.plan(dynamic_zone)
-            self.assertEquals(5, len([c for c in plan.changes
-                                      if isinstance(c, Create)]))
+            self.assertEqual(5, len([c for c in plan.changes
+                                     if isinstance(c, Create)]))
             self.assertFalse(isdir(dynamic_zone_dir))
             # Apply it
-            self.assertEquals(5, target.apply(plan))
+            self.assertEqual(5, target.apply(plan))
             self.assertTrue(isdir(dynamic_zone_dir))
 
             # There should be no changes after the round trip
@@ -291,8 +291,8 @@ class TestSplitYamlProvider(TestCase):
 
             # A 2nd sync should still create everything
             plan = target.plan(zone)
-            self.assertEquals(17, len([c for c in plan.changes
-                                       if isinstance(c, Create)]))
+            self.assertEqual(17, len([c for c in plan.changes
+                                      if isinstance(c, Create)]))
 
             yaml_file = join(zone_dir, '$unit.tests.yaml')
             self.assertTrue(isfile(yaml_file))
@@ -353,7 +353,7 @@ class TestSplitYamlProvider(TestCase):
 
         # without it we see everything
         source.populate(zone)
-        self.assertEquals(0, len(zone.records))
+        self.assertEqual(0, len(zone.records))
 
     def test_unsorted(self):
         source = SplitYamlProvider(
@@ -383,8 +383,8 @@ class TestSplitYamlProvider(TestCase):
         zone = Zone('unit.tests.', ['sub'])
         with self.assertRaises(SubzoneRecordException) as ctx:
             source.populate(zone)
-        self.assertEquals('Record www.sub.unit.tests. is under a managed '
-                          'subzone', str(ctx.exception))
+        self.assertEqual('Record www.sub.unit.tests. is under a managed '
+                         'subzone', str(ctx.exception))
 
 
 class TestOverridingYamlProvider(TestCase):
@@ -401,7 +401,7 @@ class TestOverridingYamlProvider(TestCase):
         # Load the base, should see the 5 records
         base.populate(zone)
         got = {r.name: r for r in zone.records}
-        self.assertEquals(6, len(got))
+        self.assertEqual(6, len(got))
         # We get the "dynamic" A from the base config
         self.assertTrue('dynamic' in got['a'].data)
         # No added
@@ -410,9 +410,9 @@ class TestOverridingYamlProvider(TestCase):
         # Load the overrides, should replace one and add 1
         override.populate(zone)
         got = {r.name: r for r in zone.records}
-        self.assertEquals(7, len(got))
+        self.assertEqual(7, len(got))
         # 'a' was replaced with a generic record
-        self.assertEquals({
+        self.assertEqual({
             'ttl': 3600,
             'values': ['4.4.4.4', '5.5.5.5']
         }, got['a'].data)

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -27,7 +27,7 @@ class TestRecord(TestCase):
             'type': 'A',
             'value': '1.2.3.4',
         })
-        self.assertEquals('mixedcase', record.name)
+        self.assertEqual('mixedcase', record.name)
 
     def test_alias_lowering_value(self):
         upper_record = AliasRecord(self.zone, 'aliasUppwerValue', {
@@ -40,7 +40,7 @@ class TestRecord(TestCase):
             'type': 'ALIAS',
             'value': 'github.com',
         })
-        self.assertEquals(upper_record.value, lower_record.value)
+        self.assertEqual(upper_record.value, lower_record.value)
 
     def test_cname_lowering_value(self):
         upper_record = CnameRecord(self.zone, 'CnameUppwerValue', {
@@ -53,7 +53,7 @@ class TestRecord(TestCase):
             'type': 'CNAME',
             'value': 'github.com',
         })
-        self.assertEquals(upper_record.value, lower_record.value)
+        self.assertEqual(upper_record.value, lower_record.value)
 
     def test_dname_lowering_value(self):
         upper_record = DnameRecord(self.zone, 'DnameUppwerValue', {
@@ -66,7 +66,7 @@ class TestRecord(TestCase):
             'type': 'DNAME',
             'value': 'github.com',
         })
-        self.assertEquals(upper_record.value, lower_record.value)
+        self.assertEqual(upper_record.value, lower_record.value)
 
     def test_ptr_lowering_value(self):
         upper_record = PtrRecord(self.zone, 'PtrUppwerValue', {
@@ -79,28 +79,28 @@ class TestRecord(TestCase):
             'type': 'PTR',
             'value': 'github.com',
         })
-        self.assertEquals(upper_record.value, lower_record.value)
+        self.assertEqual(upper_record.value, lower_record.value)
 
     def test_a_and_record(self):
         a_values = ['1.2.3.4', '2.2.3.4']
         a_data = {'ttl': 30, 'values': a_values}
         a = ARecord(self.zone, 'a', a_data)
-        self.assertEquals('a', a.name)
-        self.assertEquals('a.unit.tests.', a.fqdn)
-        self.assertEquals(30, a.ttl)
-        self.assertEquals(a_values, a.values)
-        self.assertEquals(a_data, a.data)
+        self.assertEqual('a', a.name)
+        self.assertEqual('a.unit.tests.', a.fqdn)
+        self.assertEqual(30, a.ttl)
+        self.assertEqual(a_values, a.values)
+        self.assertEqual(a_data, a.data)
 
         b_value = '3.2.3.4'
         b_data = {'ttl': 30, 'value': b_value}
         b = ARecord(self.zone, 'b', b_data)
-        self.assertEquals([b_value], b.values)
-        self.assertEquals(b_data, b.data)
+        self.assertEqual([b_value], b.values)
+        self.assertEqual(b_data, b.data)
 
         # top-level
         data = {'ttl': 30, 'value': '4.2.3.4'}
-        self.assertEquals(self.zone.name, ARecord(self.zone, '', data).fqdn)
-        self.assertEquals(self.zone.name, ARecord(self.zone, None, data).fqdn)
+        self.assertEqual(self.zone.name, ARecord(self.zone, '', data).fqdn)
+        self.assertEqual(self.zone.name, ARecord(self.zone, None, data).fqdn)
 
         # ARecord equate with itself
         self.assertTrue(a == a)
@@ -122,14 +122,14 @@ class TestRecord(TestCase):
         # changes if ttl modified
         other.ttl = 31
         update = a.changes(other, target)
-        self.assertEquals(a, update.existing)
-        self.assertEquals(other, update.new)
+        self.assertEqual(a, update.existing)
+        self.assertEqual(other, update.new)
         # changes if values modified
         other.ttl = a.ttl
         other.values = ['4.4.4.4']
         update = a.changes(other, target)
-        self.assertEquals(a, update.existing)
-        self.assertEquals(other, update.new)
+        self.assertEqual(a, update.existing)
+        self.assertEqual(other, update.new)
 
         # Hashing
         records = set()
@@ -208,7 +208,7 @@ class TestRecord(TestCase):
                             'NA-US': ['4.4.4.4', '5.5.5.5'],
                             'NA-US-CA': ['6.6.6.6', '7.7.7.7']}}
         geo = ARecord(self.zone, 'geo', geo_data)
-        self.assertEquals(geo_data, geo.data)
+        self.assertEqual(geo_data, geo.data)
 
         other_data = {'ttl': 42, 'values': ['5.2.3.4', '6.2.3.4'],
                       'geo': {'AF': ['1.1.1.1'],
@@ -216,7 +216,7 @@ class TestRecord(TestCase):
                               'NA-US': ['4.4.4.4', '5.5.5.5'],
                               'NA-US-CA': ['6.6.6.6', '7.7.7.7']}}
         other = ARecord(self.zone, 'geo', other_data)
-        self.assertEquals(other_data, other.data)
+        self.assertEqual(other_data, other.data)
 
         simple_target = SimpleProvider()
         geo_target = GeoProvider()
@@ -246,16 +246,16 @@ class TestRecord(TestCase):
     def assertMultipleValues(self, _type, a_values, b_value):
         a_data = {'ttl': 30, 'values': a_values}
         a = _type(self.zone, 'a', a_data)
-        self.assertEquals('a', a.name)
-        self.assertEquals('a.unit.tests.', a.fqdn)
-        self.assertEquals(30, a.ttl)
-        self.assertEquals(a_values, a.values)
-        self.assertEquals(a_data, a.data)
+        self.assertEqual('a', a.name)
+        self.assertEqual('a.unit.tests.', a.fqdn)
+        self.assertEqual(30, a.ttl)
+        self.assertEqual(a_values, a.values)
+        self.assertEqual(a_data, a.data)
 
         b_data = {'ttl': 30, 'value': b_value}
         b = _type(self.zone, 'b', b_data)
-        self.assertEquals([b_value], b.values)
-        self.assertEquals(b_data, b.data)
+        self.assertEqual([b_value], b.values)
+        self.assertEqual(b_data, b.data)
 
     def test_aaaa(self):
         a_values = ['2001:db8:3c4d:15::1a2f:1a2b',
@@ -271,21 +271,21 @@ class TestRecord(TestCase):
             'values': values,
         }
         record = AaaaRecord(self.zone, 'aaaa', data)
-        self.assertEquals(a_values, record.values)
+        self.assertEqual(a_values, record.values)
 
     def assertSingleValue(self, _type, a_value, b_value):
         a_data = {'ttl': 30, 'value': a_value}
         a = _type(self.zone, 'a', a_data)
-        self.assertEquals('a', a.name)
-        self.assertEquals('a.unit.tests.', a.fqdn)
-        self.assertEquals(30, a.ttl)
-        self.assertEquals(a_value, a.value)
-        self.assertEquals(a_data, a.data)
+        self.assertEqual('a', a.name)
+        self.assertEqual('a.unit.tests.', a.fqdn)
+        self.assertEqual(30, a.ttl)
+        self.assertEqual(a_value, a.value)
+        self.assertEqual(a_data, a.data)
 
         b_data = {'ttl': 30, 'value': b_value}
         b = _type(self.zone, 'b', b_data)
-        self.assertEquals(b_value, b.value)
-        self.assertEquals(b_data, b.data)
+        self.assertEqual(b_value, b.value)
+        self.assertEqual(b_data, b.data)
 
         target = SimpleProvider()
         # No changes with self
@@ -302,11 +302,11 @@ class TestRecord(TestCase):
     def test_alias(self):
         a_data = {'ttl': 0, 'value': 'www.unit.tests.'}
         a = AliasRecord(self.zone, '', a_data)
-        self.assertEquals('', a.name)
-        self.assertEquals('unit.tests.', a.fqdn)
-        self.assertEquals(0, a.ttl)
-        self.assertEquals(a_data['value'], a.value)
-        self.assertEquals(a_data, a.data)
+        self.assertEqual('', a.name)
+        self.assertEqual('unit.tests.', a.fqdn)
+        self.assertEqual(0, a.ttl)
+        self.assertEqual(a_data['value'], a.value)
+        self.assertEqual(a_data, a.data)
 
         target = SimpleProvider()
         # No changes with self
@@ -333,16 +333,16 @@ class TestRecord(TestCase):
         }]
         a_data = {'ttl': 30, 'values': a_values}
         a = CaaRecord(self.zone, 'a', a_data)
-        self.assertEquals('a', a.name)
-        self.assertEquals('a.unit.tests.', a.fqdn)
-        self.assertEquals(30, a.ttl)
-        self.assertEquals(a_values[0]['flags'], a.values[0].flags)
-        self.assertEquals(a_values[0]['tag'], a.values[0].tag)
-        self.assertEquals(a_values[0]['value'], a.values[0].value)
-        self.assertEquals(a_values[1]['flags'], a.values[1].flags)
-        self.assertEquals(a_values[1]['tag'], a.values[1].tag)
-        self.assertEquals(a_values[1]['value'], a.values[1].value)
-        self.assertEquals(a_data, a.data)
+        self.assertEqual('a', a.name)
+        self.assertEqual('a.unit.tests.', a.fqdn)
+        self.assertEqual(30, a.ttl)
+        self.assertEqual(a_values[0]['flags'], a.values[0].flags)
+        self.assertEqual(a_values[0]['tag'], a.values[0].tag)
+        self.assertEqual(a_values[0]['value'], a.values[0].value)
+        self.assertEqual(a_values[1]['flags'], a.values[1].flags)
+        self.assertEqual(a_values[1]['tag'], a.values[1].tag)
+        self.assertEqual(a_values[1]['value'], a.values[1].value)
+        self.assertEqual(a_data, a.data)
 
         b_value = {
             'tag': 'iodef',
@@ -350,11 +350,11 @@ class TestRecord(TestCase):
         }
         b_data = {'ttl': 30, 'value': b_value}
         b = CaaRecord(self.zone, 'b', b_data)
-        self.assertEquals(0, b.values[0].flags)
-        self.assertEquals(b_value['tag'], b.values[0].tag)
-        self.assertEquals(b_value['value'], b.values[0].value)
+        self.assertEqual(0, b.values[0].flags)
+        self.assertEqual(b_value['tag'], b.values[0].tag)
+        self.assertEqual(b_value['value'], b.values[0].value)
         b_data['value']['flags'] = 0
-        self.assertEquals(b_data, b.data)
+        self.assertEqual(b_data, b.data)
 
         target = SimpleProvider()
         # No changes with self
@@ -406,28 +406,28 @@ class TestRecord(TestCase):
         }]
         a_data = {'ttl': 30, 'values': a_values}
         a = LocRecord(self.zone, 'a', a_data)
-        self.assertEquals('a', a.name)
-        self.assertEquals('a.unit.tests.', a.fqdn)
-        self.assertEquals(30, a.ttl)
-        self.assertEquals(a_values[0]['lat_degrees'], a.values[0].lat_degrees)
-        self.assertEquals(a_values[0]['lat_minutes'], a.values[0].lat_minutes)
-        self.assertEquals(a_values[0]['lat_seconds'], a.values[0].lat_seconds)
-        self.assertEquals(a_values[0]['lat_direction'],
-                          a.values[0].lat_direction)
-        self.assertEquals(a_values[0]['long_degrees'],
-                          a.values[0].long_degrees)
-        self.assertEquals(a_values[0]['long_minutes'],
-                          a.values[0].long_minutes)
-        self.assertEquals(a_values[0]['long_seconds'],
-                          a.values[0].long_seconds)
-        self.assertEquals(a_values[0]['long_direction'],
-                          a.values[0].long_direction)
-        self.assertEquals(a_values[0]['altitude'], a.values[0].altitude)
-        self.assertEquals(a_values[0]['size'], a.values[0].size)
-        self.assertEquals(a_values[0]['precision_horz'],
-                          a.values[0].precision_horz)
-        self.assertEquals(a_values[0]['precision_vert'],
-                          a.values[0].precision_vert)
+        self.assertEqual('a', a.name)
+        self.assertEqual('a.unit.tests.', a.fqdn)
+        self.assertEqual(30, a.ttl)
+        self.assertEqual(a_values[0]['lat_degrees'], a.values[0].lat_degrees)
+        self.assertEqual(a_values[0]['lat_minutes'], a.values[0].lat_minutes)
+        self.assertEqual(a_values[0]['lat_seconds'], a.values[0].lat_seconds)
+        self.assertEqual(a_values[0]['lat_direction'],
+                         a.values[0].lat_direction)
+        self.assertEqual(a_values[0]['long_degrees'],
+                         a.values[0].long_degrees)
+        self.assertEqual(a_values[0]['long_minutes'],
+                         a.values[0].long_minutes)
+        self.assertEqual(a_values[0]['long_seconds'],
+                         a.values[0].long_seconds)
+        self.assertEqual(a_values[0]['long_direction'],
+                         a.values[0].long_direction)
+        self.assertEqual(a_values[0]['altitude'], a.values[0].altitude)
+        self.assertEqual(a_values[0]['size'], a.values[0].size)
+        self.assertEqual(a_values[0]['precision_horz'],
+                         a.values[0].precision_horz)
+        self.assertEqual(a_values[0]['precision_vert'],
+                         a.values[0].precision_vert)
 
         b_value = {
             'lat_degrees': 32,
@@ -445,22 +445,22 @@ class TestRecord(TestCase):
         }
         b_data = {'ttl': 30, 'value': b_value}
         b = LocRecord(self.zone, 'b', b_data)
-        self.assertEquals(b_value['lat_degrees'], b.values[0].lat_degrees)
-        self.assertEquals(b_value['lat_minutes'], b.values[0].lat_minutes)
-        self.assertEquals(b_value['lat_seconds'], b.values[0].lat_seconds)
-        self.assertEquals(b_value['lat_direction'], b.values[0].lat_direction)
-        self.assertEquals(b_value['long_degrees'], b.values[0].long_degrees)
-        self.assertEquals(b_value['long_minutes'], b.values[0].long_minutes)
-        self.assertEquals(b_value['long_seconds'], b.values[0].long_seconds)
-        self.assertEquals(b_value['long_direction'],
-                          b.values[0].long_direction)
-        self.assertEquals(b_value['altitude'], b.values[0].altitude)
-        self.assertEquals(b_value['size'], b.values[0].size)
-        self.assertEquals(b_value['precision_horz'],
-                          b.values[0].precision_horz)
-        self.assertEquals(b_value['precision_vert'],
-                          b.values[0].precision_vert)
-        self.assertEquals(b_data, b.data)
+        self.assertEqual(b_value['lat_degrees'], b.values[0].lat_degrees)
+        self.assertEqual(b_value['lat_minutes'], b.values[0].lat_minutes)
+        self.assertEqual(b_value['lat_seconds'], b.values[0].lat_seconds)
+        self.assertEqual(b_value['lat_direction'], b.values[0].lat_direction)
+        self.assertEqual(b_value['long_degrees'], b.values[0].long_degrees)
+        self.assertEqual(b_value['long_minutes'], b.values[0].long_minutes)
+        self.assertEqual(b_value['long_seconds'], b.values[0].long_seconds)
+        self.assertEqual(b_value['long_direction'],
+                         b.values[0].long_direction)
+        self.assertEqual(b_value['altitude'], b.values[0].altitude)
+        self.assertEqual(b_value['size'], b.values[0].size)
+        self.assertEqual(b_value['precision_horz'],
+                         b.values[0].precision_horz)
+        self.assertEqual(b_value['precision_vert'],
+                         b.values[0].precision_vert)
+        self.assertEqual(b_data, b.data)
 
         target = SimpleProvider()
         # No changes with self
@@ -491,18 +491,18 @@ class TestRecord(TestCase):
         }]
         a_data = {'ttl': 30, 'values': a_values}
         a = MxRecord(self.zone, 'a', a_data)
-        self.assertEquals('a', a.name)
-        self.assertEquals('a.unit.tests.', a.fqdn)
-        self.assertEquals(30, a.ttl)
-        self.assertEquals(a_values[0]['preference'], a.values[0].preference)
-        self.assertEquals(a_values[0]['exchange'], a.values[0].exchange)
-        self.assertEquals(a_values[1]['priority'], a.values[1].preference)
-        self.assertEquals(a_values[1]['value'], a.values[1].exchange)
+        self.assertEqual('a', a.name)
+        self.assertEqual('a.unit.tests.', a.fqdn)
+        self.assertEqual(30, a.ttl)
+        self.assertEqual(a_values[0]['preference'], a.values[0].preference)
+        self.assertEqual(a_values[0]['exchange'], a.values[0].exchange)
+        self.assertEqual(a_values[1]['priority'], a.values[1].preference)
+        self.assertEqual(a_values[1]['value'], a.values[1].exchange)
         a_data['values'][1] = {
             'preference': 20,
             'exchange': 'smtp2.',
         }
-        self.assertEquals(a_data, a.data)
+        self.assertEqual(a_data, a.data)
 
         b_value = {
             'preference': 0,
@@ -510,9 +510,9 @@ class TestRecord(TestCase):
         }
         b_data = {'ttl': 30, 'value': b_value}
         b = MxRecord(self.zone, 'b', b_data)
-        self.assertEquals(b_value['preference'], b.values[0].preference)
-        self.assertEquals(b_value['exchange'], b.values[0].exchange)
-        self.assertEquals(b_data, b.data)
+        self.assertEqual(b_value['preference'], b.values[0].preference)
+        self.assertEqual(b_value['exchange'], b.values[0].exchange)
+        self.assertEqual(b_data, b.data)
 
         a_upper_values = [{
             'preference': 10,
@@ -523,7 +523,7 @@ class TestRecord(TestCase):
         }]
         a_upper_data = {'ttl': 30, 'values': a_upper_values}
         a_upper = MxRecord(self.zone, 'a', a_upper_data)
-        self.assertEquals(a_upper.data, a.data)
+        self.assertEqual(a_upper.data, a.data)
 
         target = SimpleProvider()
         # No changes with self
@@ -562,13 +562,13 @@ class TestRecord(TestCase):
         }]
         a_data = {'ttl': 30, 'values': a_values}
         a = NaptrRecord(self.zone, 'a', a_data)
-        self.assertEquals('a', a.name)
-        self.assertEquals('a.unit.tests.', a.fqdn)
-        self.assertEquals(30, a.ttl)
+        self.assertEqual('a', a.name)
+        self.assertEqual('a.unit.tests.', a.fqdn)
+        self.assertEqual(30, a.ttl)
         for i in (0, 1):
             for k in a_values[0].keys():
-                self.assertEquals(a_values[i][k], getattr(a.values[i], k))
-        self.assertEquals(a_data, a.data)
+                self.assertEqual(a_values[i][k], getattr(a.values[i], k))
+        self.assertEqual(a_data, a.data)
 
         b_value = {
             'order': 30,
@@ -581,8 +581,8 @@ class TestRecord(TestCase):
         b_data = {'ttl': 30, 'value': b_value}
         b = NaptrRecord(self.zone, 'b', b_data)
         for k in a_values[0].keys():
-            self.assertEquals(b_value[k], getattr(b.values[0], k))
-        self.assertEquals(b_data, b.data)
+            self.assertEqual(b_value[k], getattr(b.values[0], k))
+        self.assertEqual(b_data, b.data)
 
         target = SimpleProvider()
         # No changes with self
@@ -741,17 +741,17 @@ class TestRecord(TestCase):
         a_values = ['5.6.7.8.', '6.7.8.9.', '7.8.9.0.']
         a_data = {'ttl': 30, 'values': a_values}
         a = NsRecord(self.zone, 'a', a_data)
-        self.assertEquals('a', a.name)
-        self.assertEquals('a.unit.tests.', a.fqdn)
-        self.assertEquals(30, a.ttl)
-        self.assertEquals(a_values, a.values)
-        self.assertEquals(a_data, a.data)
+        self.assertEqual('a', a.name)
+        self.assertEqual('a.unit.tests.', a.fqdn)
+        self.assertEqual(30, a.ttl)
+        self.assertEqual(a_values, a.values)
+        self.assertEqual(a_data, a.data)
 
         b_value = '9.8.7.6.'
         b_data = {'ttl': 30, 'value': b_value}
         b = NsRecord(self.zone, 'b', b_data)
-        self.assertEquals([b_value], b.values)
-        self.assertEquals(b_data, b.data)
+        self.assertEqual([b_value], b.values)
+        self.assertEqual(b_data, b.data)
 
     def test_sshfp(self):
         a_values = [{
@@ -765,14 +765,14 @@ class TestRecord(TestCase):
         }]
         a_data = {'ttl': 30, 'values': a_values}
         a = SshfpRecord(self.zone, 'a', a_data)
-        self.assertEquals('a', a.name)
-        self.assertEquals('a.unit.tests.', a.fqdn)
-        self.assertEquals(30, a.ttl)
-        self.assertEquals(a_values[0]['algorithm'], a.values[0].algorithm)
-        self.assertEquals(a_values[0]['fingerprint_type'],
-                          a.values[0].fingerprint_type)
-        self.assertEquals(a_values[0]['fingerprint'], a.values[0].fingerprint)
-        self.assertEquals(a_data, a.data)
+        self.assertEqual('a', a.name)
+        self.assertEqual('a.unit.tests.', a.fqdn)
+        self.assertEqual(30, a.ttl)
+        self.assertEqual(a_values[0]['algorithm'], a.values[0].algorithm)
+        self.assertEqual(a_values[0]['fingerprint_type'],
+                         a.values[0].fingerprint_type)
+        self.assertEqual(a_values[0]['fingerprint'], a.values[0].fingerprint)
+        self.assertEqual(a_data, a.data)
 
         b_value = {
             'algorithm': 30,
@@ -781,11 +781,11 @@ class TestRecord(TestCase):
         }
         b_data = {'ttl': 30, 'value': b_value}
         b = SshfpRecord(self.zone, 'b', b_data)
-        self.assertEquals(b_value['algorithm'], b.values[0].algorithm)
-        self.assertEquals(b_value['fingerprint_type'],
-                          b.values[0].fingerprint_type)
-        self.assertEquals(b_value['fingerprint'], b.values[0].fingerprint)
-        self.assertEquals(b_data, b.data)
+        self.assertEqual(b_value['algorithm'], b.values[0].algorithm)
+        self.assertEqual(b_value['fingerprint_type'],
+                         b.values[0].fingerprint_type)
+        self.assertEqual(b_value['fingerprint'], b.values[0].fingerprint)
+        self.assertEqual(b_data, b.data)
 
         target = SimpleProvider()
         # No changes with self
@@ -833,14 +833,14 @@ class TestRecord(TestCase):
         }]
         a_data = {'ttl': 30, 'values': a_values}
         a = SrvRecord(self.zone, '_a._tcp', a_data)
-        self.assertEquals('_a._tcp', a.name)
-        self.assertEquals('_a._tcp.unit.tests.', a.fqdn)
-        self.assertEquals(30, a.ttl)
-        self.assertEquals(a_values[0]['priority'], a.values[0].priority)
-        self.assertEquals(a_values[0]['weight'], a.values[0].weight)
-        self.assertEquals(a_values[0]['port'], a.values[0].port)
-        self.assertEquals(a_values[0]['target'], a.values[0].target)
-        self.assertEquals(a_data, a.data)
+        self.assertEqual('_a._tcp', a.name)
+        self.assertEqual('_a._tcp.unit.tests.', a.fqdn)
+        self.assertEqual(30, a.ttl)
+        self.assertEqual(a_values[0]['priority'], a.values[0].priority)
+        self.assertEqual(a_values[0]['weight'], a.values[0].weight)
+        self.assertEqual(a_values[0]['port'], a.values[0].port)
+        self.assertEqual(a_values[0]['target'], a.values[0].target)
+        self.assertEqual(a_data, a.data)
 
         b_value = {
             'priority': 30,
@@ -850,11 +850,11 @@ class TestRecord(TestCase):
         }
         b_data = {'ttl': 30, 'value': b_value}
         b = SrvRecord(self.zone, '_b._tcp', b_data)
-        self.assertEquals(b_value['priority'], b.values[0].priority)
-        self.assertEquals(b_value['weight'], b.values[0].weight)
-        self.assertEquals(b_value['port'], b.values[0].port)
-        self.assertEquals(b_value['target'], b.values[0].target)
-        self.assertEquals(b_data, b.data)
+        self.assertEqual(b_value['priority'], b.values[0].priority)
+        self.assertEqual(b_value['weight'], b.values[0].weight)
+        self.assertEqual(b_value['port'], b.values[0].port)
+        self.assertEqual(b_value['target'], b.values[0].target)
+        self.assertEqual(b_data, b.data)
 
         target = SimpleProvider()
         # No changes with self
@@ -909,20 +909,20 @@ class TestRecord(TestCase):
         }]
         a_data = {'ttl': 30, 'values': a_values}
         a = UrlfwdRecord(self.zone, 'a', a_data)
-        self.assertEquals('a', a.name)
-        self.assertEquals('a.unit.tests.', a.fqdn)
-        self.assertEquals(30, a.ttl)
-        self.assertEquals(a_values[0]['path'], a.values[0].path)
-        self.assertEquals(a_values[0]['target'], a.values[0].target)
-        self.assertEquals(a_values[0]['code'], a.values[0].code)
-        self.assertEquals(a_values[0]['masking'], a.values[0].masking)
-        self.assertEquals(a_values[0]['query'], a.values[0].query)
-        self.assertEquals(a_values[1]['path'], a.values[1].path)
-        self.assertEquals(a_values[1]['target'], a.values[1].target)
-        self.assertEquals(a_values[1]['code'], a.values[1].code)
-        self.assertEquals(a_values[1]['masking'], a.values[1].masking)
-        self.assertEquals(a_values[1]['query'], a.values[1].query)
-        self.assertEquals(a_data, a.data)
+        self.assertEqual('a', a.name)
+        self.assertEqual('a.unit.tests.', a.fqdn)
+        self.assertEqual(30, a.ttl)
+        self.assertEqual(a_values[0]['path'], a.values[0].path)
+        self.assertEqual(a_values[0]['target'], a.values[0].target)
+        self.assertEqual(a_values[0]['code'], a.values[0].code)
+        self.assertEqual(a_values[0]['masking'], a.values[0].masking)
+        self.assertEqual(a_values[0]['query'], a.values[0].query)
+        self.assertEqual(a_values[1]['path'], a.values[1].path)
+        self.assertEqual(a_values[1]['target'], a.values[1].target)
+        self.assertEqual(a_values[1]['code'], a.values[1].code)
+        self.assertEqual(a_values[1]['masking'], a.values[1].masking)
+        self.assertEqual(a_values[1]['query'], a.values[1].query)
+        self.assertEqual(a_data, a.data)
 
         b_value = {
             'path': '/',
@@ -933,12 +933,12 @@ class TestRecord(TestCase):
         }
         b_data = {'ttl': 30, 'value': b_value}
         b = UrlfwdRecord(self.zone, 'b', b_data)
-        self.assertEquals(b_value['path'], b.values[0].path)
-        self.assertEquals(b_value['target'], b.values[0].target)
-        self.assertEquals(b_value['code'], b.values[0].code)
-        self.assertEquals(b_value['masking'], b.values[0].masking)
-        self.assertEquals(b_value['query'], b.values[0].query)
-        self.assertEquals(b_data, b.data)
+        self.assertEqual(b_value['path'], b.values[0].path)
+        self.assertEqual(b_value['target'], b.values[0].target)
+        self.assertEqual(b_value['code'], b.values[0].code)
+        self.assertEqual(b_value['masking'], b.values[0].masking)
+        self.assertEqual(b_value['query'], b.values[0].query)
+        self.assertEqual(b_data, b.data)
 
         target = SimpleProvider()
         # No changes with self
@@ -1006,8 +1006,8 @@ class TestRecord(TestCase):
             'value': 'some text',
         })
         self.assertIsInstance(txt, TxtRecord)
-        self.assertEquals('TXT', txt._type)
-        self.assertEquals(['some text'], txt.values)
+        self.assertEqual('TXT', txt._type)
+        self.assertEqual(['some text'], txt.values)
 
         # Missing type
         with self.assertRaises(Exception) as ctx:
@@ -1031,19 +1031,19 @@ class TestRecord(TestCase):
         # Identical copy.
         b = a.copy()
         self.assertIsInstance(b, ARecord)
-        self.assertEquals('unit.tests.', b.zone.name)
-        self.assertEquals('a', b.name)
-        self.assertEquals('A', b._type)
-        self.assertEquals(['1.2.3.4'], b.values)
+        self.assertEqual('unit.tests.', b.zone.name)
+        self.assertEqual('a', b.name)
+        self.assertEqual('A', b._type)
+        self.assertEqual(['1.2.3.4'], b.values)
 
         # Copy with another zone object.
         c_zone = Zone('other.tests.', [])
         c = a.copy(c_zone)
         self.assertIsInstance(c, ARecord)
-        self.assertEquals('other.tests.', c.zone.name)
-        self.assertEquals('a', c.name)
-        self.assertEquals('A', c._type)
-        self.assertEquals(['1.2.3.4'], c.values)
+        self.assertEqual('other.tests.', c.zone.name)
+        self.assertEqual('a', c.name)
+        self.assertEqual('A', c._type)
+        self.assertEqual(['1.2.3.4'], c.values)
 
         # Record with no record type specified in data.
         d_data = {
@@ -1052,7 +1052,7 @@ class TestRecord(TestCase):
         }
         d = TxtRecord(self.zone, 'txt', d_data)
         d.copy()
-        self.assertEquals('TXT', d._type)
+        self.assertEqual('TXT', d._type)
 
     def test_dynamic_record_copy(self):
         a_data = {
@@ -1097,22 +1097,22 @@ class TestRecord(TestCase):
             'value': 'some change',
         })
         create = Create(new)
-        self.assertEquals(new.values, create.record.values)
+        self.assertEqual(new.values, create.record.values)
         update = Update(existing, new)
-        self.assertEquals(new.values, update.record.values)
+        self.assertEqual(new.values, update.record.values)
         delete = Delete(existing)
-        self.assertEquals(existing.values, delete.record.values)
+        self.assertEqual(existing.values, delete.record.values)
 
     def test_geo_value(self):
         code = 'NA-US-CA'
         values = ['1.2.3.4']
         geo = GeoValue(code, values)
-        self.assertEquals(code, geo.code)
-        self.assertEquals('NA', geo.continent_code)
-        self.assertEquals('US', geo.country_code)
-        self.assertEquals('CA', geo.subdivision_code)
-        self.assertEquals(values, geo.values)
-        self.assertEquals(['NA-US', 'NA'], list(geo.parents))
+        self.assertEqual(code, geo.code)
+        self.assertEqual('NA', geo.continent_code)
+        self.assertEqual('US', geo.country_code)
+        self.assertEqual('CA', geo.subdivision_code)
+        self.assertEqual(values, geo.values)
+        self.assertEqual(['NA-US', 'NA'], list(geo.parents))
 
         a = GeoValue('NA-US-CA', values)
         b = GeoValue('AP-JP', values)
@@ -1160,10 +1160,10 @@ class TestRecord(TestCase):
                 }
             }
         })
-        self.assertEquals('/_ready', new.healthcheck_path)
-        self.assertEquals('bleep.bloop', new.healthcheck_host())
-        self.assertEquals('HTTP', new.healthcheck_protocol)
-        self.assertEquals(8080, new.healthcheck_port)
+        self.assertEqual('/_ready', new.healthcheck_path)
+        self.assertEqual('bleep.bloop', new.healthcheck_host())
+        self.assertEqual('HTTP', new.healthcheck_protocol)
+        self.assertEqual(8080, new.healthcheck_port)
 
         # empty host value in healthcheck
         new = Record.new(self.zone, 'a', {
@@ -1179,17 +1179,17 @@ class TestRecord(TestCase):
                 }
             }
         })
-        self.assertEquals('1.2.3.4', new.healthcheck_host(value="1.2.3.4"))
+        self.assertEqual('1.2.3.4', new.healthcheck_host(value="1.2.3.4"))
 
         new = Record.new(self.zone, 'a', {
             'ttl': 44,
             'type': 'A',
             'value': '1.2.3.4',
         })
-        self.assertEquals('/_dns', new.healthcheck_path)
-        self.assertEquals('a.unit.tests', new.healthcheck_host())
-        self.assertEquals('HTTPS', new.healthcheck_protocol)
-        self.assertEquals(443, new.healthcheck_port)
+        self.assertEqual('/_dns', new.healthcheck_path)
+        self.assertEqual('a.unit.tests', new.healthcheck_host())
+        self.assertEqual('HTTPS', new.healthcheck_protocol)
+        self.assertEqual(443, new.healthcheck_port)
 
     def test_healthcheck_tcp(self):
         new = Record.new(self.zone, 'a', {
@@ -1207,8 +1207,8 @@ class TestRecord(TestCase):
         })
         self.assertIsNone(new.healthcheck_path)
         self.assertIsNone(new.healthcheck_host())
-        self.assertEquals('TCP', new.healthcheck_protocol)
-        self.assertEquals(8080, new.healthcheck_port)
+        self.assertEqual('TCP', new.healthcheck_protocol)
+        self.assertEqual(8080, new.healthcheck_port)
 
         new = Record.new(self.zone, 'a', {
             'ttl': 44,
@@ -1222,8 +1222,8 @@ class TestRecord(TestCase):
         })
         self.assertIsNone(new.healthcheck_path)
         self.assertIsNone(new.healthcheck_host())
-        self.assertEquals('TCP', new.healthcheck_protocol)
-        self.assertEquals(443, new.healthcheck_port)
+        self.assertEqual('TCP', new.healthcheck_protocol)
+        self.assertEqual(443, new.healthcheck_port)
 
     def test_inored(self):
         new = Record.new(self.zone, 'txt', {
@@ -1273,10 +1273,10 @@ class TestRecord(TestCase):
             'value': '2601:644:500:e210:62f8:1dff:feb8:947a',
         })
 
-        self.assertEquals(a, a)
-        self.assertEquals(b, b)
-        self.assertEquals(c, c)
-        self.assertEquals(aaaa, aaaa)
+        self.assertEqual(a, a)
+        self.assertEqual(b, b)
+        self.assertEqual(c, c)
+        self.assertEqual(aaaa, aaaa)
 
         self.assertNotEqual(a, b)
         self.assertNotEqual(a, c)
@@ -1708,7 +1708,7 @@ class TestRecordValidation(TestCase):
                 'type': 'A',
                 'value': '1.2.3.4',
             })
-        self.assertEquals(['missing ttl'], ctx.exception.reasons)
+        self.assertEqual(['missing ttl'], ctx.exception.reasons)
 
         # invalid ttl
         with self.assertRaises(ValidationError) as ctx:
@@ -1717,8 +1717,8 @@ class TestRecordValidation(TestCase):
                 'ttl': -1,
                 'value': '1.2.3.4',
             })
-        self.assertEquals('www.unit.tests.', ctx.exception.fqdn)
-        self.assertEquals(['invalid ttl'], ctx.exception.reasons)
+        self.assertEqual('www.unit.tests.', ctx.exception.fqdn)
+        self.assertEqual(['invalid ttl'], ctx.exception.reasons)
 
         # no exception if we're in lenient mode
         Record.new(self.zone, 'www', {
@@ -1733,7 +1733,7 @@ class TestRecordValidation(TestCase):
                 'type': 'A',
                 'ttl': -1,
             }, lenient=True)
-        self.assertEquals(('value',), ctx.exception.args)
+        self.assertEqual(('value',), ctx.exception.args)
 
         # no exception if we're in lenient mode from config
         Record.new(self.zone, 'www', {
@@ -1774,7 +1774,7 @@ class TestRecordValidation(TestCase):
                 'type': 'A',
                 'ttl': 600,
             })
-        self.assertEquals(['missing value(s)'], ctx.exception.reasons)
+        self.assertEqual(['missing value(s)'], ctx.exception.reasons)
 
         # missing value(s), empty values
         with self.assertRaises(ValidationError) as ctx:
@@ -1783,7 +1783,7 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'values': []
             })
-        self.assertEquals(['missing value(s)'], ctx.exception.reasons)
+        self.assertEqual(['missing value(s)'], ctx.exception.reasons)
 
         # missing value(s), None values
         with self.assertRaises(ValidationError) as ctx:
@@ -1792,7 +1792,7 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'values': None
             })
-        self.assertEquals(['missing value(s)'], ctx.exception.reasons)
+        self.assertEqual(['missing value(s)'], ctx.exception.reasons)
 
         # missing value(s) and empty value
         with self.assertRaises(ValidationError) as ctx:
@@ -1801,8 +1801,8 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'values': [None, '']
             })
-        self.assertEquals(['missing value(s)',
-                           'empty value'], ctx.exception.reasons)
+        self.assertEqual(['missing value(s)',
+                          'empty value'], ctx.exception.reasons)
 
         # missing value(s), None value
         with self.assertRaises(ValidationError) as ctx:
@@ -1811,7 +1811,7 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': None
             })
-        self.assertEquals(['missing value(s)'], ctx.exception.reasons)
+        self.assertEqual(['missing value(s)'], ctx.exception.reasons)
 
         # empty value, empty string value
         with self.assertRaises(ValidationError) as ctx:
@@ -1820,15 +1820,15 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': ''
             })
-        self.assertEquals(['empty value'], ctx.exception.reasons)
+        self.assertEqual(['empty value'], ctx.exception.reasons)
 
         # missing value(s) & ttl
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, '', {
                 'type': 'A',
             })
-        self.assertEquals(['missing ttl', 'missing value(s)'],
-                          ctx.exception.reasons)
+        self.assertEqual(['missing ttl', 'missing value(s)'],
+                         ctx.exception.reasons)
 
         # invalid ipv4 address
         with self.assertRaises(ValidationError) as ctx:
@@ -1837,8 +1837,8 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': 'hello'
             })
-        self.assertEquals(['invalid IPv4 address "hello"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['invalid IPv4 address "hello"'],
+                         ctx.exception.reasons)
 
         # invalid ipv4 addresses
         with self.assertRaises(ValidationError) as ctx:
@@ -1847,7 +1847,7 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'values': ['hello', 'goodbye']
             })
-        self.assertEquals([
+        self.assertEqual([
             'invalid IPv4 address "hello"',
             'invalid IPv4 address "goodbye"'
         ], ctx.exception.reasons)
@@ -1858,7 +1858,7 @@ class TestRecordValidation(TestCase):
                 'type': 'A',
                 'values': ['1.2.3.4', 'hello', '5.6.7.8']
             })
-        self.assertEquals([
+        self.assertEqual([
             'missing ttl',
             'invalid IPv4 address "hello"',
         ], ctx.exception.reasons)
@@ -1892,7 +1892,7 @@ class TestRecordValidation(TestCase):
                 'type': 'AAAA',
                 'ttl': 600,
             })
-        self.assertEquals(['missing value(s)'], ctx.exception.reasons)
+        self.assertEqual(['missing value(s)'], ctx.exception.reasons)
 
         # missing value(s), empty values
         with self.assertRaises(ValidationError) as ctx:
@@ -1901,7 +1901,7 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'values': []
             })
-        self.assertEquals(['missing value(s)'], ctx.exception.reasons)
+        self.assertEqual(['missing value(s)'], ctx.exception.reasons)
 
         # missing value(s), None values
         with self.assertRaises(ValidationError) as ctx:
@@ -1910,7 +1910,7 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'values': None
             })
-        self.assertEquals(['missing value(s)'], ctx.exception.reasons)
+        self.assertEqual(['missing value(s)'], ctx.exception.reasons)
 
         # missing value(s) and empty value
         with self.assertRaises(ValidationError) as ctx:
@@ -1919,8 +1919,8 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'values': [None, '']
             })
-        self.assertEquals(['missing value(s)',
-                           'empty value'], ctx.exception.reasons)
+        self.assertEqual(['missing value(s)',
+                          'empty value'], ctx.exception.reasons)
 
         # missing value(s), None value
         with self.assertRaises(ValidationError) as ctx:
@@ -1929,7 +1929,7 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': None
             })
-        self.assertEquals(['missing value(s)'], ctx.exception.reasons)
+        self.assertEqual(['missing value(s)'], ctx.exception.reasons)
 
         # empty value, empty string value
         with self.assertRaises(ValidationError) as ctx:
@@ -1938,15 +1938,15 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': ''
             })
-        self.assertEquals(['empty value'], ctx.exception.reasons)
+        self.assertEqual(['empty value'], ctx.exception.reasons)
 
         # missing value(s) & ttl
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, '', {
                 'type': 'AAAA',
             })
-        self.assertEquals(['missing ttl', 'missing value(s)'],
-                          ctx.exception.reasons)
+        self.assertEqual(['missing ttl', 'missing value(s)'],
+                         ctx.exception.reasons)
 
         # invalid IPv6 address
         with self.assertRaises(ValidationError) as ctx:
@@ -1955,8 +1955,8 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': 'hello'
             })
-        self.assertEquals(['invalid IPv6 address "hello"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['invalid IPv6 address "hello"'],
+                         ctx.exception.reasons)
 
         # invalid IPv6 addresses
         with self.assertRaises(ValidationError) as ctx:
@@ -1965,7 +1965,7 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'values': ['hello', 'goodbye']
             })
-        self.assertEquals([
+        self.assertEqual([
             'invalid IPv6 address "hello"',
             'invalid IPv6 address "goodbye"'
         ], ctx.exception.reasons)
@@ -1980,7 +1980,7 @@ class TestRecordValidation(TestCase):
                     '2601:642:500:e210:62f8:1dff:feb8:947a'
                 ]
             })
-        self.assertEquals([
+        self.assertEqual([
             'missing ttl',
             'invalid IPv6 address "hello"',
         ], ctx.exception.reasons)
@@ -2007,8 +2007,8 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': '1.2.3.4',
             })
-        self.assertEquals(['invalid IPv4 address "hello"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['invalid IPv4 address "hello"'],
+                         ctx.exception.reasons)
 
         # invalid geo code
         with self.assertRaises(ValidationError) as ctx:
@@ -2020,7 +2020,7 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': '1.2.3.4',
             })
-        self.assertEquals(['invalid geo "XYZ"'], ctx.exception.reasons)
+        self.assertEqual(['invalid geo "XYZ"'], ctx.exception.reasons)
 
         # invalid ip address
         with self.assertRaises(ValidationError) as ctx:
@@ -2033,7 +2033,7 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': '1.2.3.4',
             })
-        self.assertEquals([
+        self.assertEqual([
             'invalid IPv4 address "hello"',
             'invalid IPv4 address "goodbye"'
         ], ctx.exception.reasons)
@@ -2054,8 +2054,8 @@ class TestRecordValidation(TestCase):
                     }
                 }
             })
-        self.assertEquals(['invalid healthcheck protocol'],
-                          ctx.exception.reasons)
+        self.assertEqual(['invalid healthcheck protocol'],
+                         ctx.exception.reasons)
 
     def test_AAAA(self):
         # doesn't blow up
@@ -2080,8 +2080,8 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': 'hello'
             })
-        self.assertEquals(['invalid IPv6 address "hello"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['invalid IPv6 address "hello"'],
+                         ctx.exception.reasons)
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, '', {
                 'type': 'AAAA',
@@ -2091,7 +2091,7 @@ class TestRecordValidation(TestCase):
                     '2.3.4.5',
                 ],
             })
-        self.assertEquals([
+        self.assertEqual([
             'invalid IPv6 address "1.2.3.4"',
             'invalid IPv6 address "2.3.4.5"',
         ], ctx.exception.reasons)
@@ -2103,7 +2103,7 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'values': ['hello', 'goodbye']
             })
-        self.assertEquals([
+        self.assertEqual([
             'invalid IPv6 address "hello"',
             'invalid IPv6 address "goodbye"'
         ], ctx.exception.reasons)
@@ -2123,8 +2123,8 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': 'foo.bar.com.',
             })
-        self.assertEquals(['non-root ALIAS not allowed'],
-                          ctx.exception.reasons)
+        self.assertEqual(['non-root ALIAS not allowed'],
+                         ctx.exception.reasons)
 
         # missing value
         with self.assertRaises(ValidationError) as ctx:
@@ -2132,7 +2132,7 @@ class TestRecordValidation(TestCase):
                 'type': 'ALIAS',
                 'ttl': 600,
             })
-        self.assertEquals(['missing value'], ctx.exception.reasons)
+        self.assertEqual(['missing value'], ctx.exception.reasons)
 
         # missing value
         with self.assertRaises(ValidationError) as ctx:
@@ -2141,7 +2141,7 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': None
             })
-        self.assertEquals(['missing value'], ctx.exception.reasons)
+        self.assertEqual(['missing value'], ctx.exception.reasons)
 
         # empty value
         with self.assertRaises(ValidationError) as ctx:
@@ -2150,7 +2150,7 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': ''
             })
-        self.assertEquals(['empty value'], ctx.exception.reasons)
+        self.assertEqual(['empty value'], ctx.exception.reasons)
 
         # not a valid FQDN
         with self.assertRaises(ValidationError) as ctx:
@@ -2159,8 +2159,8 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': '__.',
             })
-        self.assertEquals(['ALIAS value "__." is not a valid FQDN'],
-                          ctx.exception.reasons)
+        self.assertEqual(['ALIAS value "__." is not a valid FQDN'],
+                         ctx.exception.reasons)
 
         # missing trailing .
         with self.assertRaises(ValidationError) as ctx:
@@ -2169,8 +2169,8 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': 'foo.bar.com',
             })
-        self.assertEquals(['ALIAS value "foo.bar.com" missing trailing .'],
-                          ctx.exception.reasons)
+        self.assertEqual(['ALIAS value "foo.bar.com" missing trailing .'],
+                         ctx.exception.reasons)
 
     def test_CAA(self):
         # doesn't blow up
@@ -2195,7 +2195,7 @@ class TestRecordValidation(TestCase):
                     'value': 'http://foo.bar.com/',
                 }
             })
-        self.assertEquals(['invalid flags "-42"'], ctx.exception.reasons)
+        self.assertEqual(['invalid flags "-42"'], ctx.exception.reasons)
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, '', {
                 'type': 'CAA',
@@ -2206,7 +2206,7 @@ class TestRecordValidation(TestCase):
                     'value': 'http://foo.bar.com/',
                 }
             })
-        self.assertEquals(['invalid flags "442"'], ctx.exception.reasons)
+        self.assertEqual(['invalid flags "442"'], ctx.exception.reasons)
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, '', {
                 'type': 'CAA',
@@ -2217,7 +2217,7 @@ class TestRecordValidation(TestCase):
                     'value': 'http://foo.bar.com/',
                 }
             })
-        self.assertEquals(['invalid flags "nope"'], ctx.exception.reasons)
+        self.assertEqual(['invalid flags "nope"'], ctx.exception.reasons)
 
         # missing tag
         with self.assertRaises(ValidationError) as ctx:
@@ -2228,7 +2228,7 @@ class TestRecordValidation(TestCase):
                     'value': 'http://foo.bar.com/',
                 }
             })
-        self.assertEquals(['missing tag'], ctx.exception.reasons)
+        self.assertEqual(['missing tag'], ctx.exception.reasons)
 
         # missing value
         with self.assertRaises(ValidationError) as ctx:
@@ -2239,7 +2239,7 @@ class TestRecordValidation(TestCase):
                     'tag': 'iodef',
                 }
             })
-        self.assertEquals(['missing value'], ctx.exception.reasons)
+        self.assertEqual(['missing value'], ctx.exception.reasons)
 
     def test_CNAME(self):
         # doesn't blow up
@@ -2256,7 +2256,7 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': 'foo.bar.com.',
             })
-        self.assertEquals(['root CNAME not allowed'], ctx.exception.reasons)
+        self.assertEqual(['root CNAME not allowed'], ctx.exception.reasons)
 
         # not a valid FQDN
         with self.assertRaises(ValidationError) as ctx:
@@ -2265,8 +2265,8 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': '___.',
             })
-        self.assertEquals(['CNAME value "___." is not a valid FQDN'],
-                          ctx.exception.reasons)
+        self.assertEqual(['CNAME value "___." is not a valid FQDN'],
+                         ctx.exception.reasons)
 
         # missing trailing .
         with self.assertRaises(ValidationError) as ctx:
@@ -2275,8 +2275,8 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': 'foo.bar.com',
             })
-        self.assertEquals(['CNAME value "foo.bar.com" missing trailing .'],
-                          ctx.exception.reasons)
+        self.assertEqual(['CNAME value "foo.bar.com" missing trailing .'],
+                         ctx.exception.reasons)
 
     def test_DNAME(self):
         # A valid DNAME record.
@@ -2300,8 +2300,8 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': '.',
             })
-        self.assertEquals(['DNAME value "." is not a valid FQDN'],
-                          ctx.exception.reasons)
+        self.assertEqual(['DNAME value "." is not a valid FQDN'],
+                         ctx.exception.reasons)
 
         # missing trailing .
         with self.assertRaises(ValidationError) as ctx:
@@ -2310,8 +2310,8 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': 'foo.bar.com',
             })
-        self.assertEquals(['DNAME value "foo.bar.com" missing trailing .'],
-                          ctx.exception.reasons)
+        self.assertEqual(['DNAME value "foo.bar.com" missing trailing .'],
+                         ctx.exception.reasons)
 
     def test_LOC(self):
         # doesn't blow up
@@ -2354,7 +2354,7 @@ class TestRecordValidation(TestCase):
                 }
             })
 
-        self.assertEquals(['missing lat_degrees'], ctx.exception.reasons)
+        self.assertEqual(['missing lat_degrees'], ctx.exception.reasons)
 
         # missing float key
         with self.assertRaises(ValidationError) as ctx:
@@ -2376,7 +2376,7 @@ class TestRecordValidation(TestCase):
                 }
             })
 
-        self.assertEquals(['missing lat_seconds'], ctx.exception.reasons)
+        self.assertEqual(['missing lat_seconds'], ctx.exception.reasons)
 
         # missing text key
         with self.assertRaises(ValidationError) as ctx:
@@ -2398,7 +2398,7 @@ class TestRecordValidation(TestCase):
                 }
             })
 
-        self.assertEquals(['missing lat_direction'], ctx.exception.reasons)
+        self.assertEqual(['missing lat_direction'], ctx.exception.reasons)
 
         # invalid direction
         with self.assertRaises(ValidationError) as ctx:
@@ -2421,8 +2421,8 @@ class TestRecordValidation(TestCase):
                 }
             })
 
-        self.assertEquals(['invalid direction for lat_direction "U"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['invalid direction for lat_direction "U"'],
+                         ctx.exception.reasons)
 
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, '', {
@@ -2444,8 +2444,8 @@ class TestRecordValidation(TestCase):
                 }
             })
 
-        self.assertEquals(['invalid direction for long_direction "N"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['invalid direction for long_direction "N"'],
+                         ctx.exception.reasons)
 
         # invalid degrees
         with self.assertRaises(ValidationError) as ctx:
@@ -2468,8 +2468,8 @@ class TestRecordValidation(TestCase):
                 }
             })
 
-        self.assertEquals(['invalid value for lat_degrees "360"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['invalid value for lat_degrees "360"'],
+                         ctx.exception.reasons)
 
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, '', {
@@ -2491,8 +2491,8 @@ class TestRecordValidation(TestCase):
                 }
             })
 
-        self.assertEquals(['invalid lat_degrees "nope"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['invalid lat_degrees "nope"'],
+                         ctx.exception.reasons)
 
         # invalid minutes
         with self.assertRaises(ValidationError) as ctx:
@@ -2515,8 +2515,8 @@ class TestRecordValidation(TestCase):
                 }
             })
 
-        self.assertEquals(['invalid value for lat_minutes "60"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['invalid value for lat_minutes "60"'],
+                         ctx.exception.reasons)
 
         # invalid seconds
         with self.assertRaises(ValidationError) as ctx:
@@ -2539,8 +2539,8 @@ class TestRecordValidation(TestCase):
                 }
             })
 
-        self.assertEquals(['invalid value for lat_seconds "60"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['invalid value for lat_seconds "60"'],
+                         ctx.exception.reasons)
 
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, '', {
@@ -2562,8 +2562,8 @@ class TestRecordValidation(TestCase):
                 }
             })
 
-        self.assertEquals(['invalid lat_seconds "nope"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['invalid lat_seconds "nope"'],
+                         ctx.exception.reasons)
 
         # invalid altitude
         with self.assertRaises(ValidationError) as ctx:
@@ -2586,8 +2586,8 @@ class TestRecordValidation(TestCase):
                 }
             })
 
-        self.assertEquals(['invalid value for altitude "-666666"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['invalid value for altitude "-666666"'],
+                         ctx.exception.reasons)
 
         # invalid size
         with self.assertRaises(ValidationError) as ctx:
@@ -2610,8 +2610,8 @@ class TestRecordValidation(TestCase):
                 }
             })
 
-        self.assertEquals(['invalid value for size "99999999.99"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['invalid value for size "99999999.99"'],
+                         ctx.exception.reasons)
 
     def test_MX(self):
         # doesn't blow up
@@ -2633,7 +2633,7 @@ class TestRecordValidation(TestCase):
                     'exchange': 'foo.bar.com.'
                 }
             })
-        self.assertEquals(['missing preference'], ctx.exception.reasons)
+        self.assertEqual(['missing preference'], ctx.exception.reasons)
 
         # invalid preference
         with self.assertRaises(ValidationError) as ctx:
@@ -2645,7 +2645,7 @@ class TestRecordValidation(TestCase):
                     'exchange': 'foo.bar.com.'
                 }
             })
-        self.assertEquals(['invalid preference "nope"'], ctx.exception.reasons)
+        self.assertEqual(['invalid preference "nope"'], ctx.exception.reasons)
 
         # missing exchange
         with self.assertRaises(ValidationError) as ctx:
@@ -2656,7 +2656,7 @@ class TestRecordValidation(TestCase):
                     'preference': 10,
                 }
             })
-        self.assertEquals(['missing exchange'], ctx.exception.reasons)
+        self.assertEqual(['missing exchange'], ctx.exception.reasons)
 
         # missing trailing .
         with self.assertRaises(ValidationError) as ctx:
@@ -2668,8 +2668,8 @@ class TestRecordValidation(TestCase):
                     'exchange': 'foo.bar.com'
                 }
             })
-        self.assertEquals(['MX value "foo.bar.com" missing trailing .'],
-                          ctx.exception.reasons)
+        self.assertEqual(['MX value "foo.bar.com" missing trailing .'],
+                         ctx.exception.reasons)
 
     def test_NXPTR(self):
         # doesn't blow up
@@ -2705,7 +2705,7 @@ class TestRecordValidation(TestCase):
                     'ttl': 600,
                     'value': v
                 })
-            self.assertEquals([f'missing {k}'], ctx.exception.reasons)
+            self.assertEqual([f'missing {k}'], ctx.exception.reasons)
 
         # non-int order
         v = dict(value)
@@ -2716,7 +2716,7 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': v
             })
-        self.assertEquals(['invalid order "boo"'], ctx.exception.reasons)
+        self.assertEqual(['invalid order "boo"'], ctx.exception.reasons)
 
         # non-int preference
         v = dict(value)
@@ -2727,7 +2727,7 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': v
             })
-        self.assertEquals(['invalid preference "who"'], ctx.exception.reasons)
+        self.assertEqual(['invalid preference "who"'], ctx.exception.reasons)
 
         # unrecognized flags
         v = dict(value)
@@ -2738,7 +2738,7 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': v
             })
-        self.assertEquals(['unrecognized flags "X"'], ctx.exception.reasons)
+        self.assertEqual(['unrecognized flags "X"'], ctx.exception.reasons)
 
     def test_NS(self):
         # doesn't blow up
@@ -2757,7 +2757,7 @@ class TestRecordValidation(TestCase):
                 'type': 'NS',
                 'ttl': 600,
             })
-        self.assertEquals(['missing value(s)'], ctx.exception.reasons)
+        self.assertEqual(['missing value(s)'], ctx.exception.reasons)
 
         # no trailing .
         with self.assertRaises(ValidationError) as ctx:
@@ -2766,8 +2766,8 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': 'foo.bar',
             })
-        self.assertEquals(['NS value "foo.bar" missing trailing .'],
-                          ctx.exception.reasons)
+        self.assertEqual(['NS value "foo.bar" missing trailing .'],
+                         ctx.exception.reasons)
 
     def test_PTR(self):
         # doesn't blow up (name & zone here don't make any sense, but not
@@ -2784,7 +2784,7 @@ class TestRecordValidation(TestCase):
                 'type': 'PTR',
                 'ttl': 600,
             })
-        self.assertEquals(['missing values'], ctx.exception.reasons)
+        self.assertEqual(['missing values'], ctx.exception.reasons)
 
         # not a valid FQDN
         with self.assertRaises(ValidationError) as ctx:
@@ -2793,8 +2793,8 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': '_.',
             })
-        self.assertEquals(['PTR value "_." is not a valid FQDN'],
-                          ctx.exception.reasons)
+        self.assertEqual(['PTR value "_." is not a valid FQDN'],
+                         ctx.exception.reasons)
 
         # no trailing .
         with self.assertRaises(ValidationError) as ctx:
@@ -2803,8 +2803,8 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': 'foo.bar',
             })
-        self.assertEquals(['PTR value "foo.bar" missing trailing .'],
-                          ctx.exception.reasons)
+        self.assertEqual(['PTR value "foo.bar" missing trailing .'],
+                         ctx.exception.reasons)
 
     def test_SSHFP(self):
         # doesn't blow up
@@ -2828,7 +2828,7 @@ class TestRecordValidation(TestCase):
                     'fingerprint': 'bf6b6825d2977c511a475bbefb88aad54a92ac73'
                 }
             })
-        self.assertEquals(['missing algorithm'], ctx.exception.reasons)
+        self.assertEqual(['missing algorithm'], ctx.exception.reasons)
 
         # invalid algorithm
         with self.assertRaises(ValidationError) as ctx:
@@ -2841,7 +2841,7 @@ class TestRecordValidation(TestCase):
                     'fingerprint': 'bf6b6825d2977c511a475bbefb88aad54a92ac73'
                 }
             })
-        self.assertEquals(['invalid algorithm "nope"'], ctx.exception.reasons)
+        self.assertEqual(['invalid algorithm "nope"'], ctx.exception.reasons)
 
         # unrecognized algorithm
         with self.assertRaises(ValidationError) as ctx:
@@ -2854,8 +2854,8 @@ class TestRecordValidation(TestCase):
                     'fingerprint': 'bf6b6825d2977c511a475bbefb88aad54a92ac73'
                 }
             })
-        self.assertEquals(['unrecognized algorithm "42"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['unrecognized algorithm "42"'],
+                         ctx.exception.reasons)
 
         # missing fingerprint_type
         with self.assertRaises(ValidationError) as ctx:
@@ -2867,7 +2867,7 @@ class TestRecordValidation(TestCase):
                     'fingerprint': 'bf6b6825d2977c511a475bbefb88aad54a92ac73'
                 }
             })
-        self.assertEquals(['missing fingerprint_type'], ctx.exception.reasons)
+        self.assertEqual(['missing fingerprint_type'], ctx.exception.reasons)
 
         # invalid fingerprint_type
         with self.assertRaises(ValidationError) as ctx:
@@ -2880,8 +2880,8 @@ class TestRecordValidation(TestCase):
                     'fingerprint': 'bf6b6825d2977c511a475bbefb88aad54a92ac73'
                 }
             })
-        self.assertEquals(['invalid fingerprint_type "yeeah"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['invalid fingerprint_type "yeeah"'],
+                         ctx.exception.reasons)
 
         # unrecognized fingerprint_type
         with self.assertRaises(ValidationError) as ctx:
@@ -2894,8 +2894,8 @@ class TestRecordValidation(TestCase):
                     'fingerprint': 'bf6b6825d2977c511a475bbefb88aad54a92ac73'
                 }
             })
-        self.assertEquals(['unrecognized fingerprint_type "42"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['unrecognized fingerprint_type "42"'],
+                         ctx.exception.reasons)
 
         # missing fingerprint
         with self.assertRaises(ValidationError) as ctx:
@@ -2907,7 +2907,7 @@ class TestRecordValidation(TestCase):
                     'fingerprint_type': 1,
                 }
             })
-        self.assertEquals(['missing fingerprint'], ctx.exception.reasons)
+        self.assertEqual(['missing fingerprint'], ctx.exception.reasons)
 
     def test_SPF(self):
         # doesn't blow up (name & zone here don't make any sense, but not
@@ -2928,7 +2928,7 @@ class TestRecordValidation(TestCase):
                 'type': 'SPF',
                 'ttl': 600,
             })
-        self.assertEquals(['missing value(s)'], ctx.exception.reasons)
+        self.assertEqual(['missing value(s)'], ctx.exception.reasons)
 
         # missing escapes
         with self.assertRaises(ValidationError) as ctx:
@@ -2937,8 +2937,8 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': 'this has some; semi-colons\\; in it',
             })
-        self.assertEquals(['unescaped ; in "this has some; '
-                           'semi-colons\\; in it"'], ctx.exception.reasons)
+        self.assertEqual(['unescaped ; in "this has some; '
+                          'semi-colons\\; in it"'], ctx.exception.reasons)
 
     def test_SRV(self):
         # doesn't blow up
@@ -2977,8 +2977,8 @@ class TestRecordValidation(TestCase):
                     'target': 'foo.bar.baz.'
                 }
             })
-        self.assertEquals(['invalid name for SRV record'],
-                          ctx.exception.reasons)
+        self.assertEqual(['invalid name for SRV record'],
+                         ctx.exception.reasons)
 
         # missing priority
         with self.assertRaises(ValidationError) as ctx:
@@ -2991,7 +2991,7 @@ class TestRecordValidation(TestCase):
                     'target': 'foo.bar.baz.'
                 }
             })
-        self.assertEquals(['missing priority'], ctx.exception.reasons)
+        self.assertEqual(['missing priority'], ctx.exception.reasons)
 
         # invalid priority
         with self.assertRaises(ValidationError) as ctx:
@@ -3005,7 +3005,7 @@ class TestRecordValidation(TestCase):
                     'target': 'foo.bar.baz.'
                 }
             })
-        self.assertEquals(['invalid priority "foo"'], ctx.exception.reasons)
+        self.assertEqual(['invalid priority "foo"'], ctx.exception.reasons)
 
         # missing weight
         with self.assertRaises(ValidationError) as ctx:
@@ -3018,7 +3018,7 @@ class TestRecordValidation(TestCase):
                     'target': 'foo.bar.baz.'
                 }
             })
-        self.assertEquals(['missing weight'], ctx.exception.reasons)
+        self.assertEqual(['missing weight'], ctx.exception.reasons)
         # invalid weight
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, '_srv._tcp', {
@@ -3031,7 +3031,7 @@ class TestRecordValidation(TestCase):
                     'target': 'foo.bar.baz.'
                 }
             })
-        self.assertEquals(['invalid weight "foo"'], ctx.exception.reasons)
+        self.assertEqual(['invalid weight "foo"'], ctx.exception.reasons)
 
         # missing port
         with self.assertRaises(ValidationError) as ctx:
@@ -3044,7 +3044,7 @@ class TestRecordValidation(TestCase):
                     'target': 'foo.bar.baz.'
                 }
             })
-        self.assertEquals(['missing port'], ctx.exception.reasons)
+        self.assertEqual(['missing port'], ctx.exception.reasons)
         # invalid port
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, '_srv._tcp', {
@@ -3057,7 +3057,7 @@ class TestRecordValidation(TestCase):
                     'target': 'foo.bar.baz.'
                 }
             })
-        self.assertEquals(['invalid port "foo"'], ctx.exception.reasons)
+        self.assertEqual(['invalid port "foo"'], ctx.exception.reasons)
 
         # missing target
         with self.assertRaises(ValidationError) as ctx:
@@ -3070,7 +3070,7 @@ class TestRecordValidation(TestCase):
                     'port': 3,
                 }
             })
-        self.assertEquals(['missing target'], ctx.exception.reasons)
+        self.assertEqual(['missing target'], ctx.exception.reasons)
         # invalid target
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, '_srv._tcp', {
@@ -3083,8 +3083,8 @@ class TestRecordValidation(TestCase):
                     'target': 'foo.bar.baz'
                 }
             })
-        self.assertEquals(['SRV value "foo.bar.baz" missing trailing .'],
-                          ctx.exception.reasons)
+        self.assertEqual(['SRV value "foo.bar.baz" missing trailing .'],
+                         ctx.exception.reasons)
 
     def test_TXT(self):
         # doesn't blow up (name & zone here don't make any sense, but not
@@ -3104,7 +3104,7 @@ class TestRecordValidation(TestCase):
                 'type': 'TXT',
                 'ttl': 600,
             })
-        self.assertEquals(['missing value(s)'], ctx.exception.reasons)
+        self.assertEqual(['missing value(s)'], ctx.exception.reasons)
 
         # missing escapes
         with self.assertRaises(ValidationError) as ctx:
@@ -3113,8 +3113,8 @@ class TestRecordValidation(TestCase):
                 'ttl': 600,
                 'value': 'this has some; semi-colons\\; in it',
             })
-        self.assertEquals(['unescaped ; in "this has some; semi-colons\\; '
-                           'in it"'], ctx.exception.reasons)
+        self.assertEqual(['unescaped ; in "this has some; semi-colons\\; '
+                          'in it"'], ctx.exception.reasons)
 
     def test_TXT_long_value_chunking(self):
         expected = '"Lorem ipsum dolor sit amet, consectetur adipiscing ' \
@@ -3145,11 +3145,11 @@ class TestRecordValidation(TestCase):
                 'this has some\\; semi-colons\\; in it',
             ]
         })
-        self.assertEquals(3, len(single.values))
-        self.assertEquals(3, len(single.chunked_values))
+        self.assertEqual(3, len(single.values))
+        self.assertEqual(3, len(single.chunked_values))
         # Note we are checking that this normalizes the chunking, not that we
         # get out what we put in.
-        self.assertEquals(expected, single.chunked_values[0])
+        self.assertEqual(expected, single.chunked_values[0])
 
         long_split_value = '"Lorem ipsum dolor sit amet, consectetur ' \
             'adipiscing elit, sed do eiusmod tempor incididunt ut ' \
@@ -3170,11 +3170,11 @@ class TestRecordValidation(TestCase):
                 '"this has some\\; semi-colons\\; in it"',
             ]
         })
-        self.assertEquals(expected, chunked.chunked_values[0])
+        self.assertEqual(expected, chunked.chunked_values[0])
         # should be single values, no quoting
-        self.assertEquals(single.values, chunked.values)
+        self.assertEqual(single.values, chunked.values)
         # should be chunked values, with quoting
-        self.assertEquals(single.chunked_values, chunked.chunked_values)
+        self.assertEqual(single.chunked_values, chunked.chunked_values)
 
     def test_URLFWD(self):
         # doesn't blow up
@@ -3219,7 +3219,7 @@ class TestRecordValidation(TestCase):
                     'query': 0,
                 }
             })
-        self.assertEquals(['missing path'], ctx.exception.reasons)
+        self.assertEqual(['missing path'], ctx.exception.reasons)
 
         # missing target
         with self.assertRaises(ValidationError) as ctx:
@@ -3233,7 +3233,7 @@ class TestRecordValidation(TestCase):
                     'query': 0,
                 }
             })
-        self.assertEquals(['missing target'], ctx.exception.reasons)
+        self.assertEqual(['missing target'], ctx.exception.reasons)
 
         # missing code
         with self.assertRaises(ValidationError) as ctx:
@@ -3247,7 +3247,7 @@ class TestRecordValidation(TestCase):
                     'query': 0,
                 }
             })
-        self.assertEquals(['missing code'], ctx.exception.reasons)
+        self.assertEqual(['missing code'], ctx.exception.reasons)
 
         # invalid code
         with self.assertRaises(ValidationError) as ctx:
@@ -3262,8 +3262,8 @@ class TestRecordValidation(TestCase):
                     'query': 0,
                 }
             })
-        self.assertEquals(['invalid return code "nope"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['invalid return code "nope"'],
+                         ctx.exception.reasons)
 
         # unrecognized code
         with self.assertRaises(ValidationError) as ctx:
@@ -3278,8 +3278,8 @@ class TestRecordValidation(TestCase):
                     'query': 0,
                 }
             })
-        self.assertEquals(['unrecognized return code "3"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['unrecognized return code "3"'],
+                         ctx.exception.reasons)
 
         # missing masking
         with self.assertRaises(ValidationError) as ctx:
@@ -3293,7 +3293,7 @@ class TestRecordValidation(TestCase):
                     'query': 0,
                 }
             })
-        self.assertEquals(['missing masking'], ctx.exception.reasons)
+        self.assertEqual(['missing masking'], ctx.exception.reasons)
 
         # invalid masking
         with self.assertRaises(ValidationError) as ctx:
@@ -3308,8 +3308,8 @@ class TestRecordValidation(TestCase):
                     'query': 0,
                 }
             })
-        self.assertEquals(['invalid masking setting "nope"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['invalid masking setting "nope"'],
+                         ctx.exception.reasons)
 
         # unrecognized masking
         with self.assertRaises(ValidationError) as ctx:
@@ -3324,8 +3324,8 @@ class TestRecordValidation(TestCase):
                     'query': 0,
                 }
             })
-        self.assertEquals(['unrecognized masking setting "3"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['unrecognized masking setting "3"'],
+                         ctx.exception.reasons)
 
         # missing query
         with self.assertRaises(ValidationError) as ctx:
@@ -3339,7 +3339,7 @@ class TestRecordValidation(TestCase):
                     'masking': 2,
                 }
             })
-        self.assertEquals(['missing query'], ctx.exception.reasons)
+        self.assertEqual(['missing query'], ctx.exception.reasons)
 
         # invalid query
         with self.assertRaises(ValidationError) as ctx:
@@ -3354,8 +3354,8 @@ class TestRecordValidation(TestCase):
                     'query': 'nope',
                 }
             })
-        self.assertEquals(['invalid query setting "nope"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['invalid query setting "nope"'],
+                         ctx.exception.reasons)
 
         # unrecognized query
         with self.assertRaises(ValidationError) as ctx:
@@ -3370,8 +3370,8 @@ class TestRecordValidation(TestCase):
                     'query': 3,
                 }
             })
-        self.assertEquals(['unrecognized query setting "3"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['unrecognized query setting "3"'],
+                         ctx.exception.reasons)
 
 
 class TestDynamicRecords(TestCase):
@@ -3422,21 +3422,21 @@ class TestDynamicRecords(TestCase):
             ],
         }
         a = ARecord(self.zone, 'weighted', a_data)
-        self.assertEquals('A', a._type)
-        self.assertEquals(a_data['ttl'], a.ttl)
-        self.assertEquals(a_data['values'], a.values)
+        self.assertEqual('A', a._type)
+        self.assertEqual(a_data['ttl'], a.ttl)
+        self.assertEqual(a_data['values'], a.values)
 
         dynamic = a.dynamic
         self.assertTrue(dynamic)
 
         pools = dynamic.pools
         self.assertTrue(pools)
-        self.assertEquals({
+        self.assertEqual({
             'value': '3.3.3.3',
             'weight': 1,
             'status': 'obey',
         }, pools['one'].data['values'][0])
-        self.assertEquals([{
+        self.assertEqual([{
             'value': '4.4.4.4',
             'weight': 1,
             'status': 'obey',
@@ -3445,7 +3445,7 @@ class TestDynamicRecords(TestCase):
             'weight': 1,
             'status': 'obey',
         }], pools['two'].data['values'])
-        self.assertEquals([{
+        self.assertEqual([{
             'weight': 10,
             'value': '4.4.4.4',
             'status': 'obey',
@@ -3457,7 +3457,7 @@ class TestDynamicRecords(TestCase):
 
         rules = dynamic.rules
         self.assertTrue(rules)
-        self.assertEquals(a_data['dynamic']['rules'][0], rules[0].data)
+        self.assertEqual(a_data['dynamic']['rules'][0], rules[0].data)
 
     def test_simple_aaaa_weighted(self):
         aaaa_data = {
@@ -3530,21 +3530,21 @@ class TestDynamicRecords(TestCase):
             ],
         }
         aaaa = AaaaRecord(self.zone, 'weighted', aaaa_data)
-        self.assertEquals('AAAA', aaaa._type)
-        self.assertEquals(aaaa_data['ttl'], aaaa.ttl)
-        self.assertEquals(aaaa_data['values'], aaaa.values)
+        self.assertEqual('AAAA', aaaa._type)
+        self.assertEqual(aaaa_data['ttl'], aaaa.ttl)
+        self.assertEqual(aaaa_data['values'], aaaa.values)
 
         dynamic = aaaa.dynamic
         self.assertTrue(dynamic)
 
         pools = dynamic.pools
         self.assertTrue(pools)
-        self.assertEquals({
+        self.assertEqual({
             'value': '2601:642:500:e210:62f8:1dff:feb8:9473',
             'weight': 1,
             'status': 'obey',
         }, pools['one'].data['values'][0])
-        self.assertEquals([{
+        self.assertEqual([{
             'value': '2601:642:500:e210:62f8:1dff:feb8:9474',
             'weight': 1,
             'status': 'obey',
@@ -3553,7 +3553,7 @@ class TestDynamicRecords(TestCase):
             'weight': 1,
             'status': 'obey',
         }], pools['two'].data['values'])
-        self.assertEquals([{
+        self.assertEqual([{
             'weight': 10,
             'value': '2601:642:500:e210:62f8:1dff:feb8:9476',
             'status': 'obey',
@@ -3565,7 +3565,7 @@ class TestDynamicRecords(TestCase):
 
         rules = dynamic.rules
         self.assertTrue(rules)
-        self.assertEquals(aaaa_data['dynamic']['rules'][0], rules[0].data)
+        self.assertEqual(aaaa_data['dynamic']['rules'][0], rules[0].data)
 
     def test_simple_cname_weighted(self):
         cname_data = {
@@ -3605,26 +3605,26 @@ class TestDynamicRecords(TestCase):
             'value': 'cname.target.',
         }
         cname = CnameRecord(self.zone, 'weighted', cname_data)
-        self.assertEquals('CNAME', cname._type)
-        self.assertEquals(cname_data['ttl'], cname.ttl)
-        self.assertEquals(cname_data['value'], cname.value)
+        self.assertEqual('CNAME', cname._type)
+        self.assertEqual(cname_data['ttl'], cname.ttl)
+        self.assertEqual(cname_data['value'], cname.value)
 
         dynamic = cname.dynamic
         self.assertTrue(dynamic)
 
         pools = dynamic.pools
         self.assertTrue(pools)
-        self.assertEquals({
+        self.assertEqual({
             'value': 'one.cname.target.',
             'weight': 1,
             'status': 'obey',
         }, pools['one'].data['values'][0])
-        self.assertEquals({
+        self.assertEqual({
             'value': 'two.cname.target.',
             'weight': 1,
             'status': 'obey',
         }, pools['two'].data['values'][0])
-        self.assertEquals([{
+        self.assertEqual([{
             'value': 'three-1.cname.target.',
             'weight': 12,
             'status': 'obey',
@@ -3636,7 +3636,7 @@ class TestDynamicRecords(TestCase):
 
         rules = dynamic.rules
         self.assertTrue(rules)
-        self.assertEquals(cname_data['dynamic']['rules'][0], rules[0].data)
+        self.assertEqual(cname_data['dynamic']['rules'][0], rules[0].data)
 
     def test_dynamic_validation(self):
         # Missing pools
@@ -3655,8 +3655,8 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals(['missing pools', 'rule 1 undefined pool "one"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['missing pools', 'rule 1 undefined pool "one"'],
+                         ctx.exception.reasons)
 
         # Empty pools
         a_data = {
@@ -3676,8 +3676,8 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals(['missing pools', 'rule 1 undefined pool "one"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['missing pools', 'rule 1 undefined pool "one"'],
+                         ctx.exception.reasons)
 
         # pools not a dict
         a_data = {
@@ -3696,9 +3696,9 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals(['pools must be a dict',
-                           'rule 1 undefined pool "one"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['pools must be a dict',
+                          'rule 1 undefined pool "one"'],
+                         ctx.exception.reasons)
 
         # Invalid addresses
         a_data = {
@@ -3747,7 +3747,7 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals([
+        self.assertEqual([
             'invalid IPv4 address "this-aint-right"',
             'invalid IPv4 address "yet-another-bad-one"',
             'invalid IPv4 address "nor-is-this"',
@@ -3794,8 +3794,8 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals(['pool "one" is missing values'],
-                          ctx.exception.reasons)
+        self.assertEqual(['pool "one" is missing values'],
+                         ctx.exception.reasons)
 
         # pool value not a dict
         a_data = {
@@ -3838,8 +3838,8 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals(['pool "one" must be a dict'],
-                          ctx.exception.reasons)
+        self.assertEqual(['pool "one" must be a dict'],
+                         ctx.exception.reasons)
 
         # empty pool value
         a_data = {
@@ -3882,8 +3882,8 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals(['pool "one" is missing values'],
-                          ctx.exception.reasons)
+        self.assertEqual(['pool "one" is missing values'],
+                         ctx.exception.reasons)
 
         # invalid int weight
         a_data = {
@@ -3930,8 +3930,8 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals(['invalid weight "101" in pool "three" value 2'],
-                          ctx.exception.reasons)
+        self.assertEqual(['invalid weight "101" in pool "three" value 2'],
+                         ctx.exception.reasons)
 
         # invalid non-int weight
         a_data = {
@@ -3978,8 +3978,8 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals(['invalid weight "foo" in pool "three" value 2'],
-                          ctx.exception.reasons)
+        self.assertEqual(['invalid weight "foo" in pool "three" value 2'],
+                         ctx.exception.reasons)
 
         # single value with weight!=1
         a_data = {
@@ -4005,8 +4005,8 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals(['pool "one" has single value with weight!=1'],
-                          ctx.exception.reasons)
+        self.assertEqual(['pool "one" has single value with weight!=1'],
+                         ctx.exception.reasons)
 
         # invalid fallback
         a_data = {
@@ -4055,8 +4055,8 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals(['undefined fallback "invalid" for pool "two"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['undefined fallback "invalid" for pool "two"'],
+                         ctx.exception.reasons)
 
         # fallback loop
         a_data = {
@@ -4106,7 +4106,7 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals([
+        self.assertEqual([
             'loop in pool fallbacks: one -> three -> two',
             'loop in pool fallbacks: three -> two -> one',
             'loop in pool fallbacks: two -> one -> three'
@@ -4152,7 +4152,7 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals([
+        self.assertEqual([
             'pool "one" must be a dict',
             'missing value in pool "three" value 1',
             'invalid weight "5000" in pool "three" value 2',
@@ -4186,7 +4186,7 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals([
+        self.assertEqual([
             'missing rules',
             'unused pools: "one", "two"',
         ], ctx.exception.reasons)
@@ -4219,7 +4219,7 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals([
+        self.assertEqual([
             'missing rules',
             'unused pools: "one", "two"',
         ], ctx.exception.reasons)
@@ -4252,7 +4252,7 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals([
+        self.assertEqual([
             'rules must be a list',
             'unused pools: "one", "two"',
         ], ctx.exception.reasons)
@@ -4289,7 +4289,7 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals([
+        self.assertEqual([
             'rule 1 missing pool',
             'unused pools: "two"',
         ], ctx.exception.reasons)
@@ -4327,7 +4327,7 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals([
+        self.assertEqual([
             'rule 1 invalid pool "[]"',
             'unused pools: "two"',
         ], ctx.exception.reasons)
@@ -4365,7 +4365,7 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals([
+        self.assertEqual([
             "rule 1 undefined pool \"non-existent\"",
             'unused pools: "two"',
         ], ctx.exception.reasons)
@@ -4403,8 +4403,8 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals(['rule 1 geos must be a list'],
-                          ctx.exception.reasons)
+        self.assertEqual(['rule 1 geos must be a list'],
+                         ctx.exception.reasons)
 
         # rule with invalid geo
         a_data = {
@@ -4439,8 +4439,8 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals(['rule 1 unknown continent code "invalid"'],
-                          ctx.exception.reasons)
+        self.assertEqual(['rule 1 unknown continent code "invalid"'],
+                         ctx.exception.reasons)
 
         # multiple default rules
         a_data = {
@@ -4474,8 +4474,8 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals(['rule 2 duplicate default'],
-                          ctx.exception.reasons)
+        self.assertEqual(['rule 2 duplicate default'],
+                         ctx.exception.reasons)
 
         # repeated pool in rules
         a_data = {
@@ -4514,8 +4514,8 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals(['rule 3 invalid, target pool "one" reused'],
-                          ctx.exception.reasons)
+        self.assertEqual(['rule 3 invalid, target pool "one" reused'],
+                         ctx.exception.reasons)
 
         # Repeated pool is OK if later one is a default
         a_data = {
@@ -4596,7 +4596,7 @@ class TestDynamicRecords(TestCase):
             ],
         }
         a = Record.new(self.zone, 'bad', a_data, lenient=True)
-        self.assertEquals({
+        self.assertEqual({
             'pools': {},
             'rules': a_data['dynamic']['rules'],
         }, a._data()['dynamic'])
@@ -4628,7 +4628,7 @@ class TestDynamicRecords(TestCase):
             ],
         }
         a = Record.new(self.zone, 'bad', a_data, lenient=True)
-        self.assertEquals({
+        self.assertEqual({
             'pools': {
                 'one': {
                     'fallback': None,
@@ -4686,7 +4686,7 @@ class TestDynamicRecords(TestCase):
             ],
         }
         a = Record.new(self.zone, 'bad', a_data, lenient=True)
-        self.assertEquals({
+        self.assertEqual({
             'pools': {
                 'one': {
                     'fallback': None,
@@ -4819,13 +4819,13 @@ class TestDynamicRecords(TestCase):
         self.assertFalse(a.changes(b, simple))
         # but is true for dynamic
         update = a.changes(b, dynamic)
-        self.assertEquals(a, update.existing)
-        self.assertEquals(b, update.new)
+        self.assertEqual(a, update.existing)
+        self.assertEqual(b, update.new)
         # transitive
         self.assertFalse(b.changes(a, simple))
         update = b.changes(a, dynamic)
-        self.assertEquals(a, update.existing)
-        self.assertEquals(b, update.new)
+        self.assertEqual(a, update.existing)
+        self.assertEqual(b, update.new)
 
         # same for a change c
         self.assertFalse(a.changes(c, simple))
@@ -4834,12 +4834,12 @@ class TestDynamicRecords(TestCase):
         self.assertTrue(c.changes(a, dynamic))
 
         # smoke test some of the equiality bits
-        self.assertEquals(a.dynamic.pools, a.dynamic.pools)
-        self.assertEquals(a.dynamic.pools['one'], a.dynamic.pools['one'])
-        self.assertNotEquals(a.dynamic.pools['one'], a.dynamic.pools['two'])
-        self.assertEquals(a.dynamic.rules, a.dynamic.rules)
-        self.assertEquals(a.dynamic.rules[0], a.dynamic.rules[0])
-        self.assertNotEquals(a.dynamic.rules[0], c.dynamic.rules[0])
+        self.assertEqual(a.dynamic.pools, a.dynamic.pools)
+        self.assertEqual(a.dynamic.pools['one'], a.dynamic.pools['one'])
+        self.assertNotEqual(a.dynamic.pools['one'], a.dynamic.pools['two'])
+        self.assertEqual(a.dynamic.rules, a.dynamic.rules)
+        self.assertEqual(a.dynamic.rules[0], a.dynamic.rules[0])
+        self.assertNotEqual(a.dynamic.rules[0], c.dynamic.rules[0])
 
     def test_dynamic_and_geo_validation(self):
         a_data = {
@@ -4891,8 +4891,8 @@ class TestDynamicRecords(TestCase):
         }
         with self.assertRaises(ValidationError) as ctx:
             Record.new(self.zone, 'bad', a_data)
-        self.assertEquals(['"dynamic" record with "geo" content'],
-                          ctx.exception.reasons)
+        self.assertEqual(['"dynamic" record with "geo" content'],
+                         ctx.exception.reasons)
 
     def test_dynamic_eqs(self):
 
@@ -4906,9 +4906,9 @@ class TestDynamicRecords(TestCase):
                 'value': '1.2.3.5',
             }],
         })
-        self.assertEquals(pool_one, pool_one)
-        self.assertNotEquals(pool_one, pool_two)
-        self.assertNotEquals(pool_one, 42)
+        self.assertEqual(pool_one, pool_one)
+        self.assertNotEqual(pool_one, pool_two)
+        self.assertNotEqual(pool_one, 42)
 
         pools = {
             'one': pool_one,
@@ -4920,9 +4920,9 @@ class TestDynamicRecords(TestCase):
         rule_two = _DynamicRule(1, {
             'pool': 'two',
         })
-        self.assertEquals(rule_one, rule_one)
-        self.assertNotEquals(rule_one, rule_two)
-        self.assertNotEquals(rule_one, 42)
+        self.assertEqual(rule_one, rule_one)
+        self.assertNotEqual(rule_one, rule_two)
+        self.assertNotEqual(rule_one, 42)
         rules = [
             rule_one,
             rule_two,
@@ -4930,6 +4930,6 @@ class TestDynamicRecords(TestCase):
 
         dynamic = _Dynamic(pools, rules)
         other = _Dynamic({}, [])
-        self.assertEquals(dynamic, dynamic)
-        self.assertNotEquals(dynamic, other)
-        self.assertNotEquals(dynamic, 42)
+        self.assertEqual(dynamic, dynamic)
+        self.assertNotEqual(dynamic, other)
+        self.assertNotEqual(dynamic, 42)

--- a/tests/test_octodns_record_geo.py
+++ b/tests/test_octodns_record_geo.py
@@ -16,67 +16,67 @@ class TestRecordGeoCodes(TestCase):
         prefix = 'xyz '
 
         # All valid
-        self.assertEquals([], GeoCodes.validate('NA', prefix))
-        self.assertEquals([], GeoCodes.validate('NA-US', prefix))
-        self.assertEquals([], GeoCodes.validate('NA-US-OR', prefix))
+        self.assertEqual([], GeoCodes.validate('NA', prefix))
+        self.assertEqual([], GeoCodes.validate('NA-US', prefix))
+        self.assertEqual([], GeoCodes.validate('NA-US-OR', prefix))
 
         # Just plain bad
-        self.assertEquals(['xyz invalid geo code "XX-YY-ZZ-AA"'],
-                          GeoCodes.validate('XX-YY-ZZ-AA', prefix))
-        self.assertEquals(['xyz unknown continent code "X-Y-Z"'],
-                          GeoCodes.validate('X-Y-Z', prefix))
-        self.assertEquals(['xyz unknown continent code "XXX-Y-Z"'],
-                          GeoCodes.validate('XXX-Y-Z', prefix))
+        self.assertEqual(['xyz invalid geo code "XX-YY-ZZ-AA"'],
+                         GeoCodes.validate('XX-YY-ZZ-AA', prefix))
+        self.assertEqual(['xyz unknown continent code "X-Y-Z"'],
+                         GeoCodes.validate('X-Y-Z', prefix))
+        self.assertEqual(['xyz unknown continent code "XXX-Y-Z"'],
+                         GeoCodes.validate('XXX-Y-Z', prefix))
 
         # Bad continent
-        self.assertEquals(['xyz unknown continent code "XX"'],
-                          GeoCodes.validate('XX', prefix))
+        self.assertEqual(['xyz unknown continent code "XX"'],
+                         GeoCodes.validate('XX', prefix))
         # Bad continent good country
-        self.assertEquals(['xyz unknown continent code "XX-US"'],
-                          GeoCodes.validate('XX-US', prefix))
+        self.assertEqual(['xyz unknown continent code "XX-US"'],
+                         GeoCodes.validate('XX-US', prefix))
         # Bad continent good country and province
-        self.assertEquals(['xyz unknown continent code "XX-US-OR"'],
-                          GeoCodes.validate('XX-US-OR', prefix))
+        self.assertEqual(['xyz unknown continent code "XX-US-OR"'],
+                         GeoCodes.validate('XX-US-OR', prefix))
 
         # Bad country, good continent
-        self.assertEquals(['xyz unknown country code "NA-XX"'],
-                          GeoCodes.validate('NA-XX', prefix))
+        self.assertEqual(['xyz unknown country code "NA-XX"'],
+                         GeoCodes.validate('NA-XX', prefix))
         # Bad country, good continent and state
-        self.assertEquals(['xyz unknown country code "NA-XX-OR"'],
-                          GeoCodes.validate('NA-XX-OR', prefix))
+        self.assertEqual(['xyz unknown country code "NA-XX-OR"'],
+                         GeoCodes.validate('NA-XX-OR', prefix))
         # Good country, good continent, but bad match
-        self.assertEquals(['xyz unknown country code "NA-GB"'],
-                          GeoCodes.validate('NA-GB', prefix))
+        self.assertEqual(['xyz unknown country code "NA-GB"'],
+                         GeoCodes.validate('NA-GB', prefix))
 
         # Bad province code, good continent and country
-        self.assertEquals(['xyz unknown province code "NA-US-XX"'],
-                          GeoCodes.validate('NA-US-XX', prefix))
+        self.assertEqual(['xyz unknown province code "NA-US-XX"'],
+                         GeoCodes.validate('NA-US-XX', prefix))
 
     def test_parse(self):
-        self.assertEquals({
+        self.assertEqual({
             'continent_code': 'NA',
             'country_code': None,
             'province_code': None,
         }, GeoCodes.parse('NA'))
-        self.assertEquals({
+        self.assertEqual({
             'continent_code': 'NA',
             'country_code': 'US',
             'province_code': None,
         }, GeoCodes.parse('NA-US'))
-        self.assertEquals({
+        self.assertEqual({
             'continent_code': 'NA',
             'country_code': 'US',
             'province_code': 'CA',
         }, GeoCodes.parse('NA-US-CA'))
 
     def test_country_to_code(self):
-        self.assertEquals('NA-US', GeoCodes.country_to_code('US'))
-        self.assertEquals('EU-GB', GeoCodes.country_to_code('GB'))
+        self.assertEqual('NA-US', GeoCodes.country_to_code('US'))
+        self.assertEqual('EU-GB', GeoCodes.country_to_code('GB'))
         self.assertFalse(GeoCodes.country_to_code('XX'))
 
     def test_province_to_code(self):
-        self.assertEquals('NA-US-OR', GeoCodes.province_to_code('OR'))
-        self.assertEquals('NA-US-KY', GeoCodes.province_to_code('KY'))
-        self.assertEquals('NA-CA-AB', GeoCodes.province_to_code('AB'))
-        self.assertEquals('NA-CA-BC', GeoCodes.province_to_code('BC'))
+        self.assertEqual('NA-US-OR', GeoCodes.province_to_code('OR'))
+        self.assertEqual('NA-US-KY', GeoCodes.province_to_code('KY'))
+        self.assertEqual('NA-CA-AB', GeoCodes.province_to_code('AB'))
+        self.assertEqual('NA-CA-BC', GeoCodes.province_to_code('BC'))
         self.assertFalse(GeoCodes.province_to_code('XX'))

--- a/tests/test_octodns_source_axfr.py
+++ b/tests/test_octodns_source_axfr.py
@@ -35,13 +35,13 @@ class TestAxfrSource(TestCase):
         ]
 
         self.source.populate(got)
-        self.assertEquals(15, len(got.records))
+        self.assertEqual(15, len(got.records))
 
         with self.assertRaises(AxfrSourceZoneTransferFailed) as ctx:
             zone = Zone('unit.tests.', [])
             self.source.populate(zone)
-        self.assertEquals('Unable to Perform Zone Transfer',
-                          str(ctx.exception))
+        self.assertEqual('Unable to Perform Zone Transfer',
+                         str(ctx.exception))
 
 
 class TestZoneFileSource(TestCase):
@@ -52,7 +52,7 @@ class TestZoneFileSource(TestCase):
         # Load zonefiles with a specified file extension
         valid = Zone('ext.unit.tests.', [])
         source.populate(valid)
-        self.assertEquals(1, len(valid.records))
+        self.assertEqual(1, len(valid.records))
 
     def test_zonefiles_without_extension(self):
         # Windows doesn't let files end with a `.` so we add a .tst to them in
@@ -72,18 +72,18 @@ class TestZoneFileSource(TestCase):
         # Load zonefiles without a specified file extension
         valid = Zone('unit.tests.', [])
         source.populate(valid)
-        self.assertEquals(15, len(valid.records))
+        self.assertEqual(15, len(valid.records))
 
     def test_populate(self):
         # Valid zone file in directory
         valid = Zone('unit.tests.', [])
         self.source.populate(valid)
-        self.assertEquals(15, len(valid.records))
+        self.assertEqual(15, len(valid.records))
 
         # 2nd populate does not read file again
         again = Zone('unit.tests.', [])
         self.source.populate(again)
-        self.assertEquals(15, len(again.records))
+        self.assertEqual(15, len(again.records))
 
         # bust the cache
         del self.source._zone_records[valid.name]
@@ -91,24 +91,24 @@ class TestZoneFileSource(TestCase):
         # No zone file in directory
         missing = Zone('missing.zone.', [])
         self.source.populate(missing)
-        self.assertEquals(0, len(missing.records))
+        self.assertEqual(0, len(missing.records))
 
         # Zone file is not valid
         with self.assertRaises(ZoneFileSourceLoadFailure) as ctx:
             zone = Zone('invalid.zone.', [])
             self.source.populate(zone)
-        self.assertEquals('The DNS zone has no NS RRset at its origin.',
-                          str(ctx.exception))
+        self.assertEqual('The DNS zone has no NS RRset at its origin.',
+                         str(ctx.exception))
 
         # Records are not to RFC (lenient=False)
         with self.assertRaises(ValidationError) as ctx:
             zone = Zone('invalid.records.', [])
             self.source.populate(zone)
-        self.assertEquals('Invalid record _invalid.invalid.records.\n'
-                          '  - invalid name for SRV record',
-                          str(ctx.exception))
+        self.assertEqual('Invalid record _invalid.invalid.records.\n'
+                         '  - invalid name for SRV record',
+                         str(ctx.exception))
 
         # Records are not to RFC, but load anyhow (lenient=True)
         invalid = Zone('invalid.records.', [])
         self.source.populate(invalid, lenient=True)
-        self.assertEquals(12, len(invalid.records))
+        self.assertEqual(12, len(invalid.records))

--- a/tests/test_octodns_source_envvar.py
+++ b/tests/test_octodns_source_envvar.py
@@ -14,11 +14,11 @@ class TestEnvVarSource(TestCase):
         with self.assertRaises(EnvironmentVariableNotFoundException) as ctx:
             source._read_variable()
         msg = f'Unknown environment variable {envvar}'
-        self.assertEquals(msg, str(ctx.exception))
+        self.assertEqual(msg, str(ctx.exception))
 
         with patch.dict('os.environ', {envvar: 'testvalue'}):
             value = source._read_variable()
-        self.assertEquals(value, 'testvalue')
+        self.assertEqual(value, 'testvalue')
 
     def test_populate(self):
         envvar = 'TEST_VAR'
@@ -31,10 +31,10 @@ class TestEnvVarSource(TestCase):
         with patch.dict('os.environ', {envvar: value}):
             source.populate(zone)
 
-        self.assertEquals(1, len(zone.records))
+        self.assertEqual(1, len(zone.records))
         record = list(zone.records)[0]
-        self.assertEquals(name, record.name)
-        self.assertEquals(f'{name}.{zone_name}', record.fqdn)
-        self.assertEquals('TXT', record._type)
-        self.assertEquals(1, len(record.values))
-        self.assertEquals(value, record.values[0])
+        self.assertEqual(name, record.name)
+        self.assertEqual(f'{name}.{zone_name}', record.fqdn)
+        self.assertEqual('TXT', record._type)
+        self.assertEqual(1, len(record.values))
+        self.assertEqual(value, record.values[0])

--- a/tests/test_octodns_source_tinydns.py
+++ b/tests/test_octodns_source_tinydns.py
@@ -20,7 +20,7 @@ class TestTinyDnsFileSource(TestCase):
     def test_populate_normal(self):
         got = Zone('example.com.', [])
         self.source.populate(got)
-        self.assertEquals(17, len(got.records))
+        self.assertEqual(17, len(got.records))
 
         expected = Zone('example.com.', [])
         for name, data in (
@@ -121,12 +121,12 @@ class TestTinyDnsFileSource(TestCase):
             expected.add_record(record)
 
         changes = expected.changes(got, SimpleProvider())
-        self.assertEquals([], changes)
+        self.assertEqual([], changes)
 
     def test_populate_normal_sub1(self):
         got = Zone('asdf.subtest.com.', [])
         self.source.populate(got)
-        self.assertEquals(1, len(got.records))
+        self.assertEqual(1, len(got.records))
 
         expected = Zone('asdf.subtest.com.', [])
         for name, data in (
@@ -140,12 +140,12 @@ class TestTinyDnsFileSource(TestCase):
             expected.add_record(record)
 
         changes = expected.changes(got, SimpleProvider())
-        self.assertEquals([], changes)
+        self.assertEqual([], changes)
 
     def test_populate_normal_sub2(self):
         got = Zone('blah-asdf.subtest.com.', [])
         self.source.populate(got)
-        self.assertEquals(2, len(got.records))
+        self.assertEqual(2, len(got.records))
 
         expected = Zone('sub-asdf.subtest.com.', [])
         for name, data in (
@@ -164,7 +164,7 @@ class TestTinyDnsFileSource(TestCase):
             expected.add_record(record)
 
         changes = expected.changes(got, SimpleProvider())
-        self.assertEquals([], changes)
+        self.assertEqual([], changes)
 
     def test_populate_in_addr_arpa(self):
 
@@ -198,9 +198,9 @@ class TestTinyDnsFileSource(TestCase):
             expected.add_record(record)
 
         changes = expected.changes(got, SimpleProvider())
-        self.assertEquals([], changes)
+        self.assertEqual([], changes)
 
     def test_ignores_subs(self):
         got = Zone('example.com.', ['sub'])
         self.source.populate(got)
-        self.assertEquals(16, len(got.records))
+        self.assertEqual(16, len(got.records))

--- a/tests/test_octodns_yaml.py
+++ b/tests/test_octodns_yaml.py
@@ -15,7 +15,7 @@ from octodns.yaml import safe_dump, safe_load
 class TestYaml(TestCase):
 
     def test_stuff(self):
-        self.assertEquals({
+        self.assertEqual({
             1: 'a',
             2: 'b',
             '3': 'c',
@@ -29,7 +29,7 @@ class TestYaml(TestCase):
 '11': e
 '''))
 
-        self.assertEquals({
+        self.assertEqual({
             '*.1.2': 'a',
             '*.2.2': 'b',
             '*.10.1': 'c',
@@ -57,8 +57,8 @@ class TestYaml(TestCase):
             '*.11.1': 43,
             '*.2.1': 44,
         }, buf)
-        self.assertEquals("---\n'*.1.1': 42\n'*.2.1': 44\n'*.11.1': 43\n",
-                          buf.getvalue())
+        self.assertEqual("---\n'*.1.1': 42\n'*.2.1': 44\n'*.11.1': 43\n",
+                         buf.getvalue())
 
         # hex sorting isn't ideal, not treated as hex, this make sure we don't
         # change the behavior
@@ -67,4 +67,4 @@ class TestYaml(TestCase):
             '45a03129': 42,
             '45a0392a': 43,
         }, buf)
-        self.assertEquals("---\n45a0392a: 43\n45a03129: 42\n", buf.getvalue())
+        self.assertEqual("---\n45a0392a: 43\n45a03129: 42\n", buf.getvalue())

--- a/tests/test_octodns_zone.py
+++ b/tests/test_octodns_zone.py
@@ -18,7 +18,7 @@ class TestZone(TestCase):
 
     def test_lowering(self):
         zone = Zone('UniT.TEsTs.', [])
-        self.assertEquals('unit.tests.', zone.name)
+        self.assertEqual('unit.tests.', zone.name)
 
     def test_hostname_from_fqdn(self):
         zone = Zone('unit.tests.', [])
@@ -32,7 +32,7 @@ class TestZone(TestCase):
             ('foo.unit.tests', 'foo.unit.tests.unit.tests.'),
             ('foo.unit.tests', 'foo.unit.tests.unit.tests'),
         ):
-            self.assertEquals(hostname, zone.hostname_from_fqdn(fqdn))
+            self.assertEqual(hostname, zone.hostname_from_fqdn(fqdn))
 
     def test_add_record(self):
         zone = Zone('unit.tests.', [])
@@ -42,21 +42,21 @@ class TestZone(TestCase):
         c = ARecord(zone, 'a', {'ttl': 43, 'value': '2.2.2.2'})
 
         zone.add_record(a)
-        self.assertEquals(zone.records, set([a]))
+        self.assertEqual(zone.records, set([a]))
         # Can't add record with same name & type
         with self.assertRaises(DuplicateRecordException) as ctx:
             zone.add_record(a)
-        self.assertEquals('Duplicate record a.unit.tests., type A',
-                          str(ctx.exception))
-        self.assertEquals(zone.records, set([a]))
+        self.assertEqual('Duplicate record a.unit.tests., type A',
+                         str(ctx.exception))
+        self.assertEqual(zone.records, set([a]))
 
         # can add duplicate with replace=True
         zone.add_record(c, replace=True)
-        self.assertEquals('2.2.2.2', list(zone.records)[0].values[0])
+        self.assertEqual('2.2.2.2', list(zone.records)[0].values[0])
 
         # Can add dup name, with different type
         zone.add_record(b)
-        self.assertEquals(zone.records, set([a, b]))
+        self.assertEqual(zone.records, set([a, b]))
 
     def test_changes(self):
         before = Zone('unit.tests.', [])
@@ -78,17 +78,17 @@ class TestZone(TestCase):
         c = ARecord(before, 'c', {'ttl': 42, 'value': '1.1.1.1'})
         after.add_record(c)
         after._remove_record(b)
-        self.assertEquals(after.records, set([a, c]))
+        self.assertEqual(after.records, set([a, c]))
         changes = before.changes(after, target)
-        self.assertEquals(2, len(changes))
+        self.assertEqual(2, len(changes))
         for change in changes:
             if isinstance(change, Create):
                 create = change
             elif isinstance(change, Delete):
                 delete = change
-        self.assertEquals(b, delete.existing)
+        self.assertEqual(b, delete.existing)
         self.assertFalse(delete.new)
-        self.assertEquals(c, create.new)
+        self.assertEqual(c, create.new)
         self.assertFalse(create.existing)
         delete.__repr__()
         create.__repr__()
@@ -98,7 +98,7 @@ class TestZone(TestCase):
         after.add_record(changed)
         after.add_record(b)
         changes = before.changes(after, target)
-        self.assertEquals(1, len(changes))
+        self.assertEqual(1, len(changes))
         update = changes[0]
         self.assertIsInstance(update, Update)
         # Using changes here to get a full equality
@@ -126,12 +126,12 @@ class TestZone(TestCase):
 
         # Only create the supported A, not the AAAA
         changes = current.changes(desired, NoAaaaProvider())
-        self.assertEquals(1, len(changes))
+        self.assertEqual(1, len(changes))
         self.assertIsInstance(changes[0], Create)
 
         # Only delete the supported A, not the AAAA
         changes = desired.changes(current, NoAaaaProvider())
-        self.assertEquals(1, len(changes))
+        self.assertEqual(1, len(changes))
         self.assertIsInstance(changes[0], Delete)
 
     def test_missing_dot(self):
@@ -149,7 +149,7 @@ class TestZone(TestCase):
             'values': ['1.2.3.4.', '2.3.4.5.'],
         })
         zone.add_record(record)
-        self.assertEquals(set([record]), zone.records)
+        self.assertEqual(set([record]), zone.records)
 
         # non-NS for exactly the sub is rejected
         zone = Zone('unit.tests.', set(['sub', 'barred']))
@@ -163,7 +163,7 @@ class TestZone(TestCase):
         self.assertTrue('not of type NS', str(ctx.exception))
         # Can add it w/lenient
         zone.add_record(record, lenient=True)
-        self.assertEquals(set([record]), zone.records)
+        self.assertEqual(set([record]), zone.records)
 
         # NS for something below the sub is rejected
         zone = Zone('unit.tests.', set(['sub', 'barred']))
@@ -177,7 +177,7 @@ class TestZone(TestCase):
         self.assertTrue('under a managed sub-zone', str(ctx.exception))
         # Can add it w/lenient
         zone.add_record(record, lenient=True)
-        self.assertEquals(set([record]), zone.records)
+        self.assertEqual(set([record]), zone.records)
 
         # A for something below the sub is rejected
         zone = Zone('unit.tests.', set(['sub', 'barred']))
@@ -191,7 +191,7 @@ class TestZone(TestCase):
         self.assertTrue('under a managed sub-zone', str(ctx.exception))
         # Can add it w/lenient
         zone.add_record(record, lenient=True)
-        self.assertEquals(set([record]), zone.records)
+        self.assertEqual(set([record]), zone.records)
 
     def test_ignored_records(self):
         zone_normal = Zone('unit.tests.', [])
@@ -243,18 +243,18 @@ class TestZone(TestCase):
         zone.add_record(a)
         with self.assertRaises(InvalidNodeException):
             zone.add_record(cname)
-        self.assertEquals(set([a]), zone.records)
+        self.assertEqual(set([a]), zone.records)
         zone.add_record(cname, lenient=True)
-        self.assertEquals(set([a, cname]), zone.records)
+        self.assertEqual(set([a, cname]), zone.records)
 
         # add a to cname
         zone = Zone('unit.tests.', [])
         zone.add_record(cname)
         with self.assertRaises(InvalidNodeException):
             zone.add_record(a)
-        self.assertEquals(set([cname]), zone.records)
+        self.assertEqual(set([cname]), zone.records)
         zone.add_record(a, lenient=True)
-        self.assertEquals(set([a, cname]), zone.records)
+        self.assertEqual(set([a, cname]), zone.records)
 
     def test_excluded_records(self):
         zone_normal = Zone('unit.tests.', [])
@@ -355,10 +355,10 @@ class TestZone(TestCase):
         self.assertTrue(zone_missing.changes(zone_normal, provider))
         self.assertFalse(zone_missing.changes(zone_included, provider))
 
-    def assertEqualsNameAndValues(self, a, b):
+    def assertEqualNameAndValues(self, a, b):
         a = dict([(r.name, r.values[0]) for r in a])
         b = dict([(r.name, r.values[0]) for r in b])
-        self.assertEquals(a, b)
+        self.assertEqual(a, b)
 
     def test_copy(self):
         zone = Zone('unit.tests.', [])
@@ -369,13 +369,13 @@ class TestZone(TestCase):
         zone.add_record(b)
 
         # Sanity check
-        self.assertEqualsNameAndValues(set((a, b)), zone.records)
+        self.assertEqualNameAndValues(set((a, b)), zone.records)
 
         copy = zone.copy()
         # We have an origin set and it is the source/original zone
-        self.assertEquals(zone, copy._origin)
+        self.assertEqual(zone, copy._origin)
         # Our records are zone's records to start (references)
-        self.assertEqualsNameAndValues(zone.records, copy.records)
+        self.assertEqualNameAndValues(zone.records, copy.records)
 
         # If we try and change something that's already there we realize and
         # then get an error about a duplicate
@@ -384,25 +384,25 @@ class TestZone(TestCase):
             copy.add_record(b_prime)
         self.assertIsNone(copy._origin)
         # Unchanged, straight copies
-        self.assertEqualsNameAndValues(zone.records, copy.records)
+        self.assertEqualNameAndValues(zone.records, copy.records)
 
         # If we add with replace things will be realized and the record will
         # have changed
         copy = zone.copy()
         copy.add_record(b_prime, replace=True)
         self.assertIsNone(copy._origin)
-        self.assertEqualsNameAndValues(set((a, b_prime)), copy.records)
+        self.assertEqualNameAndValues(set((a, b_prime)), copy.records)
 
         # If we add another record, things are reliazed and it has been added
         copy = zone.copy()
         c = ARecord(zone, 'c', {'ttl': 42, 'value': '1.1.1.3'})
         copy.add_record(c)
-        self.assertEqualsNameAndValues(set((a, b, c)), copy.records)
+        self.assertEqualNameAndValues(set((a, b, c)), copy.records)
 
         # If we remove a record, things are reliazed and it has been removed
         copy = zone.copy()
         copy.remove_record(a)
-        self.assertEqualsNameAndValues(set((b,)), copy.records)
+        self.assertEqualNameAndValues(set((b,)), copy.records)
 
         # Re-realizing is a noop
         copy = zone.copy()


### PR DESCRIPTION
This is a step in preparation for moving to pytest which captures and emits warnings. We had TONS of them and this will get rid of them before we go there. A good thing to do in general, but pretty much required to be able to cope with pytest (without disabling them) 