### PR TITLE
Add custom zone file name support

### DIFF
--- a/octodns/provider/yaml.py
+++ b/octodns/provider/yaml.py
@@ -21,6 +21,10 @@ class YamlProvider(BaseProvider):
         class: octodns.provider.yaml.YamlProvider
         # The location of yaml config files (required)
         directory: ./config
+        # Specify a custom zone file name
+        # File present in the directory declared in "directory" without specifying the extension.
+        # (optional, default empty)
+        file_name: "test"
         # The ttl to use for records when not specified in the data
         # (optional, default 3600)
         default_ttl: 3600
@@ -105,11 +109,13 @@ class YamlProvider(BaseProvider):
     SUPPORTS_DYNAMIC = True
     SUPPORTS_POOL_VALUE_STATUS = True
     SUPPORTS_MULTIVALUE_PTR = True
+    FILE_NAME = ""
 
     def __init__(
         self,
         id,
         directory,
+        file_name="",
         default_ttl=3600,
         enforce_order=True,
         populate_should_replace=False,
@@ -129,6 +135,7 @@ class YamlProvider(BaseProvider):
             populate_should_replace,
         )
         super().__init__(id, *args, **kwargs)
+        self.file_name = file_name
         self.directory = directory
         self.default_ttl = default_ttl
         self.enforce_order = enforce_order
@@ -198,7 +205,11 @@ class YamlProvider(BaseProvider):
 
         before = len(zone.records)
         utf8_filename = join(self.directory, f'{zone.decoded_name}yaml')
-        idna_filename = join(self.directory, f'{zone.name}yaml')
+
+        if self.file_name == "":
+            idna_filename = join(self.directory, f'{zone.name}yaml')
+        else:
+            idna_filename = join(self.directory, f'{self.file_name}.yaml')
 
         # we prefer utf8
         if isfile(utf8_filename):
@@ -298,6 +309,10 @@ class SplitYamlProvider(YamlProvider):
         class: octodns.provider.yaml.SplitYamlProvider
         # The location of yaml config files (required)
         directory: ./config
+        # Specify a custom zone file name
+        # File present in the directory declared in "directory" without specifying the extension.
+        # (optional, default empty)
+        file_name: "test"
         # The ttl to use for records when not specified in the data
         # (optional, default 3600)
         default_ttl: 3600
@@ -310,12 +325,16 @@ class SplitYamlProvider(YamlProvider):
     # instead of a file matching the record name.
     CATCHALL_RECORD_NAMES = ('*', '')
 
-    def __init__(self, id, directory, extension='.', *args, **kwargs):
+    def __init__(
+        self, id, directory, file_name='', extension='.', *args, **kwargs
+    ):
         super().__init__(id, directory, *args, **kwargs)
         self.extension = extension
+        self.file_name = file_name
 
     def _zone_directory(self, zone):
         filename = f'{zone.name[:-1]}{self.extension}'
+
         return join(self.directory, filename)
 
     def populate(self, zone, target=False, lenient=False):

--- a/octodns/provider/yaml.py
+++ b/octodns/provider/yaml.py
@@ -148,6 +148,11 @@ class YamlProvider(BaseProvider):
         del args['log']
         return self.__class__(**args)
 
+    def get_filenames(self, zone):
+        utf8_filename = join(self.directory, f'{zone.decoded_name}yaml')
+        idna_filename = join(self.directory, f'{zone.name}yaml')
+        return utf8_filename, idna_filename
+
     @property
     def SUPPORTS(self):
         # The yaml provider supports all record types even those defined by 3rd
@@ -204,10 +209,10 @@ class YamlProvider(BaseProvider):
             return False
 
         before = len(zone.records)
-        utf8_filename = join(self.directory, f'{zone.decoded_name}yaml')
 
+        utf8_filename = join(self.directory, f'{zone.decoded_name}yaml')
         if self.file_name == "":
-            idna_filename = join(self.directory, f'{zone.name}yaml')
+            utf8_filename, idna_filename = self.get_filenames(zone)
         else:
             idna_filename = join(self.directory, f'{self.file_name}.yaml')
 


### PR DESCRIPTION
We needed to split our area into several sub-files, we did not want to go through the area name for a given file since we have the following tree structure.

```bash
zones/example.org/root-records.yaml
zones/example.org/project1/records.yaml
zones/example.org/project2/records.yaml
zones/example.org/project3/example.org.yaml
```

And in zone config for example:

```yaml
---
providers:
  root-records:
    class: octodns.provider.yaml.YamlProvider
    directory: zones/example.org/
    file_name: "root-record"
    default_ttl: 3600
    enforce_order: False
  project1:
    class: octodns.provider.yaml.YamlProvider
    directory: zones/example.org/project1/
    file_name: "records"
    default_ttl: 60
  project2:
    class: octodns.provider.yaml.YamlProvider
    directory: zones/example.org/project2/
    file_name: "records"
    default_ttl: 60
  project3:
    class: octodns.provider.yaml.YamlProvider
    directory: zones/example.org/project3/
    default_ttl: 60
  route53:
    class: octodns_route53.Route53Provider
    access_key_id: env/AWS_ACCESS_KEY_ID
    secret_access_key: env/AWS_SECRET_ACCESS_KEY
    max_changes: 100

zones:
  example.org.:
    sources:
      - root-records
      - project1
      - project2
    targets:
      - route53
```

That's why I took the liberty of adding this feature which allows you to split an area into several sub-files when it is very large.