### PR TITLE
Add SPF processor to validate SPF values in TXT records

### DIFF
--- a/octodns/processor/spf.py
+++ b/octodns/processor/spf.py
@@ -4,6 +4,10 @@
 
 from logging import getLogger
 
+import dns.resolver
+
+from octodns.record.base import Record
+
 from .base import BaseProcessor, ProcessorException
 
 
@@ -22,6 +26,47 @@ class SpfDnsLookupProcessor(BaseProcessor):
         self.log.debug(f"SpfDnsLookupProcessor: {name}")
         super().__init__(name)
 
+    def _lookup(
+        self, record: Record, values: list[str], lookups: int = 0
+    ) -> int:
+        # SPF values must begin with 'v=spf1 '
+        spf = [value for value in values if value.startswith('v=spf1 ')]
+
+        if len(spf) == 0:
+            return lookups
+
+        if len(spf) > 1:
+            raise SpfValueException(
+                f"{record.fqdn} has more than one SPF value"
+            )
+
+        spf = spf[0]
+
+        terms = spf.removeprefix('v=spf1 ').split(' ')
+
+        for term in terms:
+            if lookups > 10:
+                raise SpfDnsLookupException(
+                    f"{record.fqdn} exceeds the 10 DNS lookup limit in the SPF record"
+                )
+
+            # These mechanisms cost one DNS lookup each
+            if term.startswith(
+                ('a', 'mx', 'exists:', 'redirect', 'include:', 'ptr')
+            ):
+                lookups += 1
+
+            # The include mechanism can result in further lookups after resolving the DNS record
+            if term.startswith('include:'):
+                answer = dns.resolver.resolve(
+                    term.removeprefix('include:'), 'TXT'
+                )
+                lookups = self._lookup(
+                    record, [value.to_text()[1:-1] for value in answer], lookups
+                )
+
+        return lookups
+
     def process_source_zone(self, zone, *args, **kwargs):
         for record in zone.records:
             if record._type != 'TXT':
@@ -30,29 +75,6 @@ class SpfDnsLookupProcessor(BaseProcessor):
             if record._octodns.get('lenient'):
                 continue
 
-            # SPF values must begin with 'v=spf1 '
-            values = [
-                value for value in record.values if value.startswith('v=spf1 ')
-            ]
-
-            if len(values) == 0:
-                continue
-
-            if len(values) > 1:
-                raise SpfValueException(
-                    f"{record.fqdn} has more than one SPF value"
-                )
-
-            lookups = 0
-            terms = values[0].removeprefix('v=spf1 ').split(' ')
-
-            for term in terms:
-                if lookups > 10:
-                    raise SpfDnsLookupException(
-                        f"{record.fqdn} has too many SPF DNS lookups"
-                    )
-
-                if term in ['a', 'mx', 'exists', 'redirect']:
-                    lookups += 1
+            self._lookup(record, record.values)
 
         return zone

--- a/octodns/processor/spf.py
+++ b/octodns/processor/spf.py
@@ -22,6 +22,35 @@ class SpfDnsLookupException(ProcessorException):
 
 
 class SpfDnsLookupProcessor(BaseProcessor):
+    '''
+    Validate that SPF values in TXT records are valid.
+
+    Example usage:
+
+    processors:
+      spf:
+        class: octodns.processor.spf.SpfDnsLookupProcessor
+
+    zones:
+      example.com.:
+        sources:
+          - config
+        processors:
+          - spf
+        targets:
+          - route53
+
+    The validation can be skipped for specific records by setting the lenient
+    flag, e.g.
+
+    _spf:
+      octodns:
+        lenient: true
+      ttl: 86400
+      type: TXT
+      value: v=spf1 ptr ~all
+    '''
+
     log = getLogger('SpfDnsLookupProcessor')
 
     def __init__(self, name):

