### PR TITLE
Everything works with IDNA encoded names internally 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## v0.9.19 - 2022-??-?? - ???
 
+#### Noteworthy changes
+
+* Added support for automatic handling of IDNA (utf-8) zones. Everything is
+  stored IDNA encoded internally. For ASCII zones that's a noop. For zones with
+  utf-8 chars they will be converted and all internals/providers will see the
+  encoded version and work with it without any knowledge of it having been
+  converted. This means that all providers will automatically support IDNA as of
+  this version. IDNA zones will generally be displayed in the logs in their
+  decoded form. Both forms should be accepted in command line arguments.
+  Providers may need to be updated to display the decoded form in their logs,
+  until then they'd display the IDNA version.
+
+#### Stuff
+
 * Addressed shortcomings with YamlProvider.SUPPORTS in that it didn't include
   dynamically registered types, was a static list that could have drifted over
   time even ignoring 3rd party types.

--- a/octodns/cmds/report.py
+++ b/octodns/cmds/report.py
@@ -93,7 +93,7 @@ def main():
         ]
 
     for record, futures in sorted(queries.items(), key=lambda d: d[0]):
-        stdout.write(record.fqdn)
+        stdout.write(record.decoded_fqdn)
         stdout.write(',')
         stdout.write(record._type)
         stdout.write(',')

--- a/octodns/idna.py
+++ b/octodns/idna.py
@@ -2,6 +2,8 @@
 #
 #
 
+from collections.abc import MutableMapping
+
 from idna import decode as _decode, encode as _encode
 
 # Providers will need to to make calls to these at the appropriate points,
@@ -12,6 +14,7 @@ from idna import decode as _decode, encode as _encode
 def idna_encode(name):
     # Based on https://github.com/psf/requests/pull/3695/files
     # #diff-0debbb2447ce5debf2872cb0e17b18babe3566e9d9900739e8581b355bd513f7R39
+    name = name.lower()
     try:
         name.encode('ascii')
         # No utf8 chars, just use as-is
@@ -34,3 +37,35 @@ def idna_decode(name):
         return _decode(name)
     # not idna, just return as-is
     return name
+
+
+class IdnaDict(MutableMapping):
+    '''A dict type that is insensitive to case and utf-8/idna encoded strings'''
+
+    def __init__(self, data=None):
+        self._data = dict()
+        if data is not None:
+            self.update(data)
+
+    def __setitem__(self, k, v):
+        self._data[idna_encode(k)] = v
+
+    def __getitem__(self, k):
+        return self._data[idna_encode(k)]
+
+    def __delitem__(self, k):
+        del self._data[idna_encode(k)]
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __len__(self):
+        return len(self._data)
+
+    def decoded_keys(self):
+        for key in self.keys():
+            yield idna_decode(key)
+
+    def decoded_items(self):
+        for key, value in self.items():
+            yield (idna_decode(key), value)

--- a/octodns/idna.py
+++ b/octodns/idna.py
@@ -69,3 +69,6 @@ class IdnaDict(MutableMapping):
     def decoded_items(self):
         for key, value in self.items():
             yield (idna_decode(key), value)
+
+    def __repr__(self):
+        return self._data.__repr__()

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -17,7 +17,7 @@ from sys import stdout
 import logging
 
 from . import __VERSION__
-from .idna import IdnaDict, idna_decode
+from .idna import IdnaDict, idna_decode, idna_encode
 from .provider.base import BaseProvider
 from .provider.plan import Plan
 from .provider.yaml import SplitYamlProvider, YamlProvider
@@ -464,13 +464,13 @@ class Manager(object):
             getattr(plan_output_fh, 'name', plan_output_fh.__class__.__name__),
         )
 
-        zones = self.config['zones'].items()
+        zones = self.config['zones']
         if eligible_zones:
-            zones = [z for z in zones if z[0] in eligible_zones]
+            zones = {idna_encode(n): zones.get(n) for n in eligible_zones}
 
         aliased_zones = {}
         futures = []
-        for zone_name, config in zones:
+        for zone_name, config in zones.items():
             self.log.info('sync:   zone=%s', idna_decode(zone_name))
             if 'alias' in config:
                 source_zone = config['alias']

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -338,6 +338,17 @@ class Manager(object):
         return kwargs
 
     def configured_sub_zones(self, zone_name):
