### PR TITLE
Dynamic Record type registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   just standardizes what they are doing as many other providers appear to need
   to do so, but weren't. There was an ordering before, but it was essentially
   arbitrarily picked.
+* Record.register_type added so that providers can register custom record
+  types, see [docs/records.md](docs/records.md) for more information
 
 ## v0.9.16 - 2022-03-04 - Manage the root of the problem
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -124,10 +124,10 @@ If you'd like to enable lenience for a whole zone you can do so with the followi
 
 #### Restrict Record manipulations
 
-OctoDNS currently provides the ability to limit the number of updates/deletes on 
+OctoDNS currently provides the ability to limit the number of updates/deletes on
 DNS records by configuring a percentage of allowed operations as a threshold.
-If left unconfigured, suitable defaults take over instead. In the below example, 
-the Dyn provider is configured with limits of 40% on both update and 
+If left unconfigured, suitable defaults take over instead. In the below example,
+the Dyn provider is configured with limits of 40% on both update and
 delete operations over all the records present.
 
 ````yaml
@@ -136,3 +136,42 @@ dyn:
     update_pcent_threshold: 0.4
     delete_pcent_threshold: 0.4
 ````
+
+## Provider specific record types
+
+### Creating and registering
+
+octoDNS has support for provider specific record types through a dynamic type registration system. This functionality is powered by `Route.register_type` and can be used as follows.
+
+```python
+class _SpecificValue(object):
+    ...
+
+class SomeProviderSpecificRecord(ValuesMixin, Record):
+    _type = 'SomeProvider/SPECIFIC'
+    _value_type = _SpecificValue
+
+Record.register_type(SomeProviderSpecificRecord)
+```
+
+Have a look in [octodns.record](/octodns/record/__init__.py) for examples of how records are implemented. `NsRecord` and `_NsValue` are fairly simple examples to start with. You can also take a look at [`Route53Provider`'s `Route53Provider/ALIAS` type](https://github.com/octodns/octodns-route53/blob/main/octodns_route53/record.py).
+
+In general this support is intended for record types that only make sense for a single provider. If multiple providers have a similar record it may make sense to implement it in octoDNS core.
+
+### Naming
+
+By convention the record type should be prefix with the provider class, e.g. `Route53Provider` followed by a `/` and an all-caps record type name `ALIAS`, e.g. `Route53Provider/ALIAS`.
+
+### YamlProvider support
+
+Once the type is registered `YamlProvider` will automatically gain support for it and they can be included in your zone yaml files.
+
+```yaml
+alias:
+  type: Route53Provider/ALIAS
+  values:
+    - name: www
+      type: A
+    - name: www
+      type: AAAA
+```

--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -90,7 +90,7 @@ class Record(EqualityTupleMixin):
     def register_type(cls, _class, _type=None):
         if _type is None:
             _type = _class._type
-        existing = cls._CLASSES.get(_type, None)
+        existing = cls._CLASSES.get(_type)
         if existing:
             module = existing.__module__
             name = existing.__name__

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -12,7 +12,8 @@ from octodns.record import ARecord, AaaaRecord, AliasRecord, CaaRecord, \
     LocValue, MxRecord, MxValue, NaptrRecord, NaptrValue, NsRecord, \
     PtrRecord, Record, RecordException, SshfpRecord, SshfpValue, SpfRecord, \
     SrvRecord, SrvValue, TxtRecord, Update, UrlfwdRecord, UrlfwdValue, \
-    ValidationError, _Dynamic, _DynamicPool, _DynamicRule
+    ValidationError, _Dynamic, _DynamicPool, _DynamicRule, _NsValue, \
+    _ValuesMixin
 from octodns.zone import Zone
 
 from helpers import DynamicProvider, GeoProvider, SimpleProvider
@@ -26,6 +27,18 @@ class TestRecord(TestCase):
             Record.register_type('A', None)
         self.assertEqual('Type "A" already registered by '
                          'octodns.record.ARecord', str(ctx.exception))
+
+        class AaRecord(_ValuesMixin, Record):
+            _type = 'AA'
+            _value_type = _NsValue
+
+        Record.register_type('AA', AaRecord)
+        aa = Record.new(self.zone, 'registered', {
+            'ttl': 360,
+            'type': 'AA',
+            'value': 'does.not.matter.',
+        })
+        self.assertEqual(AaRecord, aa.__class__)
 
     def test_lowering(self):
         record = ARecord(self.zone, 'MiXeDcAsE', {

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -13,7 +13,7 @@ from octodns.record import ARecord, AaaaRecord, AliasRecord, CaaRecord, \
     PtrRecord, Record, RecordException, SshfpRecord, SshfpValue, SpfRecord, \
     SrvRecord, SrvValue, TxtRecord, Update, UrlfwdRecord, UrlfwdValue, \
     ValidationError, _Dynamic, _DynamicPool, _DynamicRule, _NsValue, \
-    _ValuesMixin
+    ValuesMixin
 from octodns.zone import Zone
 
 from helpers import DynamicProvider, GeoProvider, SimpleProvider
@@ -24,15 +24,15 @@ class TestRecord(TestCase):
 
     def test_registration(self):
         with self.assertRaises(RecordException) as ctx:
-            Record.register_type('A', None)
+            Record.register_type(None, 'A')
         self.assertEqual('Type "A" already registered by '
                          'octodns.record.ARecord', str(ctx.exception))
 
-        class AaRecord(_ValuesMixin, Record):
+        class AaRecord(ValuesMixin, Record):
             _type = 'AA'
             _value_type = _NsValue
 
-        Record.register_type('AA', AaRecord)
+        Record.register_type(AaRecord)
         aa = Record.new(self.zone, 'registered', {
             'ttl': 360,
             'type': 'AA',

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -10,9 +10,9 @@ from unittest import TestCase
 from octodns.record import ARecord, AaaaRecord, AliasRecord, CaaRecord, \
     CaaValue, CnameRecord, DnameRecord, Create, Delete, GeoValue, LocRecord, \
     LocValue, MxRecord, MxValue, NaptrRecord, NaptrValue, NsRecord, \
-    PtrRecord, Record, SshfpRecord, SshfpValue, SpfRecord, SrvRecord, \
-    SrvValue, TxtRecord, Update, UrlfwdRecord, UrlfwdValue, ValidationError, \
-    _Dynamic, _DynamicPool, _DynamicRule
+    PtrRecord, Record, RecordException, SshfpRecord, SshfpValue, SpfRecord, \
+    SrvRecord, SrvValue, TxtRecord, Update, UrlfwdRecord, UrlfwdValue, \
+    ValidationError, _Dynamic, _DynamicPool, _DynamicRule
 from octodns.zone import Zone
 
 from helpers import DynamicProvider, GeoProvider, SimpleProvider
@@ -20,6 +20,12 @@ from helpers import DynamicProvider, GeoProvider, SimpleProvider
 
 class TestRecord(TestCase):
     zone = Zone('unit.tests.', [])
+
+    def test_registration(self):
+        with self.assertRaises(RecordException) as ctx:
+            Record.register_type('A', None)
+        self.assertEqual('Type "A" already registered by '
+                         'octodns.record.ARecord', str(ctx.exception))
 
     def test_lowering(self):
         record = ARecord(self.zone, 'MiXeDcAsE', {


### PR DESCRIPTION
Support for dynamically registering new record types in octoDNS.  This should allow providers to add special record types that only they support without polluting the core of octoDNS.

* [x] Full testing of registration including usage
* [x] Document requirements/behavior, specifically naming conventions
   * ~~ROUTE53-ALIAS?~~
   * ~~SYMLINK (better name for Route53's ALIAS, claiming top-level names/free for all)~~
   * Route53Provider/ALIAS

/cc https://github.com/octodns/octodns-route53/issues/24 for a potential use