### PR TITLE
1.0 RC: Provider.strict_supports=True by default, fix tests that didn't like that

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 #### Noteworthy changes
 
+* Provider.strict_supports defaults to true, can be returned to the old
+  behavior by setting strict_supports=False in your provider params.
+
 #### Stuff
 
 * Added simple IgnoreRootNsFilter

--- a/octodns/provider/base.py
+++ b/octodns/provider/base.py
@@ -15,7 +15,7 @@ class BaseProvider(BaseSource):
         apply_disabled=False,
         update_pcent_threshold=Plan.MAX_SAFE_UPDATE_PCENT,
         delete_pcent_threshold=Plan.MAX_SAFE_DELETE_PCENT,
-        strict_supports=False,
+        strict_supports=True,
     ):
         super().__init__(id)
         self.log.debug(

--- a/tests/config/always-dry-run.yaml
+++ b/tests/config/always-dry-run.yaml
@@ -2,10 +2,12 @@ providers:
   in:
     class: octodns.provider.yaml.YamlProvider
     directory: tests/config
+    strict_supports: False
   dump:
     class: octodns.provider.yaml.YamlProvider
     directory: env/YAML_TMP_DIR
     supports_root_ns: False
+    strict_supports: False
 zones:
   unit.tests.:
     always-dry-run: true

--- a/tests/config/processors.yaml
+++ b/tests/config/processors.yaml
@@ -7,10 +7,12 @@ providers:
     # This helps us get coverage when printing out provider versions
     class: helpers.TestYamlProvider
     directory: tests/config
+    strict_supports: False
   dump:
     class: octodns.provider.yaml.YamlProvider
     directory: env/YAML_TMP_DIR
     supports_root_ns: False
+    strict_supports: False
   geo:
     class: helpers.GeoProvider
   nosshfp:

--- a/tests/config/simple-alias-zone.yaml
+++ b/tests/config/simple-alias-zone.yaml
@@ -4,10 +4,12 @@ providers:
   in:
     class: octodns.provider.yaml.YamlProvider
     directory: tests/config
+    strict_supports: False
   dump:
     class: octodns.provider.yaml.YamlProvider
     directory: env/YAML_TMP_DIR
     supports_root_ns: False
+    strict_supports: False
 zones:
   unit.tests.:
     sources:

--- a/tests/config/simple.yaml
+++ b/tests/config/simple.yaml
@@ -5,17 +5,20 @@ providers:
     class: octodns.provider.yaml.YamlProvider
     directory: tests/config
     supports_root_ns: False
+    strict_supports: False
   dump:
     class: octodns.provider.yaml.YamlProvider
     directory: env/YAML_TMP_DIR
     default_ttl: 999
     supports_root_ns: False
+    strict_supports: False
   # This is sort of ugly, but it shouldn't hurt anything. It'll just write out
   # the target file twice where it and dump are both used
   dump2:
     class: octodns.provider.yaml.YamlProvider
     directory: env/YAML_TMP_DIR2
     supports_root_ns: False
+    strict_supports: False
   simple:
     class: helpers.SimpleProvider
   geo:

--- a/tests/test_octodns_provider_base.py
+++ b/tests/test_octodns_provider_base.py
@@ -715,6 +715,7 @@ class TestBaseProviderSupportsRootNs(TestCase):
     def test_supports_root_ns_false_matches(self):
         # provider has a matching existing root record
         provider = self.Provider(self.has_root)
+        provider.strict_supports = False
         provider.SUPPORTS_ROOT_NS = False
 
         # matching root NS in the desired
@@ -737,6 +738,7 @@ class TestBaseProviderSupportsRootNs(TestCase):
     def test_supports_root_ns_false_different(self):
         # provider has a non-matching existing record
         provider = self.Provider(self.different_root)
+        provider.strict_supports = False
         provider.SUPPORTS_ROOT_NS = False
 
         # different root is in the desired
@@ -760,6 +762,7 @@ class TestBaseProviderSupportsRootNs(TestCase):
     def test_supports_root_ns_false_missing(self):
         # provider has an existing record
         provider = self.Provider(self.has_root)
+        provider.strict_supports = False
         provider.SUPPORTS_ROOT_NS = False
 
         # desired doesn't have a root
@@ -778,6 +781,7 @@ class TestBaseProviderSupportsRootNs(TestCase):
     def test_supports_root_ns_false_create_zone(self):
         # provider has no existing records (create)
         provider = self.Provider()
+        provider.strict_supports = False
         provider.SUPPORTS_ROOT_NS = False
 
         # case where we have a root NS in the desired

--- a/tests/test_octodns_provider_yaml.py
+++ b/tests/test_octodns_provider_yaml.py
@@ -54,7 +54,9 @@ class TestYamlProvider(TestCase):
             directory = join(td.dirname, 'sub', 'dir')
             yaml_file = join(directory, 'unit.tests.yaml')
             dynamic_yaml_file = join(directory, 'dynamic.tests.yaml')
-            target = YamlProvider('test', directory, supports_root_ns=False)
+            target = YamlProvider(
+                'test', directory, supports_root_ns=False, strict_supports=False
+            )
 
             # We add everything
             plan = target.plan(zone)
@@ -343,7 +345,10 @@ class TestSplitYamlProvider(TestCase):
 
     def test_provider(self):
         source = SplitYamlProvider(
-            'test', join(dirname(__file__), 'config/split'), extension='.tst'
+            'test',
+            join(dirname(__file__), 'config/split'),
+            extension='.tst',
+            strict_supports=False,
         )
 
         zone = Zone('unit.tests.', [])
@@ -366,7 +371,11 @@ class TestSplitYamlProvider(TestCase):
             zone_dir = join(directory, 'unit.tests.tst')
             dynamic_zone_dir = join(directory, 'dynamic.tests.tst')
             target = SplitYamlProvider(
-                'test', directory, extension='.tst', supports_root_ns=False
+                'test',
+                directory,
+                extension='.tst',
+                supports_root_ns=False,
+                strict_supports=False,
             )
 
             # We add everything


### PR DESCRIPTION
* Provider.strict_supports defaults to true, can be returned to the old behavior by setting strict_supports=False in your provider params.