### PR TITLE
Pass lenient through to arpa processor

### DIFF
--- a/octodns/processor/arpa.py
+++ b/octodns/processor/arpa.py
@@ -61,8 +61,13 @@ class AutoArpa(BaseProcessor):
                     zone,
                     name,
                     {'ttl': self.ttl, 'type': 'PTR', 'values': fqdns},
+                    lenient=lenient,
                 )
-                zone.add_record(record, replace=self.populate_should_replace)
+                zone.add_record(
+                    record,
+                    replace=self.populate_should_replace,
+                    lenient=lenient,
+                )
 
         self.log.info(
             'populate:   found %s records', len(zone.records) - before

--- a/tests/test_octodns_processor_arpa.py
+++ b/tests/test_octodns_processor_arpa.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 
 from octodns.processor.arpa import AutoArpa
 from octodns.record import Record
+from octodns.record.exception import ValidationError
 from octodns.zone import Zone
 
 
@@ -226,3 +227,39 @@ class TestAutoArpa(TestCase):
         arpa = Zone('0.10.in-addr.arpa.', [])
         aa.populate(arpa)
         self.assertEqual(0, len(arpa.records))
+
+    def test_single_value_A_with_space(self):
+        zone = Zone('unit.tests.', [])
+
+        # invalid record without lenient
+        with self.assertRaises(ValidationError):
+            Record.new(
+                zone,
+                'a with spaces',
+                {'ttl': 32, 'type': 'A', 'value': '1.2.3.4'},
+            )
+
+        # invalid record with lenient
+        lenient = True
+        record = Record.new(
+            zone,
+            'a with spaces',
+            {'ttl': 32, 'type': 'A', 'value': '1.2.3.4'},
+            lenient=lenient,
+        )
+        zone.add_record(record)
+        aa = AutoArpa('auto-arpa')
+        aa.process_source_zone(zone, [])
+        self.assertEqual(
+            {'4.3.2.1.in-addr.arpa.': {'a with spaces.unit.tests.'}},
+            aa._records,
+        )
+
+        # matching zone
+        arpa = Zone('3.2.1.in-addr.arpa.', [])
+        aa.populate(arpa, lenient=lenient)
+        self.assertEqual(1, len(arpa.records))
+        (ptr,) = arpa.records
+        self.assertEqual('4.3.2.1.in-addr.arpa.', ptr.fqdn)
+        self.assertEqual(record.fqdn, ptr.value)
+        self.assertEqual(3600, ptr.ttl)


### PR DESCRIPTION
# Summary

I noticed that when using the auto-arpa processor that lenient was not being passed through to records. Let me know if this was by design/intentional!

# Testing

```
tests/test_octodns_equality.py ..                                                                                                                                                                     [  0%]
tests/test_octodns_idna.py .........                                                                                                                                                                  [  4%]
tests/test_octodns_manager.py ......................................                                                                                                                                  [ 19%]
tests/test_octodns_plan.py ..........                                                                                                                                                                 [ 23%]
tests/test_octodns_processor_acme.py .                                                                                                                                                                [ 23%]
tests/test_octodns_processor_arpa.py .........                                                                                                                                                        [ 27%]
tests/test_octodns_processor_filter.py .......                                                                                                                                                        [ 29%]
tests/test_octodns_processor_ownership.py ...                                                                                                                                                         [ 31%]
tests/test_octodns_processor_restrict.py .                                                                                                                                                            [ 31%]
tests/test_octodns_processor_spf.py .......                                                                                                                                                           [ 34%]
tests/test_octodns_provider_base.py ................................                                                                                                                                  [ 46%]
tests/test_octodns_provider_yaml.py ................                                                                                                                                                  [ 53%]
tests/test_octodns_record.py ..............                                                                                                                                                           [ 58%]
tests/test_octodns_record_a.py ..                                                                                                                                                                     [ 59%]
tests/test_octodns_record_aaaa.py ...                                                                                                                                                                 [ 60%]
tests/test_octodns_record_alias.py ...                                                                                                                                                                [ 61%]
tests/test_octodns_record_caa.py ....                                                                                                                                                                 [ 63%]
tests/test_octodns_record_change.py ..                                                                                                                                                                [ 64%]
tests/test_octodns_record_chunked.py .                                                                                                                                                                [ 64%]
tests/test_octodns_record_cname.py ...                                                                                                                                                                [ 65%]
tests/test_octodns_record_dname.py ...                                                                                                                                                                [ 66%]
tests/test_octodns_record_ds.py .                                                                                                                                                                     [ 67%]
tests/test_octodns_record_dynamic.py ...............                                                                                                                                                  [ 73%]
tests/test_octodns_record_geo.py .......                                                                                                                                                              [ 75%]
tests/test_octodns_record_ip.py .                                                                                                                                                                     [ 76%]
tests/test_octodns_record_loc.py ....                                                                                                                                                                 [ 77%]
tests/test_octodns_record_mx.py ....                                                                                                                                                                  [ 79%]
tests/test_octodns_record_naptr.py ...                                                                                                                                                                [ 80%]
tests/test_octodns_record_ns.py ...                                                                                                                                                                   [ 81%]
tests/test_octodns_record_ptr.py ...                                                                                                                                                                  [ 83%]
tests/test_octodns_record_spf.py ..                                                                                                                                                                   [ 83%]
tests/test_octodns_record_srv.py ....                                                                                                                                                                 [ 85%]
tests/test_octodns_record_sshfp.py ....                                                                                                                                                               [ 87%]
tests/test_octodns_record_target.py .                                                                                                                                                                 [ 87%]
tests/test_octodns_record_tlsa.py ...                                                                                                                                                                 [ 88%]
tests/test_octodns_record_txt.py ...                                                                                                                                                                  [ 89%]
tests/test_octodns_record_urlfwd.py ..                                                                                                                                                                [ 90%]
tests/test_octodns_source_envvar.py ..                                                                                                                                                                [ 91%]
tests/test_octodns_source_tinydns.py .....                                                                                                                                                            [ 93%]
tests/test_octodns_yaml.py .                                                                                                                                                                          [ 93%]
tests/test_octodns_zone.py ................                                                                                                                                                           [100%]

---------- coverage: platform darwin, python 3.11.2-final-0 ----------
Name                             Stmts   Miss Branch BrPart  Cover
------------------------------------------------------------------
octodns/__init__.py                  1      0      0      0   100%
octodns/equality.py                 15      0      0      0   100%
octodns/idna.py                     53      0     13      0   100%
octodns/manager.py                 464      0    192      0   100%
octodns/processor/__init__.py        0      0      0      0   100%
octodns/processor/acme.py           22      0      8      0   100%
octodns/processor/arpa.py           40      0     20      0   100%
octodns/processor/base.py           11      0      0      0   100%
octodns/processor/filter.py         73      0     31      0   100%
octodns/processor/ownership.py      45      0     20      0   100%
octodns/processor/restrict.py       21      0     10      0   100%
octodns/processor/spf.py            57      0     26      0   100%
octodns/provider/__init__.py         4      0      0      0   100%
octodns/provider/base.py           145      0     70      0   100%
octodns/provider/plan.py           203      0     65      0   100%
octodns/provider/yaml.py           139      0     58      0   100%
octodns/record/__init__.py          73      0      0      0   100%
octodns/record/a.py                 13      0      0      0   100%
octodns/record/aaaa.py              13      0      0      0   100%
octodns/record/alias.py             15      0      4      0   100%
octodns/record/base.py             235      0    102      0   100%
octodns/record/caa.py               69      0     34      0   100%
octodns/record/change.py            28      0      2      0   100%
octodns/record/chunked.py           46      0     26      0   100%
octodns/record/cname.py             16      0      4      0   100%
octodns/record/dname.py              9      0      0      0   100%
octodns/record/ds.py                93      0     40      0   100%
octodns/record/dynamic.py          267      0    122      0   100%
octodns/record/exception.py         12      0      2      0   100%
octodns/record/geo.py              115      0     50      0   100%
octodns/record/geo_data.py           1      0      0      0   100%
octodns/record/ip.py                33      0     22      0   100%
octodns/record/loc.py              182      0     82      0   100%
octodns/record/mx.py                87      0     32      0   100%
octodns/record/naptr.py            105      0     50      0   100%
octodns/record/ns.py                 8      0      0      0   100%
octodns/record/ptr.py               11      0      2      0   100%
octodns/record/rr.py                12      0      0      0   100%
octodns/record/spf.py                6      0      0      0   100%
octodns/record/srv.py              113      0     46      0   100%
octodns/record/sshfp.py             85      0     38      0   100%
octodns/record/subnet.py            13      0      4      0   100%
octodns/record/target.py            57      0     38      0   100%
octodns/record/tlsa.py              96      0     44      0   100%
octodns/record/txt.py                8      0      0      0   100%
octodns/record/urlfwd.py            85      0     46      0   100%
octodns/source/__init__.py           0      0      0      0   100%
octodns/source/base.py              22      0      8      0   100%
octodns/source/envvar.py            36      0      2      0   100%
octodns/source/tinydns.py          145      0     54      0   100%
octodns/yaml.py                     30      0      8      0   100%
octodns/zone.py                    133      0     73      0   100%
------------------------------------------------------------------
TOTAL                             3565      0   1448      0   100%
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml

Required test coverage of 100% reached. Total coverage: 100.00%
```