### PR TITLE
Fully vet the setup.py requirements and installed code during cibuild

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,13 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '42 4 * * *'
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          days-before-stale: 90
+          days-before-close: 7

--- a/script/cibuild
+++ b/script/cibuild
@@ -37,5 +37,5 @@ python setup.py install
 octodns-sync --help
 echo "## validate tests can run against installed code ###############################"
 pip install pytest pytest-network
-pytest
+pytest --disable-network
 echo "## complete ####################################################################"

--- a/script/cibuild
+++ b/script/cibuild
@@ -37,6 +37,5 @@ python setup.py install
 octodns-sync --help
 echo "## validate tests can run against installed code ###############################"
 pip install .[dev]
-cd $TMP_DIR
 pytest --disable-network
 echo "## complete ####################################################################"

--- a/script/cibuild
+++ b/script/cibuild
@@ -7,15 +7,15 @@ cd "$(dirname "$0")/.."
 echo "## bootstrap ###################################################################"
 script/bootstrap
 
-echo "## environment & versions ######################################################"
-python --version
-python -m pip --version
-
 if [ -z "$VENV_NAME" ]; then
     VENV_NAME="env"
 fi
 
 . "$VENV_NAME/bin/activate"
+
+echo "## environment & versions ######################################################"
+python --version
+pip --version
 
 echo "## clean up ####################################################################"
 find octodns tests -name "*.pyc" -exec rm {} \;

--- a/script/cibuild
+++ b/script/cibuild
@@ -32,7 +32,7 @@ echo "## validate setup.py install #############################################
 deactivate
 TMP_DIR=$(mktemp -d -t ci-XXXXXXXXXX)
 python3 -m venv $TMP_DIR
-source "$TMP_DIR/bin/activate"
+. "$TMP_DIR/bin/activate"
 python setup.py install
 octodns-sync --help
 echo "## validate tests can run against installed code ###############################"

--- a/script/cibuild
+++ b/script/cibuild
@@ -36,6 +36,6 @@ python3 -m venv $TMP_DIR
 python setup.py install
 octodns-sync --help
 echo "## validate tests can run against installed code ###############################"
-pip install .[dev]
-pytest --disable-network
+pip install pytest pytest-network
+pytest
 echo "## complete ####################################################################"

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,4 +1,5 @@
 #!/bin/sh
+
 set -e
 
 cd "$(dirname "$0")/.."
@@ -27,4 +28,15 @@ echo "## tests/coverage ########################################################
 script/coverage
 echo "## validate setup.py build #####################################################"
 python setup.py build
+echo "## validate setup.py install ###################################################"
+deactivate
+TMP_DIR=$(mktemp -d -t ci-XXXXXXXXXX)
+python3 -m venv $TMP_DIR
+source "$TMP_DIR/bin/activate"
+python setup.py install
+octodns-sync --help
+echo "## validate tests can run against installed code ###############################"
+pip install .[dev]
+cd $TMP_DIR
+pytest --disable-network
 echo "## complete ####################################################################"


### PR DESCRIPTION
This builds off of https://github.com/octodns/octodns/pull/866 as it needs the `extras_require.dev` stuff in there to know what to install during tests. 

This runs `setup.py install` and then `octodns-sync --help` to generally vet things and ensure the commands are installed.

It then runs `pytest --no-network` against the tmp venv which should run the tests against the installed code (no `PYTHONPATH=.`

If this works out something similar will be created for octodns-template and all the provider repos. 