### PR TITLE
AxfrSource and ZoneFileSource: support multi-value PTR records

### DIFF
--- a/octodns/source/axfr.py
+++ b/octodns/source/axfr.py
@@ -59,6 +59,7 @@ class AxfrBaseSource(BaseSource):
     _data_for_A = _data_for_multiple
     _data_for_AAAA = _data_for_multiple
     _data_for_NS = _data_for_multiple
+    _data_for_PTR = _data_for_multiple
 
     def _data_for_CAA(self, _type, records):
         values = []
@@ -122,7 +123,6 @@ class AxfrBaseSource(BaseSource):
         return {'ttl': record['ttl'], 'type': _type, 'value': record['value']}
 
     _data_for_CNAME = _data_for_single
-    _data_for_PTR = _data_for_single
 
     def _data_for_SRV(self, _type, records):
         values = []

--- a/tests/test_octodns_source_axfr.py
+++ b/tests/test_octodns_source_axfr.py
@@ -34,8 +34,14 @@ class TestAxfrSource(TestCase):
         './tests/zones/unit.tests.tst', 'unit.tests', relativize=False
     )
 
+    reverse_zonefile = dns.zone.from_file(
+        './tests/zones/2.0.192.in-addr.arpa.',
+        '2.0.192.in-addr.arpa',
+        relativize=False,
+    )
+
     @patch('dns.zone.from_xfr')
-    def test_populate(self, from_xfr_mock):
+    def test_populate_forward(self, from_xfr_mock):
         got = Zone('unit.tests.', [])
 
         from_xfr_mock.side_effect = [self.forward_zonefile, DNSException]
@@ -47,6 +53,15 @@ class TestAxfrSource(TestCase):
             zone = Zone('unit.tests.', [])
             self.source.populate(zone)
         self.assertEqual('Unable to Perform Zone Transfer', str(ctx.exception))
+
+    @patch('dns.zone.from_xfr')
+    def test_populate_reverse(self, from_xfr_mock):
+        got = Zone('2.0.192.in-addr.arpa.', [])
+
+        from_xfr_mock.side_effect = [self.reverse_zonefile]
+
+        self.source.populate(got)
+        self.assertEqual(4, len(got.records))
 
 
 class TestZoneFileSource(TestCase):

--- a/tests/zones/2.0.192.in-addr.arpa.
+++ b/tests/zones/2.0.192.in-addr.arpa.
@@ -1,0 +1,18 @@
+$ORIGIN 2.0.192.in-addr.arpa.
+@           3600 IN	SOA	ns1.unit.tests. root.unit.tests. (
+                        2018071501		; Serial
+                        3600    ; Refresh (1 hour)
+                        600     ; Retry (10 minutes)
+                        604800  ; Expire (1 week)
+                        3600    ; NXDOMAIN ttl (1 hour)
+                    )
+
+; NS Records
+@           3600  IN  NS  ns1.unit.tests.
+@           3600  IN  NS  ns2.unit.tests.
+
+; PTR Records
+1   IN  PTR foo-1.unit.tests.
+2   IN  PTR foo-2.unit.tests.
+3   IN  PTR foo-3.unit.tests.
+3   IN  PTR foo-4.unit.tests.


### PR DESCRIPTION
Fixes #912 

PTR records can be multi-valued, the initial source was written with an mistaken assumption that they were only single value.

/cc @harpreetnav