### PR TITLE
Log the octoDNS version as part of Manager.__init__ info line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   to do so, but weren't. There was an ordering before, but it was essentially
   arbitrarily picked.
 
+#### Stuff
+
+* Manager includes the octoDNS version in its init log line
+
 ## v0.9.16 - 2022-03-04 - Manage the root of the problem
 
 #### Noteworthy changes

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -115,10 +115,13 @@ class Manager(object):
                 self.log.exception('Invalid provider class')
                 raise ManagerException(f'Provider {provider_name} is missing '
                                        'class')
-            _class = self._get_named_class('provider', _class)
+            _class, module, version = self._get_named_class('provider', _class)
             kwargs = self._build_kwargs(provider_config)
             try:
                 self.providers[provider_name] = _class(provider_name, **kwargs)
+                if not module.startswith('octodns.'):
+                    self.log.info('__init__: provider=%s (%s %s)',
+                                  provider_name, module, version)
             except TypeError:
                 self.log.exception('Invalid provider config')
                 raise ManagerException('Incorrect provider config for ' +
@@ -133,11 +136,15 @@ class Manager(object):
                 self.log.exception('Invalid processor class')
                 raise ManagerException(f'Processor {processor_name} is '
                                        'missing class')
-            _class = self._get_named_class('processor', _class)
+            _class, module, version = self._get_named_class('processor',
+                                                            _class)
             kwargs = self._build_kwargs(processor_config)
             try:
                 self.processors[processor_name] = _class(processor_name,
                                                          **kwargs)
+                if not module.startswith('octodns.'):
+                    self.log.info('__init__: processor=%s (%s %s)',
+                                  processor_name, module, version)
             except TypeError:
                 self.log.exception('Invalid processor config')
                 raise ManagerException('Incorrect processor config for ' +
@@ -177,11 +184,15 @@ class Manager(object):
                 self.log.exception('Invalid plan_output class')
                 raise ManagerException(f'plan_output {plan_output_name} is '
                                        'missing class')
-            _class = self._get_named_class('plan_output', _class)
+            _class, module, version = self._get_named_class('plan_output',
+                                                            _class)
             kwargs = self._build_kwargs(plan_output_config)
             try:
                 self.plan_outputs[plan_output_name] = \
                     _class(plan_output_name, **kwargs)
+                if not module.startswith('octodns.'):
+                    self.log.info('__init__: plan_output=%s (%s %s)',
+                                  plan_output_name, module, version)
             except TypeError:
                 self.log.exception('Invalid plan_output config')
                 raise ManagerException('Incorrect plan_output config for ' +
@@ -195,8 +206,9 @@ class Manager(object):
             self.log.exception('_get_{}_class: Unable to import '
                                'module %s', _class)
             raise ManagerException(f'Unknown {_type} class: {_class}')
+        version = getattr(module, '__VERSION__', 'n/a')
         try:
-            return getattr(module, class_name)
+            return getattr(module, class_name), module_name, version
         except AttributeError:
             self.log.exception('_get_{}_class: Unable to get class %s '
                                'from module %s', class_name, module)

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -11,6 +11,7 @@ from os import environ
 from sys import stdout
 import logging
 
+from . import __VERSION__
 from .provider.base import BaseProvider
 from .provider.plan import Plan
 from .provider.yaml import SplitYamlProvider, YamlProvider
@@ -84,7 +85,8 @@ class Manager(object):
         return len(plan.changes[0].record.zone.name) if plan.changes else 0
 
     def __init__(self, config_file, max_workers=None, include_meta=False):
-        self.log.info('__init__: config_file=%s', config_file)
+        self.log.info('__init__: config_file=%s (octoDNS %s)', config_file,
+                      __VERSION__)
 
         # Read our config file
         with open(config_file, 'r') as fh:

--- a/tests/config/processors.yaml
+++ b/tests/config/processors.yaml
@@ -1,6 +1,7 @@
 providers:
   config:
-    class: octodns.provider.yaml.YamlProvider
+    # This helps us get coverage when printing out provider versions
+    class: helpers.TestYamlProvider
     directory: tests/config
   dump:
     class: octodns.provider.yaml.YamlProvider
@@ -15,6 +16,9 @@ processors:
   # Just testing config so any processor will do
   noop:
     class: octodns.processor.base.BaseProcessor
+  test:
+    # This helps us get coverage when printing out processor versions
+    class: helpers.TestBaseProcessor
 
 zones:
   unit.tests.:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -11,6 +11,7 @@ from logging import getLogger
 
 from octodns.processor.base import BaseProcessor
 from octodns.provider.base import BaseProvider
+from octodns.provider.yaml import YamlProvider
 
 
 class SimpleSource(object):
@@ -122,3 +123,11 @@ class PlannableProvider(BaseProvider):
 
     def __repr__(self):
         return self.__class__.__name__
+
+
+class TestYamlProvider(YamlProvider):
+    pass
+
+
+class TestBaseProcessor(BaseProcessor):
+    pass

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, division, print_function, \
 from os import environ
 from os.path import dirname, join
 
+from octodns import __VERSION__
 from octodns.manager import _AggregateTarget, MainThreadExecutor, Manager, \
     ManagerException
 from octodns.processor.base import BaseProcessor
@@ -523,6 +524,29 @@ class TestManager(TestCase):
         # We planned a delete again, but this time removed it from the plan, so
         # no plans
         self.assertFalse(plans)
+
+    def test_try_version(self):
+        manager = Manager(get_config_filename('simple.yaml'))
+
+        class DummyModule(object):
+            __VERSION__ = '2.3.4'
+
+        dummy_module = DummyModule()
+
+        # use importlib.metadata.version
+        self.assertTrue(__VERSION__,
+                        manager._try_version('octodns',
+                                             module=dummy_module,
+                                             version='1.2.3'))
+
+        # use module
+        self.assertTrue(manager._try_version('doesnt-exist',
+                                             module=dummy_module))
+
+        # fall back to version, preferred over module
+        self.assertEqual('1.2.3', manager._try_version('doesnt-exist',
+                                                       module=dummy_module,
+                                                       version='1.2.3', ))
 
 
 class TestMainThreadExecutor(TestCase):

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -425,7 +425,7 @@ class TestManager(TestCase):
         plan_output_mock = MagicMock()
         plan_output_class_mock = MagicMock()
         plan_output_class_mock.return_value = plan_output_mock
-        mock.return_value = plan_output_class_mock
+        mock.return_value = (plan_output_class_mock, 'ignored', 'ignored')
         fh_mock = MagicMock()
 
         Manager(get_config_filename('plan-output-filehandle.yaml')
@@ -441,7 +441,7 @@ class TestManager(TestCase):
     def test_processor_config(self):
         # Smoke test loading a valid config
         manager = Manager(get_config_filename('processors.yaml'))
-        self.assertEqual(['noop'], list(manager.processors.keys()))
+        self.assertEqual(['noop', 'test'], list(manager.processors.keys()))
         # This zone specifies a valid processor
         manager.sync(['unit.tests.'])
 


### PR DESCRIPTION
Useful for reporting problems and just generally being able to quickly see what's being used.

/cc https://github.com/octodns/octodns-docker/issues/27#issuecomment-1079544376 which lead me to make this addition