### PR TITLE
Fix issues with sub-zone handling

### DIFF
--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -315,12 +315,13 @@ class Manager(object):
             while zones:
                 # Grab the one we'lre going to work on now
                 zone = zones.pop()
-                trimmer = len(zone) + 1
+                dotted = f'.{zone}'
+                trimmer = len(dotted)
                 subs = set()
                 # look at all the zone names that come after it
                 for candidate in zones:
-                    # If they end with this zone's name them they're a sub
-                    if candidate.endswith(zone):
+                    # If they end with this zone's dotted name, it's a sub
+                    if candidate.endswith(dotted):
                         # We want subs to exclude the zone portion
                         subs.add(candidate[:-trimmer])
 

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -102,6 +102,8 @@ class Manager(object):
         plan = p[1]
         return len(plan.changes[0].record.zone.name) if plan.changes else 0
 
+    # TODO: all of this should get broken up, mainly so that it's not so huge
+    # and each bit can be cleanly tested independently
     def __init__(self, config_file, max_workers=None, include_meta=False):
         version = self._try_version('octodns', version=__VERSION__)
         self.log.info(

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -9,6 +9,7 @@ from __future__ import (
     unicode_literals,
 )
 
+from collections import deque
 from concurrent.futures import ThreadPoolExecutor
 from importlib import import_module
 from os import environ
@@ -234,15 +235,16 @@ class Manager(object):
         if self._zone_tree is None:
             zone_tree = {}
 
-            # Get a list of all of our zone names
-            zones = list(self.config['zones'].keys())
-            # Sort them from shortest to longest so that parents will always
-            # come before their subzones
-            zones.sort(key=lambda z: len(z))
+            # Get a list of all of our zone names. Sort them from shortest to
+            # longest so that parents will always come before their subzones
+            zones = sorted(
+                self.config['zones'].keys(), key=lambda z: len(z), reverse=True
+            )
+            zones = deque(zones)
             # Until we're done processing zones
             while zones:
                 # Grab the one we'lre going to work on now
-                zone = zones.pop(0)
+                zone = zones.pop()
                 trimmer = len(zone) + 1
                 subs = set()
                 # look at all the zone names that come after it

--- a/octodns/zone.py
+++ b/octodns/zone.py
@@ -79,7 +79,7 @@ class Zone(object):
                 if not record._type == 'NS':
                     # and not a NS record, this should be in the sub
                     raise SubzoneRecordException(
-                        f'Record {record.fqdn} a managed sub-zone and not of type NS'
+                        f'Record {record.fqdn} is a managed sub-zone and not of type NS'
                     )
             else:
                 # It's not an exact match so there has to be a `.` before the

--- a/octodns/zone.py
+++ b/octodns/zone.py
@@ -79,9 +79,7 @@ class Zone(object):
                 if not record._type == 'NS':
                     # and not a NS record, this should be in the sub
                     raise SubzoneRecordException(
-                        f'Record {record.fqdn} a '
-                        'managed sub-zone and not of '
-                        'type NS'
+                        f'Record {record.fqdn} a managed sub-zone and not of type NS'
                     )
             else:
                 # It's not an exact match so there has to be a `.` before the
@@ -90,8 +88,7 @@ class Zone(object):
                     if name.endswith(f'.{sub_zone}'):
                         # this should be in a sub
                         raise SubzoneRecordException(
-                            f'Record {record.fqdn} is under '
-                            'a managed subzone'
+                            f'Record {record.fqdn} is under a managed subzone'
                         )
 
         if replace:

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -712,6 +712,34 @@ class TestManager(TestCase):
             ),
         )
 
