### PR TITLE
Always add ownership flagging records with lenient=True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## v1.0.0.rc2 - 2023-??-?? -
 
 * Record and Zone validation now ensures there's no whitespace in names
+* OwnershipProcessor managed records always add w/lenient=True, this allows
+  ownership to be marked in the same zone for delegation NS records.
+* octodns-report access --lenient flag to allow running reports with records
+  sourced from providers with non-compliant record data.
 
 ## v1.0.0.rc0 - 2023-05-16 - First of the ones
 

--- a/octodns/cmds/report.py
+++ b/octodns/cmds/report.py
@@ -46,6 +46,12 @@ def main():
     parser.add_argument(
         '--timeout', default=1, help='Number seconds to wait for an answer'
     )
+    parser.add_argument(
+        '--lenient',
+        action='store_true',
+        default=False,
+        help='Ignore record validations and do a best effort dump',
+    )
     parser.add_argument('server', nargs='+', help='Servers to query')
 
     args = parser.parse_args()
@@ -61,7 +67,7 @@ def main():
 
     zone = manager.get_zone(args.zone)
     for source in sources:
-        source.populate(zone)
+        source.populate(zone, lenient=args.lenient)
 
     servers = ','.join(args.server)
     print(f'name,type,ttl,{servers},consistent')

--- a/octodns/processor/ownership.py
+++ b/octodns/processor/ownership.py
@@ -32,7 +32,9 @@ class OwnershipProcessor(BaseProcessor):
                 name,
                 {'type': 'TXT', 'ttl': 60, 'value': self.txt_value},
             )
-            desired.add_record(txt)
+            # add these w/lenient to cover the case when the ownership record
+            # for a NS delegation record should technically live in the subzone
+            desired.add_record(txt, lenient=True)
 
         return desired
 


### PR DESCRIPTION
This is intened to address cases where NS delegation ownership records are added to the parent zone when they technically should live in the delegated child. They're only used as ~metadata so this is fine, so long as the provider supports it.

/cc https://github.com/octodns/octodns/issues/1012 @JamesHarrison  