### PR TITLE
Processor impl that filters on name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Now that it's used as it needed to be YamlProvider overrides
   Provider.supports and just always says Yes so that any dynamically registered
   types will be supported.
+* NameAllowlistFilter & NameRejectlistFilter implementations to support
+  filtering on record names to include/exclude records from management.
 
 ## v0.9.18 - 2022-08-14 - Subzone handling
 

--- a/octodns/processor/filter.py
+++ b/octodns/processor/filter.py
@@ -137,8 +137,7 @@ class NameAllowlistFilter(_NameBaseFilter):
             name = record.name
             if name in self.exact:
                 continue
-
-            if any(r.search(name) for r in self.regex):
+            elif any(r.search(name) for r in self.regex):
                 continue
 
             zone.remove_record(record)

--- a/octodns/processor/filter.py
+++ b/octodns/processor/filter.py
@@ -9,6 +9,8 @@ from __future__ import (
     unicode_literals,
 )
 
+from re import compile as re_compile
+
 from .base import BaseProcessor
 
 
@@ -19,8 +21,8 @@ class TypeAllowlistFilter(BaseProcessor):
 
     processors:
       only-a-and-aaaa:
-        class: octodns.processor.filter.TypeRejectlistFilter
-        rejectlist:
+        class: octodns.processor.filter.TypeAllowlistFilter
+        allowlist:
           - A
           - AAAA
 
@@ -35,7 +37,7 @@ class TypeAllowlistFilter(BaseProcessor):
     '''
 
     def __init__(self, name, allowlist):
-        super(TypeAllowlistFilter, self).__init__(name)
+        super().__init__(name)
         self.allowlist = set(allowlist)
 
     def _process(self, zone, *args, **kwargs):
@@ -71,13 +73,124 @@ class TypeRejectlistFilter(BaseProcessor):
     '''
 
     def __init__(self, name, rejectlist):
-        super(TypeRejectlistFilter, self).__init__(name)
+        super().__init__(name)
         self.rejectlist = set(rejectlist)
 
     def _process(self, zone, *args, **kwargs):
         for record in zone.records:
             if record._type in self.rejectlist:
                 zone.remove_record(record)
+
+        return zone
+
+    process_source_zone = _process
+    process_target_zone = _process
+
+
+class _NameBaseFilter(BaseProcessor):
+    def __init__(self, name, _list):
+        super().__init__(name)
+        exact = set()
+        regex = []
+        for pattern in _list:
+            if pattern.startswith('/'):
+                regex.append(re_compile(pattern[1:-1]))
+            else:
+                exact.add(pattern)
+        self.exact = exact
+        self.regex = regex
+
+
+class NameAllowlistFilter(_NameBaseFilter):
+    '''Only manage records with names that match the provider patterns
+
+    Example usage:
+
+    processors:
+      only-these:
+        class: octodns.processor.filter.NameAllowlistFilter
+        allowlist:
+          # exact string match
+          - www
+          # contains/substring match
+          - /substring/
+          # regex pattern match
+          - /some-pattern-\\d\\+/
+          # regex - anchored so has to match start to end
+          - /^start-.+-end$/
+
+    zones:
+      exxampled.com.:
+        sources:
+          - config
+        processors:
+          - only-these
+        targets:
+          - route53
+    '''
+
+    def __init__(self, name, allowlist):
+        super().__init__(name, allowlist)
+
+    def _process(self, zone, *args, **kwargs):
+        for record in zone.records:
+            name = record.name
+            if name in self.exact:
+                continue
+
+            if any(r.search(name) for r in self.regex):
+                continue
+
+            zone.remove_record(record)
+
+        return zone
+
+    process_source_zone = _process
+    process_target_zone = _process
+
+
+class NameRejectlistFilter(_NameBaseFilter):
+    '''Reject managing records with names that match the provider patterns
+
+    Example usage:
+
+    processors:
+      not-these:
+        class: octodns.processor.filter.NameRejectlistFilter
+        rejectlist:
+          # exact string match
+          - www
+          # contains/substring match
+          - /substring/
+          # regex pattern match
+          - /some-pattern-\\d\\+/
+          # regex - anchored so has to match start to end
+          - /^start-.+-end$/
+
+    zones:
+      exxampled.com.:
+        sources:
+          - config
+        processors:
+          - not-these
+        targets:
+          - route53
+    '''
+
+    def __init__(self, name, rejectlist):
+        super().__init__(name, rejectlist)
+
+    def _process(self, zone, *args, **kwargs):
+        for record in zone.records:
+            name = record.name
+            if name in self.exact:
+                zone.remove_record(record)
+                continue
+
+            for regex in self.regex:
+                if regex.search(name):
+                    zone.remove_record(record)
+                    break
 
         return zone
 


### PR DESCRIPTION
Docstring have more details, but bascially this adds two new filter style processors that work on the record names allowing or rejecting based on which type is selected things that match the prescribed patterns. Patterns can be exact string matches or full regexes. 

/cc https://github.com/octodns/octodns/issues/752#issuecomment-1239726527 which requested this @sjparkinson