+    def test_subzone_handling(self):
+        manager = Manager(get_config_filename('simple.yaml'))
+
+        manager.config['zones'] = {
+            'unit.tests.': {},
+            'sub.unit.tests.': {},
+            'another.sub.unit.tests.': {},
+            'skipped.alevel.unit.tests.': {},
+        }
+
+        self.assertEqual(
+            {'unit.tests': {'skipped.alevel': {}, 'sub': {'another': {}}}},
+            manager.zone_tree,
+        )
+        self.assertEqual(
+            {'sub', 'skipped.alevel'},
+            manager.configured_sub_zones('unit.tests.'),
+        )
+        self.assertEqual(
+            {'another'}, manager.configured_sub_zones('sub.unit.tests.')
+        )
+        self.assertEqual(
+            set(), manager.configured_sub_zones('another.unit.tests.')
+        )
+        self.assertEqual(
+            set(), manager.configured_sub_zones('skipped.alevel.unit.tests.')
+        )
+
 
 class TestMainThreadExecutor(TestCase):
     def test_success(self):

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -724,15 +724,6 @@ class TestManager(TestCase):
         }
 
         self.assertEqual(
-            {
-                'unit.tests.': {'sub', 'another.sub', 'skipped.alevel'},
-                'sub.unit.tests.': {'another'},
-                'another.sub.unit.tests.': set(),
-                'skipped.alevel.unit.tests.': set(),
-            },
-            manager.zone_tree,
-        )
-        self.assertEqual(
             {'another.sub', 'sub', 'skipped.alevel'},
             manager.configured_sub_zones('unit.tests.'),
         )
@@ -757,20 +748,7 @@ class TestManager(TestCase):
             'skipped.alevel.unit.tests.': {},
             'skipped.alevel.unit2.tests.': {},
         }
-        manager._zone_tree = None
-        self.assertEqual(
-            {
-                'unit.tests.': {'sub', 'another.sub', 'skipped.alevel'},
-                'sub.unit.tests.': {'another'},
-                'another.sub.unit.tests.': set(),
-                'skipped.alevel.unit.tests.': set(),
-                'unit2.tests.': {'sub', 'another.sub', 'skipped.alevel'},
-                'sub.unit2.tests.': {'another'},
-                'another.sub.unit2.tests.': set(),
-                'skipped.alevel.unit2.tests.': set(),
-            },
-            manager.zone_tree,
-        )
+        manager._configured_sub_zones = None
         self.assertEqual(
             {'another.sub', 'sub', 'skipped.alevel'},
             manager.configured_sub_zones('unit.tests.'),

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -776,6 +776,17 @@ class TestManager(TestCase):
             set(), manager.configured_sub_zones('skipped.alevel.unit2.tests.')
         )
 
+        # zones that end with names of others
+        manager.config['zones'] = {
+            'unit.tests.': {},
+            'uunit.tests.': {},
+            'uuunit.tests.': {},
+        }
+        manager._configured_sub_zones = None
+        self.assertEqual(set(), manager.configured_sub_zones('unit.tests.'))
+        self.assertEqual(set(), manager.configured_sub_zones('uunit.tests.'))
+        self.assertEqual(set(), manager.configured_sub_zones('uuunit.tests.'))
+
 
 class TestMainThreadExecutor(TestCase):
     def test_success(self):

--- a/tests/test_octodns_zone.py
+++ b/tests/test_octodns_zone.py
@@ -208,6 +208,16 @@ class TestZone(TestCase):
         zone.add_record(record, lenient=True)
         self.assertEqual(set([record]), zone.records)
 
+        # A that happens to end with a string that matches a sub (no .) is OK
+        zone = Zone('unit.tests.', set(['sub', 'barred']))
+        record = Record.new(
+            zone,
+            'foo.bar_sub',
+            {'ttl': 3600, 'type': 'A', 'values': ['1.2.3.4', '2.3.4.5']},
+        )
+        zone.add_record(record)
+        self.assertEqual(1, len(zone.records))
+
     def test_ignored_records(self):
         zone_normal = Zone('unit.tests.', [])
         zone_ignored = Zone('unit.tests.', [])


### PR DESCRIPTION
Refactor `Manager.zone_tree` for easier testing and add some thorough tests of it as well as `Manager.configured_sub_zones`.

/cc https://github.com/octodns/octodns/issues/916 which reported issues with sub-zone handling as of 0.9.18
/cc https://github.com/octodns/octodns/pull/908 which was a change in that release and likely related. 
/cc @brianeclow @nakato 