### PR TITLE
Add Python 3.11 to Test Matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         # Tested versions based on dates in https://devguide.python.org/devcycle/#end-of-life-branches, 
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@master
       - name: Setup python


### PR DESCRIPTION
Add Python 3.11 to testing matrix - https://github.com/octodns/octodns/issues/1006