+        '''
+        Accepts either UTF-8 or IDNA encoded zone name and returns the list of
+        any configured sub-zones in IDNA form. E.g. for the following
+        configured zones:
+          some.com.
+          other.some.com.
+          deep.thing.some.com.
+        It would return
+          other
+          deep.thing
+        '''
         if self._configured_sub_zones is None:
             # First time through we compute all the sub-zones
 

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -471,33 +471,22 @@ class Manager(object):
         aliased_zones = {}
         futures = []
         for zone_name, config in zones.items():
-            self.log.info('sync:   zone=%s', idna_decode(zone_name))
+            decoded_zone_name = idna_decode(zone_name)
+            self.log.info('sync:   zone=%s', decoded_zone_name)
             if 'alias' in config:
                 source_zone = config['alias']
 
                 # Check that the source zone is defined.
                 if source_zone not in self.config['zones']:
-                    self.log.error(
-                        f'Invalid alias zone {zone_name}, '
-                        f'target {source_zone} does not exist'
-                    )
-                    raise ManagerException(
-                        f'Invalid alias zone {zone_name}: '
-                        f'source zone {source_zone} does '
-                        'not exist'
-                    )
+                    msg = f'Invalid alias zone {decoded_zone_name}: source zone {idna_decode(source_zone)} does not exist'
+                    self.log.error(msg)
+                    raise ManagerException(msg)
 
                 # Check that the source zone is not an alias zone itself.
                 if 'alias' in self.config['zones'][source_zone]:
-                    self.log.error(
-                        f'Invalid alias zone {zone_name}, '
-                        f'target {source_zone} is an alias zone'
-                    )
-                    raise ManagerException(
-                        f'Invalid alias zone {zone_name}: '
-                        f'source zone {source_zone} is an '
-                        'alias zone'
-                    )
+                    msg = f'Invalid alias zone {decoded_zone_name}: source zone {idna_decode(source_zone)} is an alias zone'
+                    self.log.error(msg)
+                    raise ManagerException(msg)
 
                 aliased_zones[zone_name] = source_zone
                 continue
@@ -506,12 +495,16 @@ class Manager(object):
             try:
                 sources = config['sources']
             except KeyError:
-                raise ManagerException(f'Zone {zone_name} is missing sources')
+                raise ManagerException(
+                    f'Zone {decoded_zone_name} is missing sources'
+                )
 
             try:
                 targets = config['targets']
             except KeyError:
-                raise ManagerException(f'Zone {zone_name} is missing targets')
+                raise ManagerException(
+                    f'Zone {decoded_zone_name} is missing targets'
+                )
 
             processors = config.get('processors', [])
 
@@ -540,7 +533,8 @@ class Manager(object):
                 processors = collected
             except KeyError:
                 raise ManagerException(
-                    f'Zone {zone_name}, unknown ' f'processor: {processor}'
+                    f'Zone {decoded_zone_name}, unknown '
+                    f'processor: {processor}'
                 )
 
             try:
@@ -553,7 +547,7 @@ class Manager(object):
                 sources = collected
             except KeyError:
                 raise ManagerException(
-                    f'Zone {zone_name}, unknown ' f'source: {source}'
+                    f'Zone {decoded_zone_name}, unknown ' f'source: {source}'
                 )
 
             try:
