### PR TITLE
Update README sample to reflect extracted providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ providers:
     username: 'username'
     password: env/DYN_PASSWORD
   route53:
-    class: octodns.provider.route53.Route53Provider
+    class: octodns_route53.Route53Provider
     access_key_id: env/AWS_ACCESS_KEY_ID
     secret_access_key: env/AWS_SECRET_ACCESS_KEY
 


### PR DESCRIPTION
https://github.com/octodns/octodns#updating-to-use-extracted-providers changed the class names to use but that wasn't reflected in the sample code