### PR TITLE
Refactor YamlProvider to add get_filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 #### Stuff
 
 * Added simple IgnoreRootNsFilter
+* Minor refactor on YamlProvider to add get_filenames making it a bit easier to
+  create specialized providers inheriting from it
 
 ## v0.9.21 - 2022-10-16 - Last of the oughts
 

--- a/octodns/provider/yaml.py
+++ b/octodns/provider/yaml.py
@@ -183,6 +183,12 @@ class YamlProvider(BaseProvider):
                 '_populate_from_file: successfully loaded "%s"', filename
             )
 
+    def get_filenames(self, zone):
+        return (
+            join(self.directory, f'{zone.decoded_name}yaml'),
+            join(self.directory, f'{zone.name}yaml'),
+        )
+
     def populate(self, zone, target=False, lenient=False):
         self.log.debug(
             'populate: name=%s, target=%s, lenient=%s',
@@ -197,8 +203,7 @@ class YamlProvider(BaseProvider):
             return False
 
         before = len(zone.records)
-        utf8_filename = join(self.directory, f'{zone.decoded_name}yaml')
-        idna_filename = join(self.directory, f'{zone.name}yaml')
+        utf8_filename, idna_filename = self.get_filenames(zone)
 
         # we prefer utf8
         if isfile(utf8_filename):


### PR DESCRIPTION
Makes it easier to inherit from YamlProvider to add custom filename handling

/cc https://github.com/octodns/octodns/pull/961 which this replaces
/cc https://github.com/octodns/octodns/issues/962 which discusses this change as well.