### PR TITLE
Rel 0.9.20 version bump & CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.9.20 - 2022-??-?? - ???
+## v0.9.20 - 2022-10-05 - International friendly
 
 #### Noteworthy changes
 
@@ -34,6 +34,15 @@
   filtering on record names to include/exclude records from management.
 * All Record values are now first class objects. This shouldn't be an externally
   visible change, but will enable future improvements.
+* --quiet command line option added to raise log level to WARNING, plan
+  output now comes from `plan` logger rather than `Manager` so that it can stay
+  at info
+* --logging-config command line option added to allow complete logging config
+  customization, see
+  https://docs.python.org/3/library/logging.config.html#logging-config-dictschema
+  for file format and
+  https://github.com/octodns/octodns/pull/945#issuecomment-1262839550 for an
+  example config
 
 ## v0.9.19 - 2022-08-14 - Subzone handling
 

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -1,3 +1,3 @@
 'OctoDNS: DNS as code - Tools for managing DNS across multiple providers'
 
-__VERSION__ = '0.9.19'
+__VERSION__ = '0.9.20'


### PR DESCRIPTION
## v0.9.20 - 2022-10-05 - International friendly

#### Noteworthy changes

* Added support for automatic handling of IDNA (utf-8) zones. Everything is
  stored IDNA encoded internally. For ASCII zones that's a noop. For zones with
  utf-8 chars they will be converted and all internals/providers will see the
  encoded version and work with it without any knowledge of it having been
  converted. This means that all providers will automatically support IDNA as of
  this version. IDNA zones will generally be displayed in the logs in their
  decoded form. Both forms should be accepted in command line arguments.
  Providers may need to be updated to display the decoded form in their logs,
  until then they'd display the IDNA version.
* IDNA value support for Record types that hold FQDNs: ALIAS, CNAME, DNAME, PTR,
  MX, NS, and SRV.
* Support for configuring global processors that apply to all zones with
  `manager.processors`

#### Stuff

* Addressed shortcomings with YamlProvider.SUPPORTS in that it didn't include
  dynamically registered types, was a static list that could have drifted over
  time even ignoring 3rd party types.
* Provider._process_desired_zone needed to call Provider.supports rather than
  doing it's own `_type in provider.SUPPORTS`. The default behavior in
  Source.supports is ^, but it's possible for providers to override that
  behavior and do special checking and `_process_desired_zone` wasn't taking
  that into account.
* Now that it's used as it needed to be YamlProvider overrides
  Provider.supports and just always says Yes so that any dynamically registered
  types will be supported.
* Add TtlRestrictionFilter processor for adding ttl restriction/checking
* NameAllowlistFilter & NameRejectlistFilter implementations to support
  filtering on record names to include/exclude records from management.
* All Record values are now first class objects. This shouldn't be an externally
  visible change, but will enable future improvements.
* --quiet command line option added to raise log level to WARNING, plan
  output now comes from `plan` logger rather than `Manager` so that it can stay
  at info
* --logging-config command line option added to allow complete logging config
  customization, see
  https://docs.python.org/3/library/logging.config.html#logging-config-dictschema
  for file format and
  https://github.com/octodns/octodns/pull/945#issuecomment-1262839550 for an
  example config