### PR TITLE
SSHFP support for Source AXFR/Zonefile

### DIFF
--- a/octodns/source/axfr.py
+++ b/octodns/source/axfr.py
@@ -26,7 +26,7 @@ class AxfrBaseSource(BaseSource):
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
     SUPPORTS = set(('A', 'AAAA', 'CAA', 'CNAME', 'LOC', 'MX', 'NS', 'PTR',
-                    'SPF', 'SRV', 'TXT'))
+                    'SPF', 'SRV', 'SSHFP', 'TXT'))
 
     def __init__(self, id):
         super(AxfrBaseSource, self).__init__(id)
@@ -128,6 +128,22 @@ class AxfrBaseSource(BaseSource):
                 'weight': weight,
                 'port': port,
                 'target': target,
+            })
+        return {
+            'type': _type,
+            'ttl': records[0]['ttl'],
+            'values': values
+        }
+
+    def _data_for_SSHFP(self, _type, records):
+        values = []
+        for record in records:
+            algorithm, fingerprint_type, fingerprint = \
+                record['value'].split(' ', 2)
+            values.append({
+                'algorithm': algorithm,
+                'fingerprint_type': fingerprint_type,
+                'fingerprint': fingerprint,
             })
         return {
             'type': _type,

--- a/tests/test_octodns_source_axfr.py
+++ b/tests/test_octodns_source_axfr.py
@@ -35,7 +35,7 @@ class TestAxfrSource(TestCase):
         ]
 
         self.source.populate(got)
-        self.assertEqual(15, len(got.records))
+        self.assertEqual(16, len(got.records))
 
         with self.assertRaises(AxfrSourceZoneTransferFailed) as ctx:
             zone = Zone('unit.tests.', [])
@@ -72,18 +72,18 @@ class TestZoneFileSource(TestCase):
         # Load zonefiles without a specified file extension
         valid = Zone('unit.tests.', [])
         source.populate(valid)
-        self.assertEqual(15, len(valid.records))
+        self.assertEqual(16, len(valid.records))
 
     def test_populate(self):
         # Valid zone file in directory
         valid = Zone('unit.tests.', [])
         self.source.populate(valid)
-        self.assertEqual(15, len(valid.records))
+        self.assertEqual(16, len(valid.records))
 
         # 2nd populate does not read file again
         again = Zone('unit.tests.', [])
         self.source.populate(again)
-        self.assertEqual(15, len(again.records))
+        self.assertEqual(16, len(again.records))
 
         # bust the cache
         del self.source._zone_records[valid.name]

--- a/tests/zones/unit.tests.tst
+++ b/tests/zones/unit.tests.tst
@@ -13,6 +13,10 @@ $ORIGIN unit.tests.
 under       3600  IN  NS  ns1.unit.tests.
 under       3600  IN  NS  ns2.unit.tests.
 
+; SSHFP Records
+@           600   IN  SSHFP 1 1 bf6b6825d2977c511a475bbefb88aad54a92ac73
+@           600   IN  SSHFP 1 1 7491973e5f8b39d5327cd4e08bc81b05f7710b49
+
 ; CAA Records
 caa         1800  IN  CAA 0 issue "ca.unit.tests"
 caa         1800  IN  CAA 0 iodef "mailto:admin@unit.tests"


### PR DESCRIPTION
I added support for SSHFP records to `source/axfr.py`. Tests and Linting are passing.
(Maybe will do TLSA as well soon).

Thank you!