### PR TITLE
Add IgnoreRootNsFilter w/tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v1.0.0.rc0 - 2022-??-?? - First of the ones
+
+#### Noteworthy changes
+
+#### Stuff
+
+* Added simple IgnoreRootNsFilter
+
 ## v0.9.21 - 2022-10-16 - Last of the oughts
 
 * Shim AxfrSource and ZoneFileSource post extraction into

--- a/octodns/processor/filter.py
+++ b/octodns/processor/filter.py
@@ -188,3 +188,33 @@ class NameRejectlistFilter(_NameBaseFilter):
 
     process_source_zone = _process
     process_target_zone = _process
+
+
+class IgnoreRootNsFilter(BaseProcessor):
+    '''Do not manage Root NS Records.
+
+    Example usage:
+
+    processors:
+      no-root-ns:
+        class: octodns.processor.filter.IgnoreRootNsFilter
+
+    zones:
+      exxampled.com.:
+        sources:
+          - config
+        processors:
+          - no-root-ns
+        targets:
+          - ns1
+    '''
+
+    def _process(self, zone, *args, **kwargs):
+        for record in zone.records:
+            if record._type == 'NS' and not record.name:
+                zone.remove_record(record)
+
+        return zone
+
+    process_source_zone = _process
+    process_target_zone = _process


### PR DESCRIPTION
Simple filter to ignore Root NS records that can be used in cases where one or more providers involved in a sync support Root NS records but the user wishes to leave them unmanaged.

/cc Fixes https://github.com/octodns/octodns/issues/954 @sevencastles 