### PR TITLE
Rel 1.0.0.rc0 version bump & CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.0.0.rc0 - 2022-05-19 - First of the ones
+## v1.0.0.rc0 - 2023-05-19 - First of the ones
 
 #### Noteworthy changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.0.0.rc0 - 2023-05-19 - First of the ones
+## v1.0.0.rc0 - 2023-05-16 - First of the ones
 
 #### Noteworthy changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,9 @@
   [this section](/docs/dynamic_records.md#subnets) of dynamic records
   documentation for more information.
 * Enhanced validations on dynamic rules to encourage best practices
-   * The last rule should be a catch-all w/o any targeted geos or subnets
+   * The last rule must be a catch-all w/o any targeted geos or subnets
    * Geos must not be repeated in multiple rules
-   * Geos in rules subsequent rules should be ordered most to least specific,
+   * Geos in rules and subsequent rules must be ordered most to least specific,
      e.g. NA-US-TN must come before NA-US, which must occur before NA
    * Similarly, subnets must not be repeated in multiple rules, and various
      subnet rules must be ordered such that most specific subnets appear before

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.0.0.rc0 - 2022-??-?? - First of the ones
+## v1.0.0.rc0 - 2022-05-19 - First of the ones
 
 #### Noteworthy changes
 
@@ -16,12 +16,19 @@
   longer as they were considered private/protected.
 * Beta support for auto-arpa has been added, See the
   [auto-arpa documentation](/docs/auto_arpa.md) for more information.
+* Support for subnet targeting in dynamic records, see
+  [this section](/docs/dynamic_records.md#subnets) of dynamic records
+  documentation for more information.
 * Enhanced validations on dynamic rules to encourage best practices
-   * The last rule should be a catch-all w/o any targeted geos
-   * Geos should not be repeated in multiple rules
+   * The last rule should be a catch-all w/o any targeted geos or subnets
+   * Geos must not be repeated in multiple rules
    * Geos in rules subsequent rules should be ordered most to least specific,
      e.g. NA-US-TN must come before NA-US, which must occur before NA
-* Support for subnet targeting in dynamic records added.
+   * Similarly, subnets must not be repeated in multiple rules, and various
+     subnet rules must be ordered such that most specific subnets appear before
+     less specific ones; e.g. 10.1.1.0/24 must appear before 10.1.0.0/16.
+   * Subnet-only rules must appear before any subnet+geo rules, followed by
+     geo-only rules (and catch-all w/o any geos/subnets in the end)
 
 #### Stuff
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,9 @@
    * Similarly, subnets must not be repeated in multiple rules, and various
      subnet rules must be ordered such that most specific subnets appear before
      less specific ones; e.g. 10.1.1.0/24 must appear before 10.1.0.0/16.
-   * Subnet-only rules must appear before any subnet+geo rules, followed by
-     geo-only rules (and catch-all w/o any geos/subnets in the end)
+   * Subnet targeting is considered to be more specific than geo targeting, so
+     subnet-only rules must appear before any subnet+geo rules, followed by
+     geo-only rules (and catch-all rule w/o any geos/subnets in the end)
 
 #### Stuff
 

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -1,3 +1,3 @@
 'OctoDNS: DNS as code - Tools for managing DNS across multiple providers'
 
-__VERSION__ = '0.9.21'
+__VERSION__ = '1.0.0.rc0'


### PR DESCRIPTION
## v1.0.0.rc0 - 2022-05-16 - First of the ones

#### Noteworthy changes

* 1.x Deprecation removals
   * Provider, Source, and Processor shims removed, they've been warnings for >
     1yr.  Everything should be using and referring to provider-specific
     modules now.
   * Provider.strict_supports defaults to true, can be returned to the old
     behavior by setting strict_supports=False in your provider params.
* octodns.record has been broken up into multiple files/modules. Most of the
  primary things that were available at that module path still will be, but if
  you are importing things like idna_encode/decode that actually live elsewhere
  from octodns.record you'll need to update and pull them from their actual
  home. Classes beginning with _ are not exported from octodns.record any
  longer as they were considered private/protected.
* Beta support for auto-arpa has been added, See the
  [auto-arpa documentation](/docs/auto_arpa.md) for more information.
* Support for subnet targeting in dynamic records, see
  [this section](/docs/dynamic_records.md#subnets) of dynamic records
  documentation for more information.
* Enhanced validations on dynamic rules to encourage best practices
   * The last rule should be a catch-all w/o any targeted geos or subnets
   * Geos must not be repeated in multiple rules
   * Geos in rules subsequent rules should be ordered most to least specific,
     e.g. NA-US-TN must come before NA-US, which must occur before NA
   * Similarly, subnets must not be repeated in multiple rules, and various
     subnet rules must be ordered such that most specific subnets appear before
     less specific ones; e.g. 10.1.1.0/24 must appear before 10.1.0.0/16.
   * Subnet-only rules must appear before any subnet+geo rules, followed by
     geo-only rules (and catch-all w/o any geos/subnets in the end)

#### Stuff

* Added new DsRecord type (provider support will be added over time)
* Added simple IgnoreRootNsFilter
* Minor refactor on YamlProvider to add get_filenames making it a bit easier to
  create specialized providers inheriting from it
* Fixed bug in OwnershipProcessor when all changes were removed from plans