@@ -568,7 +562,7 @@ class Manager(object):
                 targets = trgs
             except KeyError:
                 raise ManagerException(
-                    f'Zone {zone_name}, unknown ' f'target: {target}'
+                    f'Zone {decoded_zone_name}, unknown ' f'target: {target}'
                 )
 
             futures.append(
@@ -600,7 +594,7 @@ class Manager(object):
                 desired_config = desired[zone_source]
             except KeyError:
                 raise ManagerException(
-                    f'Zone {zone_name} cannot be sync '
+                    f'Zone {idna_decode(zone_name)} cannot be synced '
                     f'without zone {zone_source} sinced '
                     'it is aliased'
                 )

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -17,7 +17,7 @@ from sys import stdout
 import logging
 
 from . import __VERSION__
-from .idna import IdnaDict, idna_decode, idna_encode
+from .idna import IdnaDict, idna_decode
 from .provider.base import BaseProvider
 from .provider.plan import Plan
 from .provider.yaml import SplitYamlProvider, YamlProvider
@@ -466,7 +466,7 @@ class Manager(object):
 
         zones = self.config['zones']
         if eligible_zones:
-            zones = {idna_encode(n): zones.get(n) for n in eligible_zones}
+            zones = IdnaDict({n: zones.get(n) for n in eligible_zones})
 
         aliased_zones = {}
         futures = []

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -341,7 +341,7 @@ class Manager(object):
         if self._configured_sub_zones is None:
             # First time through we compute all the sub-zones
 
-            configured_sub_zones = {}
+            configured_sub_zones = IdnaDict()
 
             # Get a list of all of our zone names. Sort them from shortest to
             # longest so that parents will always come before their subzones
@@ -758,6 +758,7 @@ class Manager(object):
         target.apply(plan)
 
     def validate_configs(self):
+        # TODO: this code can probably be shared with stuff in sync
         for zone_name, config in self.config['zones'].items():
             zone = Zone(zone_name, self.configured_sub_zones(zone_name))
 
@@ -824,8 +825,10 @@ class Manager(object):
                 f'Invalid zone name {zone_name}, missing ' 'ending dot'
             )
 
-        for name, config in self.config['zones'].items():
-            if name == zone_name:
-                return Zone(name, self.configured_sub_zones(name))
+        zone = self.config['zones'].get(zone_name)
+        if zone:
+            return Zone(
+                idna_decode(zone_name), self.configured_sub_zones(zone_name)
+            )
 
         raise ManagerException(f'Unknown zone name {zone_name}')

--- a/octodns/provider/base.py
+++ b/octodns/provider/base.py
@@ -114,7 +114,7 @@ class BaseProvider(BaseSource):
                 self.log.warning(
                     'root NS record supported, but no record '
                     'is configured for %s',
-                    desired.name,
+                    desired.decoded_name,
                 )
         else:
             if record:
@@ -179,7 +179,7 @@ class BaseProvider(BaseSource):
         self.log.warning('%s; %s', msg, fallback)
 
     def plan(self, desired, processors=[]):
-        self.log.info('plan: desired=%s', desired.name)
+        self.log.info('plan: desired=%s', desired.decoded_name)
 
         existing = Zone(desired.name, desired.sub_zones)
         exists = self.populate(existing, target=True, lenient=True)
@@ -247,7 +247,7 @@ class BaseProvider(BaseSource):
             self.log.info('apply: disabled')
             return 0
 
-        zone_name = plan.desired.name
+        zone_name = plan.desired.decoded_name
         num_changes = len(plan.changes)
         self.log.info('apply: making %d changes to %s', num_changes, zone_name)
         self._apply(plan)

--- a/octodns/provider/plan.py
+++ b/octodns/provider/plan.py
@@ -165,8 +165,8 @@ class PlanLogger(_PlanOutput):
         if plans:
             current_zone = None
             for target, plan in plans:
-                if plan.desired.name != current_zone:
-                    current_zone = plan.desired.name
+                if plan.desired.decoded_name != current_zone:
+                    current_zone = plan.desired.decoded_name
                     buf.write(hr)
                     buf.write('* ')
                     buf.write(current_zone)
@@ -215,8 +215,8 @@ class PlanMarkdown(_PlanOutput):
         if plans:
             current_zone = None
             for target, plan in plans:
-                if plan.desired.name != current_zone:
-                    current_zone = plan.desired.name
+                if plan.desired.decoded_name != current_zone:
+                    current_zone = plan.desired.decoded_name
                     fh.write('## ')
                     fh.write(current_zone)
                     fh.write('\n\n')
@@ -276,8 +276,8 @@ class PlanHtml(_PlanOutput):
         if plans:
             current_zone = None
             for target, plan in plans:
-                if plan.desired.name != current_zone:
-                    current_zone = plan.desired.name
+                if plan.desired.decoded_name != current_zone:
+                    current_zone = plan.desired.decoded_name
                     fh.write('<h2>')
                     fh.write(current_zone)
                     fh.write('</h2>\n')

