### PR TITLE
Add a 90d/5d stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,13 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '42 4 * * *'
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          days-before-stale: 90
+          days-before-close: 7


### PR DESCRIPTION
Based on doc https://github.com/actions/stale with much longer timeframe of 90 days.

There's lots of old issues & PRs at this point and this will groom them a bit as most of them haven't seen discussion in years.