--- a/octodns/processor/spf.py
+++ b/octodns/processor/spf.py
@@ -1,0 +1,58 @@
+#
+#
+#
+
+from logging import getLogger
+
+from .base import BaseProcessor, ProcessorException
+
+
+class SpfValueException(ProcessorException):
+    pass
+
+
+class SpfDnsLookupException(ProcessorException):
+    pass
+
+
+class SpfDnsLookupProcessor(BaseProcessor):
+    log = getLogger('SpfDnsLookupProcessor')
+
+    def __init__(self, name):
+        self.log.debug(f"SpfDnsLookupProcessor: {name}")
+        super().__init__(name)
+
+    def process_source_zone(self, zone, *args, **kwargs):
+        for record in zone.records:
+            if record._type != 'TXT':
+                continue
+
+            if record._octodns.get('lenient'):
+                continue
+
+            # SPF values must begin with 'v=spf1 '
+            values = [
+                value for value in record.values if value.startswith('v=spf1 ')
+            ]
+
+            if len(values) == 0:
+                continue
+
+            if len(values) > 1:
+                raise SpfValueException(
+                    f"{record.fqdn} has more than one SPF value"
+                )
+
+            lookups = 0
+            terms = values[0].removeprefix('v=spf1 ').split(' ')
+
+            for term in terms:
+                if lookups > 10:
+                    raise SpfDnsLookupException(
+                        f"{record.fqdn} has too many SPF DNS lookups"
+                    )
+
+                if term in ['a', 'mx', 'exists', 'redirect']:
+                    lookups += 1
+
+        return zone

--- a/octodns/processor/spf.py
+++ b/octodns/processor/spf.py
@@ -101,7 +101,7 @@ class SpfDnsLookupProcessor(BaseProcessor):
         if spf is None:
             return lookups
 
-        terms = spf.removeprefix('v=spf1 ').split(' ')
+        terms = spf[len('v=spf1 ') :].split(' ')
 
         for term in terms:
             if lookups > 10:
@@ -120,7 +120,7 @@ class SpfDnsLookupProcessor(BaseProcessor):
 
             # The include mechanism can result in further lookups after resolving the DNS record
             if term.startswith('include:'):
-                domain = term.removeprefix('include:')
+                domain = term[len('include:') :]
                 answer = dns.resolver.resolve(domain, 'TXT')
                 answer_values = self._process_answer(answer)
                 lookups = self._check_dns_lookups(

--- a/octodns/processor/spf.py
+++ b/octodns/processor/spf.py
@@ -73,10 +73,13 @@ class SpfDnsLookupProcessor(BaseProcessor):
                     f"{record.fqdn} exceeds the 10 DNS lookup limit in the SPF record"
                 )
 
+            if term.startswith('ptr'):
+                raise SpfValueException(
+                    f"{record.fqdn} uses the deprecated ptr mechanism"
+                )
+
             # These mechanisms cost one DNS lookup each
-            if term.startswith(
-                ('a', 'mx', 'exists:', 'redirect', 'include:', 'ptr')
-            ):
+            if term.startswith(('a', 'mx', 'exists:', 'redirect', 'include:')):
                 lookups += 1
 
             # The include mechanism can result in further lookups after resolving the DNS record

--- a/octodns/processor/spf.py
+++ b/octodns/processor/spf.py
@@ -3,7 +3,7 @@
 #
 
 from logging import getLogger
-from typing import Optional
+from typing import List, Optional
 
 import dns.resolver
 from dns.resolver import Answer
