### PR TITLE
Rel 0.9.17 version bump & CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.9.17 - 2022-??-?? - ???
+## v0.9.17 - 2022-04-02 - Registration required
 
 #### Noteworthy changes
 
@@ -15,10 +15,15 @@
   arbitrarily picked.
 * Record.register_type added so that providers can register custom record
   types, see [docs/records.md](docs/records.md) for more information
+* New `octodns-versions` command which will log out the version of octodns and
+  any provider/processor/plan_output modules you are using.
 
 #### Stuff
 
 * Manager includes the octoDNS version in its init log line
+* Non-official release installs will now include a bit of the sha to indicate
+  specifically what revision is being used, e.g. 0.9.17+abcdef12, these roughly
+  follow PEP440 guidelines
 
 ## v0.9.16 - 2022-03-04 - Manage the root of the problem
 

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -3,4 +3,4 @@
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-__VERSION__ = '0.9.16'
+__VERSION__ = '0.9.17'


### PR DESCRIPTION
## v0.9.17 - 2022-04-02 - Registration required

#### Noteworthy changes

* The changes in plans are now ordered based on change type prior to
  considering the record name and type as was previously done. The chosen
  order is: deletes, creates, updates. The reason for that many providers make
  changes one at a time. When changing the type of a record, e.g. from A to
  CNAME of vice versa this is done by deleting the old and creating the new.
  If the CNAME create happens before the A delete it will often violate
  rules against having typed records live at the same node as a CNAME. Several
  providers have always handled this by sorting the changes themselves. This
  just standardizes what they are doing as many other providers appear to need
  to do so, but weren't. There was an ordering before, but it was essentially
  arbitrarily picked.
* Record.register_type added so that providers can register custom record
  types, see [docs/records.md](docs/records.md) for more information
* New `octodns-versions` command which will log out the version of octodns and
  any provider/processor/plan_output modules you are using.

#### Stuff

* Manager includes the octoDNS version in its init log line
* Non-official release installs will now include a bit of the sha to indicate
  specifically what revision is being used, e.g. 0.9.17+abcdef12, these roughly
  follow PEP440 guidelines