### PR TITLE
Rel 0.9.16 version bump & CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.9.16 - 2022-??-?? - ???
+## v0.9.16 - 2022-03-04 - Manage the root of the problem
 
 #### Noteworthy changes
 
@@ -6,14 +6,16 @@
    * YamlProvider has it enabled and in general everyone should add root NS
      records that match what is in their provider(s) as of this release if they
      aren't already there.
+   * Other providers will add root NS support over time following this release
+     once they have had the chance to investigate the functionality and
+     implement management if possible with whatever accomidations are required.
    * Note that if you created your config files with `octodns-dump`, the records
      are likely already there and match what was configured at the time of the
      dump.
-   * Other providers will add root NS support over time once they have had the
-     chance to investigate the functionality and implement management if
-     possible with whatever accomidations are required.
    * Watch your providers README.md and CHANGELOG.md for support and more
      information.
+   * Root NS record changes will always require `--force` indicating that they
+     are impactful changes that need a careful :eyes:
 
 #### Stuff
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,6 @@
    * Other providers will add root NS support over time following this release
      once they have had the chance to investigate the functionality and
      implement management if possible with whatever accomidations are required.
-   * Note that if you created your config files with `octodns-dump`, the records
-     are likely already there and match what was configured at the time of the
-     dump.
    * Watch your providers README.md and CHANGELOG.md for support and more
      information.
    * Root NS record changes will always require `--force` indicating that they

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -3,4 +3,4 @@
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-__VERSION__ = '0.9.15'
+__VERSION__ = '0.9.16'


### PR DESCRIPTION
## v0.9.16 - 2022-03-04 - Manage the root of the problem

#### Noteworthy changes

* Foundational support for root NS record management.
   * YamlProvider has it enabled and in general everyone should add root NS
     records that match what is in their provider(s) as of this release if they
     aren't already there.
   * Other providers will add root NS support over time following this release
     once they have had the chance to investigate the functionality and
     implement management if possible with whatever accomidations are required.
   * Note that if you created your config files with `octodns-dump`, the records
     are likely already there and match what was configured at the time of the
     dump.
   * Watch your providers README.md and CHANGELOG.md for support and more
     information.
   * Root NS record changes will always require `--force` indicating that they
     are impactful changes that need a careful :eyes:

#### Stuff

* _AggregateTarget has more complete handling of SUPPORTS* functionality,
  mostly applicable for the compare operation.
* Fix null MX record validation error introduced in 0.9.15, `.` is again
  allowed as a valid `exchange` value.

/cc Fixes https://github.com/octodns/octodns/issues/38