### PR TITLE
Implement pep440 style public and local version numbers

### DIFF
--- a/script/release
+++ b/script/release
@@ -16,6 +16,9 @@ if [ ! -f "$ACTIVATE" ]; then
 fi
 . "$ACTIVATE"
 
+# Set so that setup.py will create a public release style version number
+export OCTODNS_RELEASE=1
+
 VERSION="$(grep __VERSION__ "$ROOT/octodns/__init__.py" | sed -e "s/.* = '//" -e "s/'$//")"
 
 git tag -s "v$VERSION" -m "Release $VERSION"

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import StringIO
+from os import environ
 from os.path import dirname, join
+from subprocess import CalledProcessError, check_output
 import octodns
 
 try:
@@ -55,6 +54,19 @@ def long_description():
     return buf.getvalue()
 
 
+def version():
+    # pep440 style public & local version numbers
+    if environ.get('OCTODNS_RELEASE', False):
+        # public
+        return octodns.__VERSION__
+    try:
+        sha = check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8')[:8]
+    except (CalledProcessError, FileNotFoundError):
+        sha = 'unknown'
+    # local
+    return f'{octodns.__VERSION__}+{sha}'
+
+
 tests_require = (
     'pytest>=6.2.5',
     'pytest-cov>=3.0.0',
@@ -94,5 +106,5 @@ setup(
     python_requires='>=3.6',
     tests_require=tests_require,
     url='https://github.com/octodns/octodns',
-    version=octodns.__VERSION__,
+    version=version(),
 )


### PR DESCRIPTION
This implements [pep440](https://peps.python.org/pep-0440/) style version numbers. 

True/public release will continue to have the `<x>.<y>.<z>` style numbering, controlled by an environmental variable `OCTODNS_RELEASE` being set when doing the install/builds. 

`0.9.16`

Local releases, installing from a git checkout etc., will use the same version number appending the first 8 characters of the git sha. 

`0.9.16.b4d66c3f`


This should differentiate publicly released builds from those done from a specific SHA, either locally or with managers such as pip. 

If we're going to go this route we'll want to add this same logic to all of the provider modules and the template. 

/cc https://github.com/octodns/octodns/pull/891#issuecomment-1079611056 for the suggestion @viranch 