### PR TITLE
Global processors support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Now that it's used as it needed to be YamlProvider overrides
   Provider.supports and just always says Yes so that any dynamically registered
   types will be supported.
+* Support for configuring global processors that apply to all zones with
+  `manager.processors`
 
 ## v0.9.18 - 2022-08-14 - Subzone handling
 

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -127,6 +127,9 @@ class Manager(object):
             manager_config, include_meta
         )
 
+        self.global_processors = manager_config.get('processors', [])
+        self.log.info('__init__: global_processors=%s', self.global_processors)
+
         providers_config = self.config['providers']
         self.providers = self._config_providers(providers_config)
 
@@ -539,7 +542,7 @@ class Manager(object):
 
             try:
                 collected = []
-                for processor in processors:
+                for processor in self.global_processors + processors:
                     collected.append(self.processors[processor])
                 processors = collected
             except KeyError:

--- a/tests/config/processors.yaml
+++ b/tests/config/processors.yaml
@@ -1,3 +1,7 @@
+manager:
+  processors:
+    - global-counter
+
 providers:
   config:
     # This helps us get coverage when printing out provider versions
@@ -19,6 +23,8 @@ processors:
   test:
     # This helps us get coverage when printing out processor versions
     class: helpers.TestBaseProcessor
+  global-counter:
+    class: helpers.CountingProcessor
 
 zones:
   unit.tests.:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -131,3 +131,13 @@ class TestYamlProvider(YamlProvider):
 
 class TestBaseProcessor(BaseProcessor):
     pass
+
+
+class CountingProcessor(BaseProcessor):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.count = 0
+
+    def process_source_zone(self, zone, *args, **kwargs):
+        self.count += len(zone.records)
+        return zone

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -643,9 +643,16 @@ class TestManager(TestCase):
     def test_processor_config(self):
         # Smoke test loading a valid config
         manager = Manager(get_config_filename('processors.yaml'))
-        self.assertEqual(['noop', 'test'], list(manager.processors.keys()))
+        self.assertEqual(
+            ['noop', 'test', 'global-counter'], list(manager.processors.keys())
+        )
+        # make sure we got the global processor and that it's count is 0 now
+        self.assertEqual(['global-counter'], manager.global_processors)
+        self.assertEqual(0, manager.processors['global-counter'].count)
         # This zone specifies a valid processor
         manager.sync(['unit.tests.'])
+        # make sure the global processor ran and counted some records
+        self.assertTrue(manager.processors['global-counter'].count >= 25)
 
         with self.assertRaises(ManagerException) as ctx:
             # This zone specifies a non-existent processor


### PR DESCRIPTION
Add support for global processors that apply to all zones. This is a good place to hook in processors that are doing general validations etc or anything that would otherwise apply to all zones. It avoids the need to include a `processors` section in every single zone. For an example of the sort of process this probably makes sense with check out the `TtlRestrictionFilter` in https://github.com/octodns/octodns/pull/933.

This builds on top of https://github.com/octodns/octodns/pull/922 mainly b/c there's a bunch of refactoring in that PR that this was likely to conflict with. 