### PR TITLE
Manually runnable modules test

### DIFF
--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -1,5 +1,7 @@
 name: OctoDNS Modules
-on: []
+on:
+  repository_dispatch:
+    types: [modules-test]
 
 jobs:
   ci:

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -1,7 +1,5 @@
 name: OctoDNS Modules
-on:
-  repository_dispatch:
-    types: [modules-test]
+on: workflow_dispatch
 
 jobs:
   ci:

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -1,0 +1,44 @@
+name: OctoDNS Modules
+on: []
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        modules:
+          - octodns/octodns-azure
+          - octodns/octodns-cloudflare
+          - octodns/octodns-constellix
+          - octodns/octodns-ddns
+          - octodns/octodns-digitalocean
+          - octodns/octodns-dnsimple
+          - octodns/octodns-dnsmadeeasy
+          - octodns/octodns-dyn
+          - octodns/octodns-easydns
+          - octodns/octodns-edgedns
+          - octodns/octodns-etchosts
+          - octodns/octodns-gandi
+          - octodns/octodns-gcore
+          - octodns/octodns-googlecloud
+          - octodns/octodns-hetzner
+          - octodns/octodns-mythicbeasts
+          - octodns/octodns-ns1
+          - octodns/octodns-ovh
+          - octodns/octodns-powerdns
+          - octodns/octodns-rackspace
+          - octodns/octodns-route53
+          - octodns/octodns-selectel
+          - octodns/octodns-transip
+          - octodns/octodns-ultra
+    steps:
+      - uses: actions/checkout@master
+      - name: Setup python
+        uses: actions/setup-python@v1
+        with:
+          # This should generally be the latest stable release of python
+          python-version: '3.10'
+          architecture: x64
+      - name: Test Module
+        run: |
+          ./script/test-module ${{ matrix.module }}

--- a/script/test-module
+++ b/script/test-module
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+module="$1"
+if [ -z "$module" ]; then
+  echo "Missing required parameter module, e.g. octodns/octodns-powerdns"
+  exit 1
+fi
+
+set -e
+
+TMP_DIR=$(mktemp -d -t ci-XXXXXXXXXX)
+
+echo "## venv ########################################################################"
+VENV_PYTHON=$(command -v python3)
+VENV_NAME="${TMP_DIR}/env"
+"$VENV_PYTHON" -m venv "$VENV_NAME"
+. "${VENV_NAME}/bin/activate"
+echo "## environment & versions ######################################################"
+python --version
+pip --version
+echo "## install octodns from pwd ####################################################"
+python setup.py install
+echo "## checkout provider module ####################################################"
+cd $TMP_DIR
+git clone "https://github.com/${module}.git"
+cd $(basename $module)
+echo "## install module dev requirements #############################################"
+pip install -e .[dev]
+export PYTHONPATH=.:$PYTHONPATH
+echo "## run module tests ############################################################"
+pytest --disable-network
+echo "## complete ####################################################################"


### PR DESCRIPTION
Add a new test script that will run a dependent (provider) module's unit tests against the current state of octoDNS and an actions job that can manually be kicked off that does a matrix of all the (current) modules. 

This is intended to be used to validate major changes and releases to ensure that they don't cause unexpected problems for the now separate octoDNS provider modules.

Currently it list all of the first-party modules, but nothing stops us from supporting/including third-party providers. There's also nothing provider specific about it so we can test any other sorts of add-on modules as well.

/cc https://github.com/octodns/octodns/issues/622