### PR TITLE
Rel 0.9.15 version bump & CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
-## v0.9.15 - 202?-??-?? - ??
+## v0.9.15 - 2022-02-07 - Where have all the providers gone?
 
 #### Noteworthy changes
 
-* Provider extraction has begun, see
+* Providers extracted from octoDNS core into individual repos
   https://github.com/octodns/octodns/issues/622 &
-  https://github.com/octodns/octodns/pull/822 for more information. Providers
-  that have been extracted in this release include:
+  https://github.com/octodns/octodns/pull/822 for more information.
    * [AzureProvider](https://github.com/octodns/octodns-azure/)
    * [AkamaiProvider](https://github.com/octodns/octodns-edgedns/)
    * [CloudflareProvider](https://github.com/octodns/octodns-cloudflare/)
@@ -34,6 +33,9 @@
   files) have been updated and minimized and a helper script,
   script/update-requirements has been added to help manage the txt files going
   forward.
+
+#### Prior to extraction
+
 * NS1 provider has received improvements to the dynamic record implementation.
   As a result, if octoDNS is downgraded from this version, any dynamic records
   created or updated using this version will show an update.
@@ -43,11 +45,14 @@
   more information. If octoDNS is downgraded from this version, any dynamic
   records created or updated using this version and matching the said edge-case
   will not be read/parsed correctly by the older version and will show a diff.
+* Transip was updated to their new client api
 
 #### Stuff
 
 * Additional FQDN validation to ALIAS/CNAME value, MX exchange, SRV target and
   tests of the functionality.
+* Improvements around dynamic record value weights allowing finer grained
+  control
 
 ## v0.9.14 - 2021-10-10 - A new supports system
 

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -3,4 +3,4 @@
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-__VERSION__ = '0.9.14'
+__VERSION__ = '0.9.15'


### PR DESCRIPTION
## v0.9.15 - 2022-02-07 - Where have all the providers gone?

#### Noteworthy changes

* Providers extracted from octoDNS core into individual repos
  https://github.com/octodns/octodns/issues/622 &
  https://github.com/octodns/octodns/pull/822 for more information.
   * [AzureProvider](https://github.com/octodns/octodns-azure/)
   * [AkamaiProvider](https://github.com/octodns/octodns-edgedns/)
   * [CloudflareProvider](https://github.com/octodns/octodns-cloudflare/)
   * [ConstellixProvider](https://github.com/octodns/octodns-constellix/)
   * [DigitalOceanProvider](https://github.com/octodns/octodns-digitalocean/)
   * [DnsimpleProvider](https://github.com/octodns/octodns-dnsimple/)
   * [DnsMadeEasyProvider](https://github.com/octodns/octodns-dnsmadeeasy/)
   * [DynProvider](https://github.com/octodns/octodns-dynprovider/)
   * [EasyDnsProvider](https://github.com/octodns/octodns-easydns/)
   * [EtcHostsProvider](https://github.com/octodns/octodns-etchosts/)
   * [GandiProvider](https://github.com/octodns/octodns-gandi/)
   * [GcoreProvider](https://github.com/octodns/octodns-gcore/)
   * [GoogleCloudProvider](https://github.com/octodns/octodns-googlecloud/)
   * [HetznerProvider](https://github.com/octodns/octodns-hetzner/)
   * [MythicBeastsProvider](https://github.com/octodns/octodns-mythicbeasts/)
   * [Ns1Provider](https://github.com/octodns/octodns-ns1/)
   * [OvhProvider](https://github.com/octodns/octodns-ovh/)
   * [PowerDnsProvider](https://github.com/octodns/octodns-powerdns/)
   * [RackspaceProvider](https://github.com/octodns/octodns-rackspace/)
   * [Route53Provider](https://github.com/octodns/octodns-route53/) also
     AwsAcmMangingProcessor
   * [SelectelProvider](https://github.com/octodns/octodns-selectel/)
   * [TransipProvider](https://github.com/octodns/octodns-transip/)
   * [UltraDnsProvider](https://github.com/octodns/octodns-ultradns/)
* As part of the extraction work octoDNS's requirements (setup.py and .txt
  files) have been updated and minimized and a helper script,
  script/update-requirements has been added to help manage the txt files going
  forward.

#### Prior to extraction

* NS1 provider has received improvements to the dynamic record implementation.
  As a result, if octoDNS is downgraded from this version, any dynamic records
  created or updated using this version will show an update.
* An edge-case bug related to geo rules involving continents in NS1 provider
  has been fixed in this version. However, it will not show/fix the records that
  match this edge-case. See https://github.com/octodns/octodns/pull/809 for
  more information. If octoDNS is downgraded from this version, any dynamic
  records created or updated using this version and matching the said edge-case
  will not be read/parsed correctly by the older version and will show a diff.
* Transip was updated to their new client api

#### Stuff

* Additional FQDN validation to ALIAS/CNAME value, MX exchange, SRV target and
  tests of the functionality.
* Improvements around dynamic record value weights allowing finer grained
  control