@@ -58,7 +58,7 @@ class SpfDnsLookupProcessor(BaseProcessor):
         super().__init__(name)
 
     def _get_spf_from_txt_values(
-        self, record: Record, values: list[str]
+        self, record: Record, values: List[str]
     ) -> Optional[str]:
         self.log.debug(
             f"_get_spf_from_txt_values: record={record.fqdn} values={values}"
@@ -79,7 +79,7 @@ class SpfDnsLookupProcessor(BaseProcessor):
 
         return spf[0]
 
-    def _process_answer(self, answer: Answer) -> list[str]:
+    def _process_answer(self, answer: Answer) -> List[str]:
         values = []
 
         for value in answer:
@@ -90,7 +90,7 @@ class SpfDnsLookupProcessor(BaseProcessor):
         return values
 
     def _check_dns_lookups(
-        self, record: Record, values: list[str], lookups: int = 0
+        self, record: Record, values: List[str], lookups: int = 0
     ) -> int:
         self.log.debug(
             f"_check_dns_lookups: record={record.fqdn} values={values} lookups={lookups}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML==6.0
-dnspython==2.2.1
+dnspython==2.3.0
 fqdn==1.5.1
 idna==3.4
 natsort==8.2.0

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
     },
     install_requires=(
         'PyYaml>=4.2b1',
-        'dnspython>=1.15.0',
+        'dnspython>=2.2.1',
         'fqdn>=1.5.0',
         'idna>=3.3',
         'natsort>=5.5.0',

--- a/tests/test_octodns_processor_spf.py
+++ b/tests/test_octodns_processor_spf.py
@@ -23,7 +23,7 @@ class TestSpfDnsLookupProcessor(TestCase):
 
         self.assertIsNone(
             processor._get_spf_from_txt_values(
-                record, ['v=DMARC1\; p=reject\;']
+                record, ['v=DMARC1\\; p=reject\\;']
             )
         )
 
@@ -31,7 +31,7 @@ class TestSpfDnsLookupProcessor(TestCase):
             'v=spf1 include:example.com ~all',
             processor._get_spf_from_txt_values(
                 record,
-                ['v=DMARC1\; p=reject\;', 'v=spf1 include:example.com ~all'],
+                ['v=DMARC1\\; p=reject\\;', 'v=spf1 include:example.com ~all'],
             ),
         )
 
@@ -48,7 +48,8 @@ class TestSpfDnsLookupProcessor(TestCase):
         self.assertEqual(
             'v=spf1 include:example.com',
             processor._get_spf_from_txt_values(
-                record, ['v=spf1 include:example.com', 'v=DMARC1\; p=reject\;']
+                record,
+                ['v=spf1 include:example.com', 'v=DMARC1\\; p=reject\\;'],
             ),
         )
 
@@ -56,7 +57,7 @@ class TestSpfDnsLookupProcessor(TestCase):
             'v=spf1 +mx redirect=example.com',
             processor._get_spf_from_txt_values(
                 record,
-                ['v=spf1 +mx redirect=example.com', 'v=DMARC1\; p=reject\;'],
+                ['v=spf1 +mx redirect=example.com', 'v=DMARC1\\; p=reject\\;'],
             ),
         )
 
@@ -73,7 +74,7 @@ class TestSpfDnsLookupProcessor(TestCase):
                 {
                     'type': 'TXT',
                     'ttl': 86400,
-                    'values': ['v=DMARC1\; p=reject\;'],
+                    'values': ['v=DMARC1\\; p=reject\\;'],
                 },
             )
         )
@@ -95,7 +96,7 @@ class TestSpfDnsLookupProcessor(TestCase):
                     'ttl': 86400,
                     'values': [
                         'v=spf1 a include:example.com ~all',
-                        'v=DMARC1\; p=reject\;',
+                        'v=DMARC1\\; p=reject\\;',
                     ],
                 },
             )
@@ -119,7 +120,7 @@ class TestSpfDnsLookupProcessor(TestCase):
                     'ttl': 86400,
                     'values': [
                         'v=spf1 a ip4:1.2.3.4 ip6:2001:0db8:85a3:0000:0000:8a2e:0370:7334 -all',
-                        'v=DMARC1\; p=reject\;',
+                        'v=DMARC1\\; p=reject\\;',
                     ],
                 },
             )
@@ -137,7 +138,7 @@ class TestSpfDnsLookupProcessor(TestCase):
                     'ttl': 86400,
                     'values': [
                         'v=spf1 a mx exists:example.com a a a a a a a a ~all',
-                        'v=DMARC1\; p=reject\;',
+                        'v=DMARC1\\; p=reject\\;',
                     ],
                 },
             )
@@ -156,7 +157,7 @@ class TestSpfDnsLookupProcessor(TestCase):
                     'ttl': 86400,
                     'values': [
                         'v=spf1 include:example.com -all',
-                        'v=DMARC1\; p=reject\;',
+                        'v=DMARC1\\; p=reject\\;',
                     ],
                 },
             )
@@ -183,7 +184,7 @@ class TestSpfDnsLookupProcessor(TestCase):
                     'ttl': 86400,
                     'values': [
                         'v=spf1 include:example.com -all',
-                        'v=DMARC1\; p=reject\;',
+                        'v=DMARC1\\; p=reject\\;',
                     ],
                 },
             )
