### PR TITLE
Fqdn check w idna encode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.9.19 - 2022-??-?? -
+
+* Allow utf-8 (IDNA) values in record types that support fqdn for
+  values/targets
+
 ## v0.9.18 - 2022-09-09 - Internationalization
 
 * Added octodns.idna idna_encode/idna_decode helpers, providers will need to

--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -16,6 +16,7 @@ import re
 from fqdn import FQDN
 
 from ..equality import EqualityTupleMixin
+from ..idna import idna_encode
 from .geo import GeoCodes
 
 
@@ -815,9 +816,7 @@ class _TargetValue(object):
             reasons.append('empty value')
         elif not data:
             reasons.append('missing value')
-        # NOTE: FQDN complains if the data it receives isn't a str, it doesn't
-        # allow unicode... This is likely specific to 2.7
-        elif not FQDN(str(data), allow_underscores=True).is_valid:
+        elif not FQDN(idna_encode(data), allow_underscores=True).is_valid:
             reasons.append(f'{_type} value "{data}" is not a valid FQDN')
         elif not data.endswith('.'):
             reasons.append(f'{_type} value "{data}" missing trailing .')
@@ -1151,7 +1150,9 @@ class MxValue(EqualityTupleMixin):
                 exchange = str(value.get('exchange', None) or value['value'])
                 if (
                     exchange != '.'
-                    and not FQDN(exchange, allow_underscores=True).is_valid
+                    and not FQDN(
+                        idna_encode(exchange), allow_underscores=True
+                    ).is_valid
                 ):
                     reasons.append(
                         f'Invalid MX exchange "{exchange}" is not '
@@ -1301,7 +1302,7 @@ class _NsValue(object):
             data = (data,)
         reasons = []
         for value in data:
-            if not FQDN(str(value), allow_underscores=True).is_valid:
+            if not FQDN(idna_encode(value), allow_underscores=True).is_valid:
                 reasons.append(
                     f'Invalid NS value "{value}" is not ' 'a valid FQDN.'
                 )
@@ -1512,7 +1513,9 @@ class SrvValue(EqualityTupleMixin):
                     reasons.append(f'SRV value "{target}" missing trailing .')
                 if (
                     target != '.'
-                    and not FQDN(str(target), allow_underscores=True).is_valid
+                    and not FQDN(
+                        idna_encode(target), allow_underscores=True
+                    ).is_valid
                 ):
                     reasons.append(
                         f'Invalid SRV target "{target}" is not ' 'a valid FQDN.'

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -849,11 +849,16 @@ class TestRecord(TestCase):
         self.assertEqual(a_values, a.values)
         self.assertEqual(a_data, a.data)
 
-        b_value = '9.8.7.6.'
+        b_value = 'ns1.unit.tests.'
         b_data = {'ttl': 30, 'value': b_value}
         b = NsRecord(self.zone, 'b', b_data)
         self.assertEqual([b_value], b.values)
         self.assertEqual(b_data, b.data)
+
+        # utf-8 value support
+        utf8_value = 'zajęzyk.unit.tests.'
+        u = NsRecord(self.zone, 'b', {'ttl': 33, 'value': utf8_value})
+        self.assertEqual([utf8_value], u.values)
 
     def test_sshfp(self):
         a_values = [
@@ -1700,6 +1705,11 @@ class TestRecord(TestCase):
         self.assertEqual(a.__hash__(), a.__hash__())
         self.assertNotEqual(a.__hash__(), b.__hash__())
 
+        # utf-8 value support
+        utf8_value = 'zajęzyk.unit.tests.'
+        u = MxValue({'preference': 0, 'priority': 'a', 'value': utf8_value})
+        self.assertEqual(utf8_value, u.exchange)
+
     def test_sshfp_value(self):
         a = SshfpValue(
             {'algorithm': 0, 'fingerprint_type': 0, 'fingerprint': 'abcd'}
@@ -1829,6 +1839,13 @@ class TestRecord(TestCase):
         self.assertFalse(b in values)
         values.add(b)
         self.assertTrue(b in values)
+
+        # utf-8 value support
+        utf8_value = 'zajęzyk.unit.tests.'
+        u = SrvValue(
+            {'priority': 0, 'weight': 42, 'port': 80, 'target': utf8_value}
+        )
+        self.assertEqual(utf8_value, u.target)
 
 
 class TestRecordValidation(TestCase):
@@ -2429,6 +2446,13 @@ class TestRecordValidation(TestCase):
             'www',
             {'type': 'CNAME', 'ttl': 600, 'value': 'foo.bar.com.'},
         )
+
+        # utf-8 characters are allowed in values
+        utf8_value = 'zajęzyk.bar.com.'
+        r = Record.new(
+            self.zone, 'www', {'type': 'CNAME', 'ttl': 600, 'value': utf8_value}
+        )
+        self.assertEqual(utf8_value, r.value)
 
         # root cname is a no-no
         with self.assertRaises(ValidationError) as ctx:


### PR DESCRIPTION
Allow UTF-8 values in record answers. We were previously using a `FQDN` function to check values with a `str` to fix issues with passing unicode strings in 2.7. 2.7 is no more (for octoDNS) so we don't need the `str`, but the `FQDN` checks still don't allow utf-8 so we need to encode before sending things off to it.

These are only validations and if you run into them before this is included in a release you can either pin a SHA will this change or temporarily add `lenient` to the records to ignore the validation issues.

/cc https://github.com/octodns/octodns/issues/199 
/cc https://github.com/octodns/octodns-ns1/pull/20#issuecomment-1209560348 @viranch 