### PR TITLE
Rel 0.9.19 version bump & CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.9.18 - 2022-09-14 - Subzone handling
+
+* Fixed issue with sub-zone handling introduced in 0.9.18
+
 ## v0.9.18 - 2022-09-09 - Internationalization
 
 * Added octodns.idna idna_encode/idna_decode helpers, providers will need to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 * Added octodns.idna idna_encode/idna_decode helpers, providers will need to
   individually add support via these helpers though :-/
+* `black` formatting implemented (including .git-blame-ignore-revs)
+* --output-provider support for dump to allow configurable dump
+  formatting/details
+* TLSA record type support
+* Subzones support for skipping levels
 
 ## v0.9.17 - 2022-04-02 - Registration required
 

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -7,4 +7,4 @@ from __future__ import (
     unicode_literals,
 )
 
-__VERSION__ = '0.9.18'
+__VERSION__ = '0.9.19'


### PR DESCRIPTION
## v0.9.18 - 2022-09-14 - Subzone handling

* Fixed issue with sub-zone handling introduced in 0.9.18

## v0.9.18 - 2022-09-09 - Internationalization

* Added octodns.idna idna_encode/idna_decode helpers, providers will need to
  individually add support via these helpers though :-/
* `black` formatting implemented (including .git-blame-ignore-revs)
* --output-provider support for dump to allow configurable dump
  formatting/details
* TLSA record type support
* Subzones support for skipping levels