### PR TITLE
Switch to pytests, add a tiny bit of smoke test coverage to get something coverage no longer gets

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = octodns/cmds/*

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-filterwarnings =
-  # ovh has apparently vendored an old requests version that hits warnings :-/, it'll go away/move soon enough
-  ignore::DeprecationWarning:ovh.*:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+filterwarnings =
+  # ovh has apparently vendored an old requests version that hits warnings :-/, it'll go away/move soon enough
+  ignore::DeprecationWarning:ovh.*:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,17 +1,10 @@
 build==0.7.0
 coverage
 mock
-nose
-nose-no-network
-nose-timer
 pycodestyle==2.6.0
 pyflakes==2.2.0
+pytest
+pytest-network
 readme_renderer[md]==26.0
 requests_mock
 twine==3.4.2
-
-# Profiling tests...
-# nose-cprof
-# snakeviz
-# ./script/test --with-cprof --cprofile-stats-erase
-# snakeviz stats.dat

--- a/script/coverage
+++ b/script/coverage
@@ -36,7 +36,9 @@ grep -r -I --line-number "# pragma: +no.*cover" octodns && {
   exit 1
 }
 
-coverage run --branch --source=octodns --omit=octodns/cmds/* "$(command -v nosetests)" --with-no-network --with-xunit "$@"
+export PYTHONPATH=.:$PYTHONPATH
+
+coverage run --branch --source=octodns --omit=octodns/cmds/* "$(command -v pytest)" --disable-network "$@"
 coverage html
 coverage xml
 coverage report --show-missing

--- a/script/coverage
+++ b/script/coverage
@@ -30,19 +30,23 @@ export ARM_CLIENT_SECRET=
 export ARM_TENANT_ID=
 export ARM_SUBSCRIPTION_ID=
 
+SOURCE_DIR="octodns/"
+
 # Don't allow disabling coverage
-grep -r -I --line-number "# pragma: +no.*cover" octodns && {
-  echo "Code coverage should not be disabled"
-  exit 1
+grep -r -I --line-number "# pragma: +no.*cover" $SOURCE_DIR && {
+    echo "Code coverage should not be disabled"
+    exit 1
 }
 
 export PYTHONPATH=.:$PYTHONPATH
 
-coverage run --branch --source=octodns --omit=octodns/cmds/* "$(command -v pytest)" --disable-network "$@"
-coverage html
-coverage xml
-coverage report --show-missing
-coverage report | grep ^TOTAL | grep -qv 100% && {
-    echo "Incomplete code coverage" >&2
-    exit 1
-} || echo "Code coverage 100%"
+pytest \
+  --disable-network \
+  --cov-reset \
+  --cov=$SOURCE_DIR \
+  --cov-fail-under=100 \
+  --cov-report=html \
+  --cov-report=xml \
+  --cov-report=term \
+  --cov-branch \
+  "$@"

--- a/script/test
+++ b/script/test
@@ -30,4 +30,6 @@ export ARM_CLIENT_SECRET=
 export ARM_TENANT_ID=
 export ARM_SUBSCRIPTION_ID=
 
-nosetests --with-no-network "$@"
+export PYTHONPATH=.:$PYTHONPATH
+
+pytest --disable-network "$@"

--- a/setup.py
+++ b/setup.py
@@ -80,4 +80,8 @@ setup(
     python_requires='>=3.6',
     url='https://github.com/octodns/octodns',
     version=octodns.__VERSION__,
+    tests_require=(
+        'pytest',
+        'pytest-network',
+    ),
 )

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -3459,6 +3459,12 @@ class TestDynamicRecords(TestCase):
         self.assertTrue(rules)
         self.assertEqual(a_data['dynamic']['rules'][0], rules[0].data)
 
+        # smoke test of _DynamicMixin.__repr__
+        a.__repr__()
+        delattr(a, 'values')
+        a.value = 'abc'
+        a.__repr__()
+
     def test_simple_aaaa_weighted(self):
         aaaa_data = {
             'dynamic': {


### PR DESCRIPTION
nose is long since abandoned and as of python 3.10 we need to ditch it b/c it's broken. This moves everything to the much more modern and nice pytest. Long overdue...

/cc fixes https://github.com/octodns/octodns/issues/849