### PR TITLE
Run the modules ci jobs when reviews are submitted

### DIFF
--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -1,5 +1,8 @@
 name: OctoDNS Modules
-on: workflow_dispatch
+on:
+  workflow_dispatch: # option to run manually if/when needed
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   ci:


### PR DESCRIPTION
Looking for a better workflow here. Will likely review the required bit from these jobs so they don't show up/get in the way until we're close to the end (review submitted.) 