### PR TITLE
Fix subzone false positives on label longer than subzone

### DIFF
--- a/octodns/zone.py
+++ b/octodns/zone.py
@@ -73,18 +73,22 @@ class Zone(object):
 
         name = record.name
 
-        if not lenient and any((name.endswith(sz) for sz in self.sub_zones)):
+        # Create an exhaustive list of potential subzones for a label
+        parts = name.split('.')
+        name_zones = []
+        for index in range(len(parts)):
+            name_zones.append('.'.join(parts[index:]))
+
+        if not lenient and any(nz in self.sub_zones for nz in name_zones):
             if name not in self.sub_zones:
                 # it's a record for something under a sub-zone
                 raise SubzoneRecordException(
-                    f'Record {record.fqdn} is under ' 'a managed subzone'
+                    f'Record {record.fqdn} is under a managed subzone'
                 )
             elif record._type != 'NS':
                 # It's a non NS record for exactly a sub-zone
                 raise SubzoneRecordException(
-                    f'Record {record.fqdn} a '
-                    'managed sub-zone and not of '
-                    'type NS'
+                    f'Record {record.fqdn} is a managed sub-zone and not of type NS'
                 )
 
         if replace:

--- a/tests/config/unit.tests.yaml
+++ b/tests/config/unit.tests.yaml
@@ -167,6 +167,11 @@ sub.txt:
   values:
   - ns1.test.
   - ns2.test.
+sub_longer_label_not_subzone:
+  type: A
+  values:
+  - 192.0.2.22
+  - 192.0.2.23
 subzone:
   type: 'NS'
   values:

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -142,13 +142,13 @@ class TestManager(TestCase):
             environ['YAML_TMP_DIR'] = tmpdir.dirname
             environ['YAML_TMP_DIR2'] = tmpdir.dirname
             tc = Manager(get_config_filename('simple.yaml')).sync(dry_run=False)
-            self.assertEqual(28, tc)
+            self.assertEqual(29, tc)
 
             # try with just one of the zones
             tc = Manager(get_config_filename('simple.yaml')).sync(
                 dry_run=False, eligible_zones=['unit.tests.']
             )
-            self.assertEqual(22, tc)
+            self.assertEqual(23, tc)
 
             # the subzone, with 2 targets
             tc = Manager(get_config_filename('simple.yaml')).sync(
@@ -166,13 +166,13 @@ class TestManager(TestCase):
             tc = Manager(get_config_filename('simple.yaml')).sync(
                 dry_run=False, force=True
             )
-            self.assertEqual(28, tc)
+            self.assertEqual(29, tc)
 
             # Again with max_workers = 1
             tc = Manager(
                 get_config_filename('simple.yaml'), max_workers=1
             ).sync(dry_run=False, force=True)
-            self.assertEqual(28, tc)
+            self.assertEqual(29, tc)
 
             # Include meta
             tc = Manager(
@@ -180,7 +180,7 @@ class TestManager(TestCase):
                 max_workers=1,
                 include_meta=True,
             ).sync(dry_run=False, force=True)
-            self.assertEqual(33, tc)
+            self.assertEqual(34, tc)
 
     def test_eligible_sources(self):
         with TemporaryDirectory() as tmpdir:
@@ -260,13 +260,13 @@ class TestManager(TestCase):
             # compare doesn't use _process_desired_zone and thus doesn't filter
             # out root NS records, that seems fine/desirable
             changes = manager.compare(['in'], ['dump'], 'unit.tests.')
-            self.assertEqual(23, len(changes))
+            self.assertEqual(24, len(changes))
 
             # Compound sources with varying support
             changes = manager.compare(
                 ['in', 'nosshfp'], ['dump'], 'unit.tests.'
             )
-            self.assertEqual(22, len(changes))
+            self.assertEqual(23, len(changes))
 
             with self.assertRaises(ManagerException) as ctx:
                 manager.compare(['nope'], ['dump'], 'unit.tests.')

--- a/tests/test_octodns_provider_yaml.py
+++ b/tests/test_octodns_provider_yaml.py
@@ -40,7 +40,7 @@ class TestYamlProvider(TestCase):
 
         # without it we see everything
         source.populate(zone)
-        self.assertEqual(25, len(zone.records))
+        self.assertEqual(26, len(zone.records))
 
         source.populate(dynamic_zone)
         self.assertEqual(6, len(dynamic_zone.records))
@@ -64,12 +64,12 @@ class TestYamlProvider(TestCase):
             # We add everything
             plan = target.plan(zone)
             self.assertEqual(
-                22, len([c for c in plan.changes if isinstance(c, Create)])
+                23, len([c for c in plan.changes if isinstance(c, Create)])
             )
             self.assertFalse(isfile(yaml_file))
 
             # Now actually do it
-            self.assertEqual(22, target.apply(plan))
+            self.assertEqual(23, target.apply(plan))
             self.assertTrue(isfile(yaml_file))
 
             # Dynamic plan
@@ -101,7 +101,7 @@ class TestYamlProvider(TestCase):
             # A 2nd sync should still create everything
             plan = target.plan(zone)
             self.assertEqual(
-                22, len([c for c in plan.changes if isinstance(c, Create)])
+                23, len([c for c in plan.changes if isinstance(c, Create)])
             )
 
             with open(yaml_file) as fh:
@@ -123,6 +123,9 @@ class TestYamlProvider(TestCase):
                 self.assertTrue('values' in data.pop('loc'))
                 self.assertTrue('values' in data.pop('urlfwd'))
                 self.assertTrue('values' in data.pop('sub.txt'))
+                self.assertTrue(
+                    'values' in data.pop('sub_longer_label_not_subzone')
+                )
                 self.assertTrue('values' in data.pop('subzone'))
                 # these are stored as singular 'value'
                 self.assertTrue('value' in data.pop('_imap._tcp'))


### PR DESCRIPTION
If the label of a zone is longer than the subzone, then the matching on
label.endswith(subzone) will improperly match due to checking if the
label endswith any of the subzones.

As such, this means given the two following domains:
1. example.com
2. puff.example.com

If the label "jigglypuff" exists in the "example.com" zone, the
following error will be thrown.

octodns.zone.SubzoneRecordException: Record jigglypuff.example.com. is under a managed subzone

---

I'm not 100% certain this fully addresses #916, as I'm not sure how an exact subzone match is occurring, error message `Record example2.com. a managed sub-zone and not of type NS`, that would not have triggered in 0.9.17 but is in 0.9.18.  The names are obfuscated, so I've had to guess a lot here.