### PR TITLE
Add Zone.config, pass it in from Manager.get_zone

### DIFF
--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -833,6 +833,6 @@ class Manager(object):
         zone = self.config['zones'].get(zone_name)
         if zone is not None:
             sub_zones = self.configured_sub_zones(zone_name)
-            return Zone(idna_encode(zone_name), sub_zones)
+            return Zone(idna_encode(zone_name), sub_zones, config=zone)
 
         raise ManagerException(f'Unknown zone name {idna_decode(zone_name)}')

--- a/octodns/zone.py
+++ b/octodns/zone.py
@@ -25,7 +25,7 @@ class InvalidNodeException(Exception):
 class Zone(object):
     log = getLogger('Zone')
 
-    def __init__(self, name, sub_zones):
+    def __init__(self, name, sub_zones, config={}):
         if not name[-1] == '.':
             raise Exception(f'Invalid zone name {name}, missing ending dot')
         # internally everything is idna
@@ -33,6 +33,7 @@ class Zone(object):
         # we'll keep a decoded version around for logs and errors
         self.decoded_name = idna_decode(self.name)
         self.sub_zones = sub_zones
+        self.config = config
         # We're grouping by node, it allows us to efficiently search for
         # duplicates and detect when CNAMEs co-exist with other records. Also
         # node that we always store things with Record.name which will be idna


### PR DESCRIPTION
Pass in zone config to Zone object so that things can get at extra configuration for the zone, e.g. TTLs. 

After starting to try and use this I pretty quickly realized that it's not viable as all of the providers are creating records themselves and would have to individually be updated to look into the zone for the ttl or any other extra config. Too cumbersome and more importantly error prone. ☹️ 

/cc https://github.com/octodns/octodns/issues/75