--- a/octodns/provider/yaml.py
+++ b/octodns/provider/yaml.py
@@ -148,7 +148,7 @@ class YamlProvider(BaseProvider):
         self.log = logging.getLogger(f'{klass}[{id}]')
         self.log.debug(
             '__init__: id=%s, directory=%s, default_ttl=%d, '
-            'nforce_order=%d, populate_should_replace=%d',
+            'enforce_order=%d, populate_should_replace=%d',
             id,
             directory,
             default_ttl,
@@ -254,6 +254,7 @@ class YamlProvider(BaseProvider):
                 del d['ttl']
             if record._octodns:
                 d['octodns'] = record._octodns
+            # we want to output the utf-8 version of the name
             data[record.decoded_name].append(d)
 
         # Flatten single element lists

--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -164,7 +164,7 @@ class Record(EqualityTupleMixin):
     def __init__(self, zone, name, data, source=None):
         self.log.debug(
             '__init__: zone.name=%s, type=%11s, name=%s',
-            zone.name,
+            zone.decoded_name,
             self.__class__.__name__,
             name,
         )

--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -167,12 +167,6 @@ class Record(EqualityTupleMixin):
         return reasons
 
     def __init__(self, zone, name, data, source=None):
-        self.log.debug(
-            '__init__: zone.name=%s, type=%11s, name=%s',
-            zone.decoded_name,
-            self.__class__.__name__,
-            name,
-        )
         self.zone = zone
         if name:
             # internally everything is idna
@@ -181,6 +175,12 @@ class Record(EqualityTupleMixin):
             self.decoded_name = idna_decode(self.name)
         else:
             self.name = self.decoded_name = name
+        self.log.debug(
+            '__init__: zone.name=%s, type=%11s, name=%s',
+            zone.decoded_name,
+            self.__class__.__name__,
+            self.decoded_name,
+        )
         self.source = source
         self.ttl = int(data['ttl'])
 

--- a/octodns/zone.py
+++ b/octodns/zone.py
@@ -41,7 +41,9 @@ class Zone(object):
         self.decoded_name = idna_decode(self.name)
         self.sub_zones = sub_zones
         # We're grouping by node, it allows us to efficiently search for
-        # duplicates and detect when CNAMEs co-exist with other records
+        # duplicates and detect when CNAMEs co-exist with other records. Also
+        # node that we always store things with Record.name which will be idna
+        # encoded thus we don't have to deal with idna/utf8 collisions
         self._records = defaultdict(set)
         self._root_ns = None
         # optional leading . to match empty hostname

--- a/octodns/zone.py
+++ b/octodns/zone.py
@@ -13,6 +13,7 @@ from collections import defaultdict
 from logging import getLogger
 import re
 
+from .idna import idna_decode
 from .record import Create, Delete
 
 
@@ -36,6 +37,7 @@ class Zone(object):
             raise Exception(f'Invalid zone name {name}, missing ending dot')
         # Force everything to lowercase just to be safe
         self.name = str(name).lower() if name else name
+        self.decoded_name = idna_decode(self.name)
         self.sub_zones = sub_zones
         # We're grouping by node, it allows us to efficiently search for
         # duplicates and detect when CNAMEs co-exist with other records
@@ -283,4 +285,4 @@ class Zone(object):
         return copy
 
     def __repr__(self):
-        return f'Zone<{self.name}>'
+        return f'Zone<{self.decoded_name}>'

--- a/octodns/zone.py
+++ b/octodns/zone.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 from logging import getLogger
 import re
 
-from .idna import idna_decode
+from .idna import idna_decode, idna_encode
 from .record import Create, Delete
 
 
@@ -36,7 +36,7 @@ class Zone(object):
         if not name[-1] == '.':
             raise Exception(f'Invalid zone name {name}, missing ending dot')
         # internally everything is idna
-        self.name = str(name).lower() if name else name
+        self.name = idna_encode(str(name)) if name else name
         # we'll keep a decoded version around for logs and errors
         self.decoded_name = idna_decode(self.name)
         self.sub_zones = sub_zones

--- a/octodns/zone.py
+++ b/octodns/zone.py
@@ -35,8 +35,9 @@ class Zone(object):
     def __init__(self, name, sub_zones):
         if not name[-1] == '.':
             raise Exception(f'Invalid zone name {name}, missing ending dot')
-        # Force everything to lowercase just to be safe
+        # internally everything is idna
         self.name = str(name).lower() if name else name
+        # we'll keep a decoded version around for logs and errors
         self.decoded_name = idna_decode(self.name)
         self.sub_zones = sub_zones
         # We're grouping by node, it allows us to efficiently search for

--- a/tests/test_octodns_idna.py
+++ b/tests/test_octodns_idna.py
@@ -59,6 +59,14 @@ class TestIdna(TestCase):
         self.assertEqual('zajęzyk.pl.', idna_decode('XN--ZAJZYK-Y4A.PL.'))
         self.assertEqual('xn--zajzyk-y4a.pl.', idna_encode('ZajęzyK.Pl.'))
 
+    def test_repeated_encode_decoded(self):
+        self.assertEqual(
+            'zajęzyk.pl.', idna_decode(idna_decode('xn--zajzyk-y4a.pl.'))
+        )
+        self.assertEqual(
+            'xn--zajzyk-y4a.pl.', idna_encode(idna_encode('zajęzyk.pl.'))
+        )
+
 
 class TestIdnaDict(TestCase):
     plain = 'testing.tests.'

--- a/tests/test_octodns_idna.py
+++ b/tests/test_octodns_idna.py
@@ -11,7 +11,7 @@ from __future__ import (
 
 from unittest import TestCase
 
-from octodns.idna import IdnaDict, idna_decode, idna_encode
+from octodns.idna import IdnaDict, IdnaError, idna_decode, idna_encode
 
 
 class TestIdna(TestCase):
@@ -66,6 +66,15 @@ class TestIdna(TestCase):
         self.assertEqual(
             'xn--zajzyk-y4a.pl.', idna_encode(idna_encode('zajęzyk.pl.'))
         )
+
+    def test_exception_translation(self):
+        with self.assertRaises(IdnaError) as ctx:
+            idna_encode('déjà..vu.')
+        self.assertEqual('Empty Label', str(ctx.exception))
+
+        with self.assertRaises(IdnaError) as ctx:
+            idna_decode('xn--djvu-1na6c..com.')
+        self.assertEqual('Empty Label', str(ctx.exception))
 
 
 class TestIdnaDict(TestCase):

--- a/tests/test_octodns_idna.py
+++ b/tests/test_octodns_idna.py
@@ -108,6 +108,9 @@ class TestIdnaDict(TestCase):
         self.assertFalse(self.utf8 in d)
         self.assertFalse(idna_encode(self.utf8) in d)
 
+        # smoke test of repr
+        d.__repr__()
+
     def test_keys(self):
         d = IdnaDict(self.normal)
 

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -11,6 +11,7 @@ from __future__ import (
 
 from unittest import TestCase
 
+from octodns.idna import idna_encode
 from octodns.record import (
     ARecord,
     AaaaRecord,
@@ -82,6 +83,18 @@ class TestRecord(TestCase):
             self.zone, 'MiXeDcAsE', {'ttl': 30, 'type': 'A', 'value': '1.2.3.4'}
         )
         self.assertEqual('mixedcase', record.name)
+
+    def test_utf8(self):
+        zone = Zone('natación.mx.', [])
+        utf8 = 'niño'
+        encoded = idna_encode(utf8)
+        record = ARecord(
+            zone, utf8, {'ttl': 30, 'type': 'A', 'value': '1.2.3.4'}
+        )
+        self.assertEqual(encoded, record.name)
+        self.assertEqual(utf8, record.decoded_name)
+        self.assertTrue(f'{encoded}.{zone.name}', record.fqdn)
+        self.assertTrue(f'{utf8}.{zone.decoded_name}', record.decoded_fqdn)
 
     def test_alias_lowering_value(self):
         upper_record = AliasRecord(

--- a/tests/test_octodns_zone.py
+++ b/tests/test_octodns_zone.py
@@ -11,6 +11,7 @@ from __future__ import (
 
 from unittest import TestCase
 
+from octodns.idna import idna_encode
 from octodns.record import (
     ARecord,
     AaaaRecord,
@@ -35,6 +36,13 @@ class TestZone(TestCase):
         zone = Zone('UniT.TEsTs.', [])
         self.assertEqual('unit.tests.', zone.name)
 
+    def test_utf8(self):
+        utf8 = 'grüßen.de.'
+        encoded = idna_encode(utf8)
+        zone = Zone(utf8, [])
+        self.assertEqual(encoded, zone.name)
+        self.assertEqual(utf8, zone.decoded_name)
+
     def test_hostname_from_fqdn(self):
         zone = Zone('unit.tests.', [])
         for hostname, fqdn in (
@@ -46,6 +54,27 @@ class TestZone(TestCase):
             ('foo.bar', 'foo.bar.unit.tests'),
             ('foo.unit.tests', 'foo.unit.tests.unit.tests.'),
             ('foo.unit.tests', 'foo.unit.tests.unit.tests'),
+            ('déjà', 'déjà.unit.tests'),
+            ('déjà.foo', 'déjà.foo.unit.tests'),
+            ('bar.déjà', 'bar.déjà.unit.tests'),
+            ('bar.déjà.foo', 'bar.déjà.foo.unit.tests'),
+        ):
+            self.assertEqual(hostname, zone.hostname_from_fqdn(fqdn))
+
+        zone = Zone('grüßen.de.', [])
+        for hostname, fqdn in (
+            ('', 'grüßen.de.'),
+            ('', 'grüßen.de'),
+            ('foo', 'foo.grüßen.de.'),
+            ('foo', 'foo.grüßen.de'),
+            ('foo.bar', 'foo.bar.grüßen.de.'),
+            ('foo.bar', 'foo.bar.grüßen.de'),
+            ('foo.grüßen.de', 'foo.grüßen.de.grüßen.de.'),
+            ('foo.grüßen.de', 'foo.grüßen.de.grüßen.de'),
+            ('déjà', 'déjà.grüßen.de'),
+            ('déjà.foo', 'déjà.foo.grüßen.de'),
+            ('bar.déjà', 'bar.déjà.grüßen.de'),
+            ('bar.déjà.foo', 'bar.déjà.foo.grüßen.de'),
         ):
             self.assertEqual(hostname, zone.hostname_from_fqdn(fqdn))
 


### PR DESCRIPTION
Major advantage to this route is that providers won't have to do anything to get IDNA support. The minor downside is that if they log the Zone name or Record name/fqdn they'll be printing the IDNA encoded version of it. This seems like an OK trade off and something they can update to handle in the future.

* Internally everything works in IDNA encoded names, both Zone and Record.
* IdnaDict type has been added which encodes all of its keys with idna and allows things to be accessed either way (it's like a case insensitive dict that also happens to be insensitive to idna encoding of things)
* Manager uses ^ for `self.config['zones']` so that everything works regardless of whether zones are referred to with encoded (asciii `xn--`) or decoded (utf-8) names
   * There are also checks to make sure zones aren't configured both with versions
* Zone.name is now encoded, there's a decoded version of name that's to be used in all situations where the user will be reading it. octoDNS core has made this change. All providers will want to do so after this change lands (if it does.)
* Record.name is now encoded, there's a decoded version of name that's to be used in all situations where the user will be reading it. octoDNS core has made this change. All providers will want to do so after this change lands (if it does.)

TODOs:
* [x] `YamProvider` needs to support looking for the decoded (preferred) name on disk and fall back to the encoded version if that's not found. It should probably throw an error of both exist.
* [x] Axfr need to support this, may be sufficient to just say that things should use idna encoded names?
* [x] TinyDNS need to support this, may be sufficient to just say that things should use idna encoded names
* [x] More testing
* [x] Discussion/thoughts of others
* [x] Should this be a 1.0 feature since it's a non-trivial change?
   * In general it should be fairly safe since we don't already support IDNA encoding things and everyone should have 100% ascii stuff (encoded manually if needed.) 


/cc https://github.com/octodns/octodns/issues/199