### PR TITLE
Add octodns-versions command

### DIFF
--- a/octodns/cmds/versions.py
+++ b/octodns/cmds/versions.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+'''
+octoDNS Versions
+'''
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
+from octodns.cmds.args import ArgumentParser
+from octodns.manager import Manager
+
+
+def main():
+    parser = ArgumentParser(description=__doc__.split('\n')[1])
+
+    parser.add_argument('--config-file', required=True,
+                        help='The Manager configuration file to use')
+
+    args = parser.parse_args()
+
+    Manager(args.config_file)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ cmds = (
     'dump',
     'report',
     'sync',
-    'validate'
+    'validate',
+    'versions',
 )
 cmds_dir = join(dirname(__file__), 'octodns', 'cmds')
 console_scripts = {


### PR DESCRIPTION

```console
(env) coho:octodns ross$ octodns-versions --config-file=config/dev.yaml
2022-03-30T19:05:49  [4601146880] INFO  Manager __init__: config_file=config/dev.yaml (octoDNS 0.9.16+e9d9fbc0)
2022-03-30T19:05:49  [4601146880] INFO  Manager __init__:   max_workers=1
2022-03-30T19:05:49  [4601146880] INFO  Manager __init__:   include_meta=False
2022-03-30T19:05:49  [4601146880] INFO  Manager __init__: provider=config (octodns.provider.yaml 0.9.16+e9d9fbc0)
2022-03-30T19:05:50  [4601146880] INFO  Manager __init__: provider=ns1 (octodns_ns1 0.0.2+d11d8bb8)
2022-03-30T19:05:50  [4601146880] INFO  Manager __init__: provider=route53 (octodns_route53 0.0.4)
2022-03-30T19:05:50  [4601146880] INFO  Manager __init__: processor=acme (octodns.processor.acme 0.9.16+e9d9fbc0)

```

/cc https://github.com/octodns/octodns/pull/891#issuecomment-1083980615 which mentioned the desire for this