@@ -209,7 +210,7 @@ class TestSpfDnsLookupProcessor(TestCase):
                     'ttl': 86400,
                     'values': [
                         'v=spf1 include:example.com -all',
-                        'v=DMARC1\; p=reject\;',
+                        'v=DMARC1\\; p=reject\\;',
                     ],
                 },
             )

--- a/tests/test_octodns_processor_spf.py
+++ b/tests/test_octodns_processor_spf.py
@@ -23,7 +23,10 @@ class TestSpfDnsLookupProcessor(TestCase):
                 {
                     'type': 'TXT',
                     'ttl': 86400,
-                    'values': ['v=spf1 a ~all', 'v=DMARC1\; p=reject\;'],
+                    'values': [
+                        'v=spf1 a include:_spf.google.com ~all',
+                        'v=DMARC1\; p=reject\;',
+                    ],
                 },
             )
         )
@@ -38,7 +41,7 @@ class TestSpfDnsLookupProcessor(TestCase):
                     'type': 'TXT',
                     'ttl': 86400,
                     'values': [
-                        'v=spf1 a a a a a a a a a a -all',
+                        'v=spf1 a ip4:1.2.3.4 ip4:1.2.3.4 ip4:1.2.3.4 ip4:1.2.3.4 ip4:1.2.3.4 ip4:1.2.3.4 ip4:1.2.3.4 ip4:1.2.3.4 ip4:1.2.3.4 ip4:1.2.3.4 ip4:1.2.3.4 -all',
                         'v=DMARC1\; p=reject\;',
                     ],
                 },
