### PR TITLE
Rel 0.9.18 version bump & CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## v0.9.18 - 2022-??-?? - Internationalization
+## v0.9.18 - 2022-09-09 - Internationalization
 
-* Added octodns.idna idna_encode/idna_decode helpers
+* Added octodns.idna idna_encode/idna_decode helpers, providers will need to
+  individually add support via these helpers though :-/
 
 ## v0.9.17 - 2022-04-02 - Registration required
 

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -7,4 +7,4 @@ from __future__ import (
     unicode_literals,
 )
 
-__VERSION__ = '0.9.17'
+__VERSION__ = '0.9.18'

--- a/octodns/idna.py
+++ b/octodns/idna.py
@@ -4,6 +4,10 @@
 
 from idna import decode as _decode, encode as _encode
 
+# Providers will need to to make calls to these at the appropriate points,
+# generally right before they pass names off to api calls. For an example of
+# usage see https://github.com/octodns/octodns-ns1/pull/20
+
 
 def idna_encode(name):
     # Based on https://github.com/psf/requests/pull/3695/files


### PR DESCRIPTION
## v0.9.18 - 2022-09-09 - Internationalization

* Added octodns.idna idna_encode/idna_decode helpers, providers will need to
  individually add support via these helpers though :-/