### PR TITLE
--quiet and --logging-config cmd line options

### DIFF
--- a/octodns/cmds/args.py
+++ b/octodns/cmds/args.py
@@ -50,6 +50,11 @@ class ArgumentParser(_Base):
             '--debug', action='store_true', default=False, help=_help
         )
 
+        _help = 'Decrease verbosity to show only warnings, errors, and the plan'
+        self.add_argument(
+            '--quiet', action='store_true', default=False, help=_help
+        )
+
         args = super().parse_args()
         self._setup_logging(args, default_log_level)
         return args
@@ -74,7 +79,11 @@ class ArgumentParser(_Base):
             handler.setFormatter(Formatter(fmt=fmt))
             logger.addHandler(handler)
 
-        logger.level = DEBUG if args.debug else default_log_level
+        logger.level = default_log_level
+        if args.debug:
+            logger.level = DEBUG
+        elif args.quiet:
+            logger.level = WARNING
 
         # boto is noisy, set it to warn
         getLogger('botocore').level = WARNING

--- a/octodns/cmds/args.py
+++ b/octodns/cmds/args.py
@@ -4,8 +4,10 @@
 
 from argparse import ArgumentParser as _Base
 from logging import DEBUG, INFO, WARNING, Formatter, StreamHandler, getLogger
+from logging.config import dictConfig
 from logging.handlers import SysLogHandler
 from sys import stderr, stdout
+from yaml import safe_load
 
 from octodns import __VERSION__
 
@@ -55,11 +57,22 @@ class ArgumentParser(_Base):
             '--quiet', action='store_true', default=False, help=_help
         )
 
+        _help = 'Configure logging with a YAML file, see https://docs.python.org/3/library/logging.config.html#logging-config-dictschema for schema details'
+        self.add_argument('--logging-config', default=False, help=_help)
+
         args = super().parse_args()
         self._setup_logging(args, default_log_level)
         return args
 
     def _setup_logging(self, args, default_log_level):
+        if args.logging_config:
+            with open(args.logging_config) as fh:
+                config = safe_load(fh.read())
+            dictConfig(config)
+            # if we're provided a logging_config we won't do any of our normal
+            # configuration
+            return
+
         fmt = '%(asctime)s [%(thread)d] %(levelname)-5s %(name)s %(message)s'
         formatter = Formatter(fmt=fmt, datefmt='%Y-%m-%dT%H:%M:%S ')
         stream = stdout if args.log_stream_stdout else stderr

--- a/octodns/cmds/args.py
+++ b/octodns/cmds/args.py
@@ -3,7 +3,7 @@
 #
 
 from argparse import ArgumentParser as _Base
-from logging import DEBUG, INFO, WARN, Formatter, StreamHandler, getLogger
+from logging import DEBUG, INFO, WARNING, Formatter, StreamHandler, getLogger
 from logging.handlers import SysLogHandler
 from sys import stderr, stdout
 
@@ -77,6 +77,6 @@ class ArgumentParser(_Base):
         logger.level = DEBUG if args.debug else default_log_level
 
         # boto is noisy, set it to warn
-        getLogger('botocore').level = WARN
+        getLogger('botocore').level = WARNING
         # DynectSession is noisy too
-        getLogger('DynectSession').level = WARN
+        getLogger('DynectSession').level = WARNING

--- a/octodns/cmds/args.py
+++ b/octodns/cmds/args.py
@@ -84,7 +84,11 @@ class ArgumentParser(_Base):
             logger.level = DEBUG
         elif args.quiet:
             logger.level = WARNING
+            # we still want plans to come out during quite so set the plan
+            # logger output to info in case the PlanLogger is being used
+            getLogger('Plan').setLevel(INFO)
 
+        # TODO: these should move out of octoDNS core...
         # boto is noisy, set it to warn
         getLogger('botocore').level = WARNING
         # DynectSession is noisy too

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -5,9 +5,9 @@
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor
 from importlib import import_module
+from logging import getLogger
 from os import environ
 from sys import stdout
-import logging
 
 from . import __VERSION__
 from .idna import IdnaDict, idna_decode, idna_encode
@@ -90,7 +90,8 @@ class ManagerException(Exception):
 
 
 class Manager(object):
-    log = logging.getLogger('Manager')
+    log = getLogger('Manager')
+    plan_log = getLogger('Plan')
 
     @classmethod
     def _plan_keyer(cls, p):
@@ -629,7 +630,7 @@ class Manager(object):
         plans.sort(key=self._plan_keyer, reverse=True)
 
         for output in self.plan_outputs.values():
-            output.run(plans=plans, log=self.log, fh=plan_output_fh)
+            output.run(plans=plans, log=self.plan_log, fh=plan_output_fh)
 
         if not force:
             self.log.debug('sync:   checking safety')

--- a/octodns/provider/plan.py
+++ b/octodns/provider/plan.py
@@ -134,6 +134,19 @@ class _PlanOutput(object):
         self.name = name
 
 
+class _LogLevelSetter:
+    def __init__(self, logger, level):
+        self.logger = getLogger()
+        self.level = level
+
+    def __enter__(self, *args, **kwargs):
+        self.original_level = self.logger.level
+        self.logger.setLevel(self.level)
+
+    def __exit__(self, *args, **kwargs):
+        self.logger.setLevel(self.original_level)
+
+
 class PlanLogger(_PlanOutput):
     def __init__(self, name, level='info'):
         super().__init__(name)
@@ -189,7 +202,9 @@ class PlanLogger(_PlanOutput):
             buf.write('No changes were planned\n')
         buf.write(hr)
         buf.write('\n')
-        log.log(self.level, buf.getvalue())
+
+        with _LogLevelSetter(log, INFO):
+            log.log(self.level, buf.getvalue())
 
 
 def _value_stringifier(record, sep):

--- a/octodns/provider/plan.py
+++ b/octodns/provider/plan.py
@@ -134,19 +134,6 @@ class _PlanOutput(object):
         self.name = name
 
 
-class _LogLevelSetter:
-    def __init__(self, logger, level):
-        self.logger = getLogger()
-        self.level = level
-
-    def __enter__(self, *args, **kwargs):
-        self.original_level = self.logger.level
-        self.logger.setLevel(self.level)
-
-    def __exit__(self, *args, **kwargs):
-        self.logger.setLevel(self.original_level)
-
-
 class PlanLogger(_PlanOutput):
     def __init__(self, name, level='info'):
         super().__init__(name)
@@ -203,8 +190,7 @@ class PlanLogger(_PlanOutput):
         buf.write(hr)
         buf.write('\n')
 
-        with _LogLevelSetter(log, INFO):
-            log.log(self.level, buf.getvalue())
+        log.log(self.level, buf.getvalue())
 
 
 def _value_stringifier(record, sep):


### PR DESCRIPTION
~~Annoying that the plan print needed a context to cleanly/safely change the level for a second to ensure the plan prints, but I guess it kind of makes sense.~~ Less verbosity would make it more likely that `WARNING`s are seen so that's good. Maybe worth it. This doesn't change any default behaviors beyond a dedicated logger for plans. It just adds a `--quiet` and `--logging-config` options.

/cc Fixes https://github.com/octodns/octodns/issues/943
/cc @runephilosof-abtion 