@@ -56,7 +59,26 @@ class TestSpfDnsLookupProcessor(TestCase):
                     'type': 'TXT',
                     'ttl': 86400,
                     'values': [
-                        'v=spf1 a mx exists redirect a a a a a a a ~all',
+                        'v=spf1 a mx exists:example.com a a a a a a a a ~all',
+                        'v=DMARC1\; p=reject\;',
+                    ],
+                },
+            )
+        )
+
+        with self.assertRaises(SpfDnsLookupException):
+            processor.process_source_zone(zone)
+
+        zone = Zone('unit.tests.', [])
+        zone.add_record(
+            Record.new(
+                zone,
+                '',
+                {
+                    'type': 'TXT',
+                    'ttl': 86400,
+                    'values': [
+                        'v=spf1 include:example.com include:_spf.google.com include:_spf.google.com include:_spf.google.com ~all',
                         'v=DMARC1\; p=reject\;',
                     ],
                 },

--- a/tests/test_octodns_processor_spf.py
+++ b/tests/test_octodns_processor_spf.py
@@ -1,0 +1,153 @@
+from unittest import TestCase
+
+from octodns.processor.spf import (
+    SpfDnsLookupException,
+    SpfDnsLookupProcessor,
+    SpfValueException,
+)
+from octodns.record.base import Record
+from octodns.zone import Zone
+
+
+class TestSpfDnsLookupProcessor(TestCase):
+    def test_processor(self):
+        processor = SpfDnsLookupProcessor('test')
+        assert processor.name == 'test'
+
+        processor = SpfDnsLookupProcessor('test')
+        zone = Zone('unit.tests.', [])
+        zone.add_record(
+            Record.new(
+                zone,
+                '',
+                {
+                    'type': 'TXT',
+                    'ttl': 86400,
+                    'values': ['v=spf1 a ~all', 'v=DMARC1\; p=reject\;'],
+                },
+            )
+        )
+
+        assert zone == processor.process_source_zone(zone)
+        zone = Zone('unit.tests.', [])
+        zone.add_record(
+            Record.new(
+                zone,
+                '',
+                {
+                    'type': 'TXT',
+                    'ttl': 86400,
+                    'values': [
+                        'v=spf1 a a a a a a a a a a -all',
+                        'v=DMARC1\; p=reject\;',
+                    ],
+                },
+            )
+        )
+
+        assert zone == processor.process_source_zone(zone)
+
+        zone = Zone('unit.tests.', [])
+        zone.add_record(
+            Record.new(
+                zone,
+                '',
+                {
+                    'type': 'TXT',
+                    'ttl': 86400,
+                    'values': [
+                        'v=spf1 a mx exists redirect a a a a a a a ~all',
+                        'v=DMARC1\; p=reject\;',
+                    ],
+                },
+            )
+        )
+
+        with self.assertRaises(SpfDnsLookupException):
+            processor.process_source_zone(zone)
+
+    def test_processor_skips_lenient_records(self):
+        processor = SpfDnsLookupProcessor('test')
+        zone = Zone('unit.tests.', [])
+
+        lenient = Record.new(
+            zone,
+            'lenient',
+            {
+                'type': 'TXT',
+                'ttl': 86400,
+                'value': 'v=spf1 a a a a a a a a a a a ~all',
+                'octodns': {'lenient': True},
+            },
+        )
+        zone.add_record(lenient)
+
+        processed = processor.process_source_zone(zone)
+
+        assert zone == processed
+
+    def test_processor_errors_on_many_spf_values_in_record(self):
+        processor = SpfDnsLookupProcessor('test')
+        zone = Zone('unit.tests.', [])
+
+        record = Record.new(
+            zone,
+            '',
+            {
+                'type': 'TXT',
+                'ttl': 86400,
+                'values': [
+                    'v=spf1 include:mailgun.org ~all',
+                    'v=spf1 include:_spf.google.com ~all',
+                ],
+            },
+        )
+        zone.add_record(record)
+
+        with self.assertRaises(SpfValueException):
+            processor.process_source_zone(zone)
+
+    def test_processor_filters_to_records_with_spf_values(self):
+        processor = SpfDnsLookupProcessor('test')
+        zone = Zone('unit.tests.', [])
+
+        zone.add_record(
+            Record.new(
+                zone, '', {'type': 'A', 'ttl': 86400, 'value': '1.2.3.4'}
+            )
+        )
+        zone.add_record(
+            Record.new(
+                zone,
+                '',
+                {
+                    'type': 'TXT',
+                    'ttl': 86400,
+                    'value': 'v=spf1 a a a a a a a a a a a ~all',
+                },
+            )
+        )
+
+        with self.assertRaises(SpfDnsLookupException):
+            processor.process_source_zone(zone)
+
+        zone = Zone('unit.tests.', [])
+
+        zone.add_record(
+            Record.new(
+                zone, '', {'type': 'A', 'ttl': 86400, 'value': '1.2.3.4'}
+            )
+        )
+        zone.add_record(
+            Record.new(
+                zone,
+                '',
+                {
+                    'type': 'TXT',
+                    'ttl': 86400,
+                    'values': ['AAAAAAAAAAA', 'v=spf10'],
+                },
+            )
+        )
+
+        assert zone == processor.process_source_zone(zone)


### PR DESCRIPTION
Use this processor to validate SPF values in TXT records

The processor will error on...

* more than one SPF value in a TXT record
* more than 10 DNS lookups caused by an SPF value
* any reference to the deprecated `ptr` mechanism

The processor uses recursion to handle counting the number of DNS lookups caused by `include` mechanisms. I'd be happy to hear ideas on how that could be simplified!

Another validation I'd be interested in, but is likely separate to this, is a limit on the number of values in any TXT record. I'm aware of issues occuring when the value for a DKIM key is beyond the ~50th element in a TXT record.

**Usage:**

```yaml
processors:
  spf:
    class: octodns.processor.spf.SpfDnsLookupProcessor

zones:
  example.com.:
    sources:
      - config
    processors:
      - spf
    targets:
      - route53
```

**Todo:**

- [x] Add documentation to the class
- [x] Test for more than one level of `include` mechanism
- [x] Handle chunked values in resolver answer, e.g. from `dig _spf.mailgun.org TXT`
- [x] ~Check for TXT record size, https://datatracker.ietf.org/doc/html/rfc7208#section-3.4~ Doesn't seem much of a concern? https://serverfault.com/questions/1000170/size-of-spf-with-other-txt-records
- [x] Handle the `ptr` mechanism. Looks like it is deprecated https://datatracker.ietf.org/doc/html/rfc7208#section-5.5, could be an error?

### References

* #977 