### PR TITLE
Full tinydns spec-compliant source implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * octodns-report access --lenient flag to allow running reports with records
   sourced from providers with non-compliant record data.
 * Correctly handle FQDNs in TinyDNS config files that end with trailing .'s
+* Complete rewrite of TinyDnsBaseSource to fully implement the spec and the ipv6
+  extensions
 
 ## v1.0.0.rc0 - 2023-05-16 - First of the ones
 

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -123,6 +123,10 @@ class Record(EqualityTupleMixin):
 
         return records
 
+    @classmethod
+    def parse_rdata_texts(cls, rdatas):
+        return [cls._value_type.parse_rdata_text(r) for r in rdatas]
+
     def __init__(self, zone, name, data, source=None):
         self.zone = zone
         if name:

--- a/octodns/source/tinydns.py
+++ b/octodns/source/tinydns.py
@@ -9,18 +9,25 @@ from collections import defaultdict
 from ipaddress import ip_address
 from os import listdir
 from os.path import join
+from pprint import pprint
 
 from ..record import Record
 from ..zone import DuplicateRecordException, SubzoneRecordException
 from .base import BaseSource
 
 
+def _decode_octal(s):
+    return re.sub(r'\\(\d\d\d)', lambda m: chr(int(m.group(1), 8)), s).replace(
+        ';', '\\;'
+    )
+
+
 class TinyDnsBaseSource(BaseSource):
+    # spec https://cr.yp.to/djbdns/tinydns-data.html
+    # ipv6 addon spec https://docs.bytemark.co.uk/article/tinydns-format/
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
     SUPPORTS = set(('A', 'CNAME', 'MX', 'NS', 'TXT', 'AAAA'))
-
-    split_re = re.compile(r':+')
 
     def __init__(self, id, default_ttl=3600):
         super().__init__(id)
@@ -121,48 +128,282 @@ class TinyDnsBaseSource(BaseSource):
             'populate:   found %s records', len(zone.records) - before
         )
 
+    def _records_for_at(self, zone, name, lines, in_addr=False, lenient=False):
+        # @fqdn:ip:x:dist:ttl:timestamp:lo
+        # MX (and optional A)
+        if in_addr:
+            return []
+
+        # see if we can find a ttl on any of the lines, first one wins
+        ttl = self.default_ttl
+        for line in lines:
+            try:
+                ttl = int(lines[0][4])
+                break
+            except IndexError:
+                pass
+
+        values = []
+        for line in lines:
+            mx = line[2]
+            # if there's a . in the mx we hit a special case and use it as-is
+            if '.' not in mx:
+                # otherwise we treat it as the MX hostnam and construct the rest
+                mx = f'{mx}.ns.{zone.name}'
+            elif mx[-1] != '.':
+                mx = f'{mx}.'
+
+            # default distance is 0
+            try:
+                dist = line[3] or 0
+            except IndexError:
+                dist = 0
+
+            # if we have an IP then we need to create an A for the MX
+            ip = line[1]
+            if ip:
+                mx_name = zone.hostname_from_fqdn(mx)
+                yield Record.new(
+                    zone, mx_name, {'type': 'A', 'ttl': ttl, 'value': ip}
+                )
+
+            values.append({'preference': dist, 'exchange': mx})
+
+        yield Record.new(
+            zone, name, {'ttl': ttl, 'type': 'MX', 'values': values}
+        )
+
+    def _records_for_C(self, zone, name, lines, in_addr=False, lenient=False):
+        # Cfqdn:p:ttl:timestamp:lo
+        # CNAME
+        if in_addr:
+            return []
+
+        value = lines[0][1]
+        if value[-1] != '.':
+            value = f'{value}.'
+
+        # see if we can find a ttl on any of the lines, first one wins
+        ttl = self.default_ttl
+        for line in lines:
+            try:
+                ttl = int(lines[0][2])
+                break
+            except IndexError:
+                pass
+
+        return [
+            Record.new(
+                zone, name, {'ttl': ttl, 'type': 'CNAME', 'value': value}
+            )
+        ]
+
+    def _records_for_caret(
+        self, zone, name, lines, in_addr=False, lenient=False
+    ):
+        # .fqdn:ip:x:ttl:timestamp:lo
+        # NS (and optional A)
+        if not in_addr:
+            return []
+
+        raise NotImplementedError()
+
+    def _records_for_equal(
+        self, zone, name, lines, in_addr=False, lenient=False
+    ):
+        # =fqdn:ip:ttl:timestamp:lo
+        # A (in_addr False) & PTR (in_addr True)
+        return self._records_for_plus(
+            zone, name, lines, in_addr, lenient
+        ) + self._records_for_caret(zone, name, lines, in_addr, lenient)
+
+    def _records_for_dot(self, zone, name, lines, in_addr=False, lenient=False):
+        # .fqdn:ip:x:ttl:timestamp:lo
+        # NS (and optional A)
+        if not in_addr:
+            return []
+
+        # see if we can find a ttl on any of the lines, first one wins
+        ttl = self.default_ttl
+        for line in lines:
+            try:
+                ttl = int(lines[0][3])
+                break
+            except IndexError:
+                pass
+
+        values = []
+        for line in lines:
+            ns = line[2]
+            # if there's a . in the ns we hit a special case and use it as-is
+            if '.' not in ns:
+                # otherwise we treat it as the NS hostnam and construct the rest
+                ns = f'{ns}.ns.{zone.name}'
+            elif ns[-1] != '.':
+                ns = f'{ns}.'
+
+            # if we have an IP then we need to create an A for the MX
+            ip = line[1]
+            if ip:
+                ns_name = zone.hostname_from_fqdn(ns)
+                yield Record.new(
+                    zone, ns_name, {'type': 'A', 'ttl': ttl, 'value': ip}
+                )
+
+            values.append(ns)
+
+        yield Record.new(
+            zone, name, {'ttl': ttl, 'type': 'NS', 'values': values}
+        )
+
+    _records_for_amp = _records_for_dot
+
+    def _records_for_plus(
+        self, zone, name, lines, in_addr=False, lenient=False
+    ):
+        # +fqdn:ip:ttl:timestamp:lo
+        # A
+        if in_addr:
+            return []
+
+        # collect our ip(s)
+        ips = [l[1] for l in lines if l[1] != '0.0.0.0']
+
+        if not ips:
+            # we didn't find any value ips so nothing to do
+            return []
+
+        # see if we can find a ttl on any of the lines, first one wins
+        ttl = self.default_ttl
+        for line in lines:
+            try:
+                ttl = int(lines[0][2])
+                break
+            except IndexError:
+                pass
+
+        return [
+            Record.new(zone, name, {'ttl': ttl, 'type': 'A', 'values': ips})
+        ]
+
+    def _records_for_quote(
+        self, zone, name, lines, in_addr=False, lenient=False
+    ):
+        # 'fqdn:s:ttl:timestamp:lo
+        # TXT
+        if in_addr:
+            return []
+
+        # collect our ip(s)
+        values = [_decode_octal(l[1]) for l in lines]
+
+        # see if we can find a ttl on any of the lines, first one wins
+        ttl = self.default_ttl
+        for line in lines:
+            try:
+                ttl = int(lines[0][2])
+                break
+            except IndexError:
+                pass
+
+        return [
+            Record.new(
+                zone, name, {'ttl': ttl, 'type': 'TXT', 'values': values}
+            )
+        ]
+
+    def _records_for_three(
+        self, zone, name, lines, in_addr=False, lenient=False
+    ):
+        # 3fqdn:ip:ttl:timestamp:lo
+        # AAAA
+        if in_addr:
+            return []
+
+        # collect our ip(s)
+        ips = []
+        for line in lines:
+            # TinyDNS files have the ipv6 address written in full, but with the
+            # colons removed. This inserts a colon every 4th character to make
+            # the address correct.
+            ips.append(u':'.join(textwrap.wrap(line[1], 4)))
+
+        # see if we can find a ttl on any of the lines, first one wins
+        ttl = self.default_ttl
+        for line in lines:
+            try:
+                ttl = int(lines[0][2])
+                break
+            except IndexError:
+                pass
+
+        return [
+            Record.new(zone, name, {'ttl': ttl, 'type': 'AAAA', 'values': ips})
+        ]
+
+    def _records_for_six(self, zone, name, lines, in_addr=False, lenient=False):
+        # 6fqdn:ip:ttl:timestamp:lo
+        # AAAA (in_addr False) & PTR (in_addr True)
+        return self._records_for_three(
+            zone, name, lines, in_addr, lenient
+        ) + self._records_for_caret(zone, name, lines, in_addr, lenient)
+
+    TYPE_MAP = {
+        '=': _records_for_equal,  # A
+        '^': _records_for_caret,  # PTR
+        '.': _records_for_dot,  # NS
+        'C': _records_for_C,  # CNAME
+        '+': _records_for_plus,  # A
+        '@': _records_for_at,  # MX
+        '&': _records_for_amp,  # NS
+        '\'': _records_for_quote,  # TXT
+        '3': _records_for_three,  # AAAA
+        '6': _records_for_six,  # AAAA
+        # TODO:
+        #'S': _records_for_S, # SRV
+        # Sfqdn:ip:x:port:priority:weight:ttl:timestamp:lo
+        #':': _record_for_semicolon # arbitrary
+        # :fqdn:n:rdata:ttl:timestamp:lo
+    }
+
     def _populate_normal(self, zone, lenient):
-        type_map = {
-            '=': 'A',
-            '^': None,
-            '.': 'NS',
-            'C': 'CNAME',
-            '+': 'A',
-            '@': 'MX',
-            '\'': 'TXT',
-            '3': 'AAAA',
-            '6': 'AAAA',
-        }
         name_re = re.compile(fr'((?P<name>.+)\.)?{zone.name[:-1]}\.?$')
 
         data = defaultdict(lambda: defaultdict(list))
         for line in self._lines():
             _type = line[0]
-            if _type not in type_map:
-                # Something we don't care about
-                continue
-            _type = type_map[_type]
-            if not _type:
-                continue
 
             # Skip type, remove trailing comments, and omit newline
             line = line[1:].split('#', 1)[0]
             # Split on :'s including :: and strip leading/trailing ws
-            line = [p.strip() for p in self.split_re.split(line)]
-            match = name_re.match(line[0])
-            if not match:
+            line = [p.strip() for p in line.split(':')]
+            # make sure the name portion matches the zone we're currently
+            # working on
+            name = line[0]
+            if not name_re.match(name):
+                self.log.info('skipping name %s, not a match, %s: ', name, line)
                 continue
-            name = zone.hostname_from_fqdn(line[0])
-            data[name][_type].append(line[1:])
+            # remove the zone name
+            name = zone.hostname_from_fqdn(name)
+            data[_type][name].append(line)
 
-        for name, types in data.items():
-            for _type, d in types.items():
-                data_for = getattr(self, f'_data_for_{_type}')
-                data = data_for(_type, d)
-                if data:
-                    record = Record.new(
-                        zone, name, data, source=self, lenient=lenient
-                    )
+        pprint(data)
+
+        for _type, names in data.items():
+            records_for = self.TYPE_MAP.get(_type, None)
+            if _type not in self.TYPE_MAP:
+                # Something we don't care about
+                self.log.info(
+                    'skipping type %s, not supported/interested', _type
+                )
+                continue
+
+            print(_type)
+            for name, lines in names.items():
+                for record in records_for(
+                    self, zone, name, lines, lenient=lenient
+                ):
+                    pprint({'record': record})
                     try:
                         zone.add_record(record, lenient=lenient)
                     except SubzoneRecordException:
@@ -177,7 +418,7 @@ class TinyDnsBaseSource(BaseSource):
         for line in self._lines():
             _type = line[0]
             # We're only interested in = (A+PTR), and ^ (PTR) records
-            if _type not in ('=', '^'):
+            if _type not in ('=', '^', '&'):
                 continue
 
             # Skip type, remove trailing comments, and omit newline

--- a/octodns/source/tinydns.py
+++ b/octodns/source/tinydns.py
@@ -37,6 +37,16 @@ class TinyDnsBaseSource(BaseSource):
         # All record types, including those registered by 3rd party modules
         return set(Record.registered_types().keys())
 
+    def _ttl_for(self, lines, index):
+        # see if we can find a ttl on any of the lines, first one wins
+        for line in lines:
+            try:
+                return int(line[index])
+            except IndexError:
+                pass
+        # and if we don't use the default
+        return self.default_ttl
+
     def _records_for_at(self, zone, name, lines, arpa=False):
         # @fqdn:ip:x:dist:ttl:timestamp:lo
         # MX (and optional A)
@@ -49,14 +59,7 @@ class TinyDnsBaseSource(BaseSource):
             # if name doesn't live under our zone there's nothing for us to do
             return
 
-        # see if we can find a ttl on any of the lines, first one wins
-        ttl = self.default_ttl
-        for line in lines:
-            try:
-                ttl = int(line[4])
-                break
-            except IndexError:
-                pass
+        ttl = self._ttl_for(lines, 4)
 
         values = []
         for line in lines:
@@ -99,14 +102,7 @@ class TinyDnsBaseSource(BaseSource):
         if value[-1] != '.':
             value = f'{value}.'
 
-        # see if we can find a ttl on any of the lines, first one wins
-        ttl = self.default_ttl
-        for line in lines:
-            try:
-                ttl = int(line[2])
-                break
-            except IndexError:
-                pass
+        ttl = self._ttl_for(lines, 2)
 
         yield 'CNAME', name, ttl, [value]
 
@@ -141,14 +137,7 @@ class TinyDnsBaseSource(BaseSource):
                 value = f'{value}.'
             names[name].append(value)
 
-        # see if we can find a ttl on any of the lines, first one wins
-        ttl = self.default_ttl
-        for line in lines:
-            try:
-                ttl = int(line[2])
-                break
-            except IndexError:
-                pass
+        ttl = self._ttl_for(lines, 2)
 
         for name, values in names.items():
             if zone.owns('PTR', name):
@@ -174,14 +163,7 @@ class TinyDnsBaseSource(BaseSource):
             # if name doesn't live under our zone there's nothing for us to do
             return
 
-        # see if we can find a ttl on any of the lines, first one wins
-        ttl = self.default_ttl
-        for line in lines:
-            try:
-                ttl = int(line[3])
-                break
-            except IndexError:
-                pass
+        ttl = self._ttl_for(lines, 3)
 
         values = []
         for line in lines:
@@ -223,14 +205,7 @@ class TinyDnsBaseSource(BaseSource):
             # we didn't find any value ips so nothing to do
             return []
 
-        # see if we can find a ttl on any of the lines, first one wins
-        ttl = self.default_ttl
-        for line in lines:
-            try:
-                ttl = int(line[2])
-                break
-            except IndexError:
-                pass
+        ttl = self._ttl_for(lines, 2)
 
         yield 'A', name, ttl, ips
 
@@ -252,14 +227,7 @@ class TinyDnsBaseSource(BaseSource):
             for l in lines
         ]
 
-        # see if we can find a ttl on any of the lines, first one wins
-        ttl = self.default_ttl
-        for line in lines:
-            try:
-                ttl = int(line[2])
-                break
-            except IndexError:
-                pass
+        ttl = self._ttl_for(lines, 2)
 
         yield 'TXT', name, ttl, values
 
@@ -283,14 +251,7 @@ class TinyDnsBaseSource(BaseSource):
             # the address correct.
             ips.append(u':'.join(textwrap.wrap(line[1], 4)))
 
-        # see if we can find a ttl on any of the lines, first one wins
-        ttl = self.default_ttl
-        for line in lines:
-            try:
-                ttl = int(line[2])
-                break
-            except IndexError:
-                pass
+        ttl = self._ttl_for(lines, 2)
 
         yield 'AAAA', name, ttl, ips
 
@@ -306,14 +267,7 @@ class TinyDnsBaseSource(BaseSource):
             # if name doesn't live under our zone there's nothing for us to do
             return
 
-        # see if we can find a ttl on any of the lines, first one wins
-        ttl = self.default_ttl
-        for line in lines:
-            try:
-                ttl = int(line[6])
-                break
-            except IndexError:
-                pass
+        ttl = self._ttl_for(lines, 6)
 
         values = []
         for line in lines:
@@ -383,14 +337,7 @@ class TinyDnsBaseSource(BaseSource):
                 )
                 continue
 
-            # see if we can find a ttl on any of the lines, first one wins
-            ttl = self.default_ttl
-            for line in lines:
-                try:
-                    ttl = int(line[3])
-                    break
-                except IndexError:
-                    pass
+            ttl = self._ttl_for(lines, 3)
 
             rdatas = [l[2] for l in lines]
             yield _type, name, ttl, _class.parse_rdata_texts(rdatas)

--- a/octodns/source/tinydns.py
+++ b/octodns/source/tinydns.py
@@ -10,7 +10,6 @@ from os import listdir
 from os.path import join
 
 from ..record import Record
-from ..zone import SubzoneRecordException
 from .base import BaseSource
 
 
@@ -380,12 +379,7 @@ class TinyDnsBaseSource(BaseSource):
                 else:
                     data['value'] = values[0]
                 record = Record.new(zone, name, data, lenient=lenient)
-                try:
-                    zone.add_record(record, lenient=lenient)
-                except SubzoneRecordException:
-                    self.log.error(
-                        'populate: skipping subzone record=%s', record
-                    )
+                zone.add_record(record, lenient=lenient)
 
         self.log.info(
             'populate:   found %s records', len(zone.records) - before

--- a/octodns/zone.py
+++ b/octodns/zone.py
@@ -75,6 +75,28 @@ class Zone(object):
             # it has utf8 chars
             return self._utf8_name_re.sub('', fqdn)
 
+    def owns(self, _type, fqdn):
+        if fqdn[-1] != '.':
+            fqdn = f'{fqdn}.'
+
+        # if we don't end with the zone's name we aren't owned by it
+        if not fqdn.endswith(self.name):
+            return False
+
+        hostname = self.hostname_from_fqdn(fqdn)
+        if hostname in self.sub_zones:
+            # if our hostname matches a sub-zone exactly we have to be a NS
+            # record
+            return _type == 'NS'
+
+        for sub_zone in self.sub_zones:
+            if hostname.endswith(f'.{sub_zone}'):
+                # this belongs under a sub-zone
+                return False
+
+        # otherwise we own it
+        return True
+
     def add_record(self, record, replace=False, lenient=False):
         if self._origin:
             self.hydrate()

--- a/octodns/zone.py
+++ b/octodns/zone.py
@@ -79,8 +79,12 @@ class Zone(object):
         if fqdn[-1] != '.':
             fqdn = f'{fqdn}.'
 
-        # if we don't end with the zone's name we aren't owned by it
-        if not fqdn.endswith(self.name):
+        # if we exactly match the zone name we own it
+        if fqdn == self.name:
+            return True
+
+        # if we don't end with the zone's name on a boundary we aren't owned
+        if not fqdn.endswith(f'.{self.name}'):
             return False
 
         hostname = self.hostname_from_fqdn(fqdn)

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -8,6 +8,7 @@ from octodns.idna import idna_encode
 from octodns.record import (
     AliasRecord,
     ARecord,
+    CnameRecord,
     Create,
     Delete,
     MxValue,
@@ -175,6 +176,20 @@ class TestRecord(TestCase):
         self.assertEqual('target.unit.tests.', record.value)
         # make sure there's nothing extra
         self.assertEqual(5, len(records))
+
+    def test_parse_rdata_texts(self):
+        self.assertEqual(['2.3.4.5'], ARecord.parse_rdata_texts(['2.3.4.5']))
+        self.assertEqual(
+            ['2.3.4.6', '3.4.5.7'],
+            ARecord.parse_rdata_texts(['2.3.4.6', '3.4.5.7']),
+        )
+        self.assertEqual(
+            ['some.target.'], CnameRecord.parse_rdata_texts(['some.target.'])
+        )
+        self.assertEqual(
+            ['some.target.', 'other.target.'],
+            CnameRecord.parse_rdata_texts(['some.target.', 'other.target.']),
+        )
 
     def test_values_mixin_data(self):
         # no values, no value or values in data

--- a/tests/test_octodns_source_tinydns.py
+++ b/tests/test_octodns_source_tinydns.py
@@ -17,7 +17,7 @@ class TestTinyDnsFileSource(TestCase):
     def test_populate_normal(self):
         got = Zone('example.com.', [])
         self.source.populate(got)
-        self.assertEqual(24, len(got.records))
+        self.assertEqual(25, len(got.records))
 
         expected = Zone('example.com.', [])
         for name, data in (
@@ -49,6 +49,10 @@ class TestTinyDnsFileSource(TestCase):
                 {'type': 'CNAME', 'ttl': 3600, 'value': 'www.example.com.'},
             ),
             (
+                'cname2',
+                {'type': 'CNAME', 'ttl': 48, 'value': 'www2.example.com.'},
+            ),
+            (
                 'some-host-abc123',
                 {'type': 'A', 'ttl': 1800, 'value': '10.2.3.7'},
             ),
@@ -66,7 +70,7 @@ class TestTinyDnsFileSource(TestCase):
                             'exchange': 'smtp-1-host.example.com.',
                         },
                         {
-                            'preference': 20,
+                            'preference': 0,
                             'exchange': 'smtp-2-host.example.com.',
                         },
                     ],
@@ -212,4 +216,4 @@ class TestTinyDnsFileSource(TestCase):
         got = Zone('example.com.', ['sub'])
         self.source.populate(got)
         # we don't see one www.sub.example.com. record b/c it's in a sub
-        self.assertEqual(23, len(got.records))
+        self.assertEqual(24, len(got.records))

--- a/tests/test_octodns_source_tinydns.py
+++ b/tests/test_octodns_source_tinydns.py
@@ -17,7 +17,7 @@ class TestTinyDnsFileSource(TestCase):
     def test_populate_normal(self):
         got = Zone('example.com.', [])
         self.source.populate(got)
-        self.assertEqual(25, len(got.records))
+        self.assertEqual(28, len(got.records))
 
         expected = Zone('example.com.', [])
         for name, data in (
@@ -140,6 +140,43 @@ class TestTinyDnsFileSource(TestCase):
                     'values': ['ns5.ns.example.com.', 'ns6.ns.example.com.'],
                 },
             ),
+            (
+                '_a._tcp',
+                {
+                    'type': 'SRV',
+                    'ttl': 43,
+                    'values': [
+                        {
+                            'priority': 0,
+                            'weight': 0,
+                            'port': 8888,
+                            'target': 'target.srv.example.com.',
+                        },
+                        {
+                            'priority': 10,
+                            'weight': 50,
+                            'port': 8080,
+                            'target': 'target.somewhere.else.',
+                        },
+                    ],
+                },
+            ),
+            ('target.srv', {'type': 'A', 'ttl': 43, 'value': '56.57.58.59'}),
+            (
+                '_b._tcp',
+                {
+                    'type': 'SRV',
+                    'ttl': 3600,
+                    'values': [
+                        {
+                            'priority': 0,
+                            'weight': 0,
+                            'port': 9999,
+                            'target': 'target.srv.example.com.',
+                        }
+                    ],
+                },
+            ),
         ):
             record = Record.new(expected, name, data)
             expected.add_record(record)
@@ -216,4 +253,4 @@ class TestTinyDnsFileSource(TestCase):
         got = Zone('example.com.', ['sub'])
         self.source.populate(got)
         # we don't see one www.sub.example.com. record b/c it's in a sub
-        self.assertEqual(24, len(got.records))
+        self.assertEqual(27, len(got.records))

--- a/tests/test_octodns_source_tinydns.py
+++ b/tests/test_octodns_source_tinydns.py
@@ -178,9 +178,18 @@ class TestTinyDnsFileSource(TestCase):
             expected.add_record(record)
 
         changes = expected.changes(got, SimpleProvider())
+        from pprint import pprint
+
+        pprint(
+            {
+                'changes': changes,
+                'expected': expected.records,
+                'got': got.records,
+            }
+        )
         self.assertEqual([], changes)
 
     def test_ignores_subs(self):
         got = Zone('example.com.', ['sub'])
         self.source.populate(got)
-        self.assertEqual(16, len(got.records))
+        self.assertEqual(23, len(got.records))

--- a/tests/test_octodns_source_tinydns.py
+++ b/tests/test_octodns_source_tinydns.py
@@ -17,7 +17,7 @@ class TestTinyDnsFileSource(TestCase):
     def test_populate_normal(self):
         got = Zone('example.com.', [])
         self.source.populate(got)
-        self.assertEqual(28, len(got.records))
+        self.assertEqual(30, len(got.records))
 
         expected = Zone('example.com.', [])
         for name, data in (
@@ -177,6 +177,26 @@ class TestTinyDnsFileSource(TestCase):
                     ],
                 },
             ),
+            (
+                'arbitrary-sshfp',
+                {
+                    'type': 'SSHFP',
+                    'ttl': 45,
+                    'values': [
+                        {
+                            'algorithm': 1,
+                            'fingerprint_type': 2,
+                            'fingerprint': '00479b27',
+                        },
+                        {
+                            'algorithm': 2,
+                            'fingerprint_type': 2,
+                            'fingerprint': '00479a28',
+                        },
+                    ],
+                },
+            ),
+            ('arbitrary-a', {'type': 'A', 'ttl': 3600, 'value': '80.81.82.83'}),
         ):
             record = Record.new(expected, name, data)
             expected.add_record(record)
@@ -253,4 +273,4 @@ class TestTinyDnsFileSource(TestCase):
         got = Zone('example.com.', ['sub'])
         self.source.populate(got)
         # we don't see one www.sub.example.com. record b/c it's in a sub
-        self.assertEqual(27, len(got.records))
+        self.assertEqual(29, len(got.records))

--- a/tests/test_octodns_zone.py
+++ b/tests/test_octodns_zone.py
@@ -210,6 +210,12 @@ class TestZone(TestCase):
         # including subsequent delegatoin NS records
         self.assertFalse(zone.owns('NS', 'below.sub.unit.tests.'))
 
+        # edge cases
+        # we don't own something that ends with our name, but isn't a boundary
+        self.assertFalse(zone.owns('A', 'foo-unit.tests.'))
+        # we do something that ends with the sub-zone, but isn't at a boundary
+        self.assertTrue(zone.owns('A', 'foo-sub.unit.tests.'))
+
     def test_sub_zones(self):
         # NS for exactly the sub is allowed
         zone = Zone('unit.tests.', set(['sub', 'barred']))

--- a/tests/test_octodns_zone.py
+++ b/tests/test_octodns_zone.py
@@ -191,6 +191,25 @@ class TestZone(TestCase):
             Zone('space not allowed.', [])
         self.assertTrue('whitespace not allowed' in str(ctx.exception))
 
+    def test_owns(self):
+        zone = Zone('unit.tests.', set(['sub']))
+
+        self.assertTrue(zone.owns('A', 'unit.tests'))
+        self.assertTrue(zone.owns('A', 'unit.tests.'))
+        self.assertTrue(zone.owns('A', 'www.unit.tests.'))
+        self.assertTrue(zone.owns('A', 'www.unit.tests.'))
+        # we do own our direct sub's delegation NS records
+        self.assertTrue(zone.owns('NS', 'sub.unit.tests.'))
+
+        # we don't own the root of our sub
+        self.assertFalse(zone.owns('A', 'sub.unit.tests.'))
+
+        # of anything under it
+        self.assertFalse(zone.owns('A', 'www.sub.unit.tests.'))
+
+        # including subsequent delegatoin NS records
+        self.assertFalse(zone.owns('NS', 'below.sub.unit.tests.'))
+
     def test_sub_zones(self):
         # NS for exactly the sub is allowed
         zone = Zone('unit.tests.', set(['sub', 'barred']))

--- a/tests/zones/tinydns/example.com
+++ b/tests/zones/tinydns/example.com
@@ -72,3 +72,11 @@ S_a._tcp.example.com::target.somewhere.else:8080:10:50:43
 S_b._tcp.example.com:56.57.58.59:target.srv.example.com.:9999
 # complete duplicate should be ignored
 S_b._tcp.example.com:56.57.58.59:target.srv.example.com.:9999
+
+# arbitrary multi-value non-spec record
+:arbitrary-sshfp.example.com:SSHFP:2 2 00479a28
+:arbitrary-sshfp.example.com:SSHFP:1 2 00479b27:45
+# does not make sense to do an A this way, but it'll work
+:arbitrary-a.example.com:a:80.81.82.83
+# this should just be inored b/c the type is unknown
+:arbitrary-invalid.example.com:invalid:does not matter:99

--- a/tests/zones/tinydns/example.com
+++ b/tests/zones/tinydns/example.com
@@ -27,20 +27,26 @@ Ccname.other.foo:www.other.foo
 # MX
 @example.com::smtp-1-host.example.com:10
 @example.com.::smtp-2-host.example.com:20
-# MX with ttl
-@smtp.example.com::smtp-1-host.example.com:30:1800
-@smtp.example.com.::smtp-2-host.example.com:40:1800
+# MX with ttl and ip
+@smtp.example.com:21.22.23.24:smtp-1-host:30:1800
+@smtp.example.com.:22.23.24.25:smtp-2-host:40:1800
 
-# NS
+# NS for sub
 .sub.example.com::ns3.ns.com:30
 .sub.example.com.::ns4.ns.com:30
+# NS with ip
+.other.example.com:14.15.16.17:ns5:30
+.other.example.com.:15.16.17.18:ns6:30
 
 # A, under sub
-+www.sub.example.com::1.2.3.4
++www.sub.example.com:1.2.3.4
 
 # Top-level NS
 .example.com::ns1.ns.com
 .example.com.::ns2.ns.com
+# Top-level NS with automatic A
+&example.com:42.43.44.45:a
+&example.com.:43.44.45.46:b:31
 
 # sub special cases
 +a1.blah-asdf.subtest.com:10.2.3.5

--- a/tests/zones/tinydns/example.com
+++ b/tests/zones/tinydns/example.com
@@ -28,8 +28,8 @@ Ccname.other.foo:www.other.foo
 @example.com::smtp-1-host.example.com:10
 @example.com.::smtp-2-host.example.com:20
 # MX with ttl and ip
-@smtp.example.com:21.22.23.24:smtp-1-host:30:1800
-@smtp.example.com.:22.23.24.25:smtp-2-host:40:1800
+@smtp.example.com:21.22.23.24:smtp-3-host:30:1800
+@smtp.example.com.:22.23.24.25:smtp-4-host:40:1800
 
 # NS for sub
 .sub.example.com::ns3.ns.com:30

--- a/tests/zones/tinydns/example.com
+++ b/tests/zones/tinydns/example.com
@@ -61,3 +61,9 @@ Ccname.other.foo:www.other.foo
 6ipv6-6.example.com:2a021348017cd5d0002419fffef35743
 
 'semicolon.example.com:v=DKIM1; k=rsa; p=blah:300
+
+# SRV
+S_a._tcp.example.com:56.57.58.59:target:8888
+S_a._tcp.example.com::target.somewhere.else:8080:10:50:43
+# TODO: add an IP so it tries to create a record that already exists
+S_b._tcp.example.com::target.srv.example.com.:9999

--- a/tests/zones/tinydns/example.com
+++ b/tests/zones/tinydns/example.com
@@ -26,14 +26,14 @@ Ccname.other.foo:www.other.foo
 
 # MX
 @example.com::smtp-1-host.example.com:10
-@example.com.::smtp-2-host.example.com:20
+@example.com.::smtp-2-host.example.com.
 # MX with ttl and ip
 @smtp.example.com:21.22.23.24:smtp-3-host:30:1800
 @smtp.example.com.:22.23.24.25:smtp-4-host:40:1800
 
 # NS for sub
 .sub.example.com::ns3.ns.com:30
-.sub.example.com.::ns4.ns.com:30
+.sub.example.com.::ns4.ns.com.:30
 # NS with ip
 .other.example.com:14.15.16.17:ns5:30
 .other.example.com.:15.16.17.18:ns6:30

--- a/tests/zones/tinydns/example.com
+++ b/tests/zones/tinydns/example.com
@@ -5,6 +5,8 @@
 # Multi-value A
 +example.com:10.2.3.4:30
 +example.com.:10.2.3.5:30
+# duplicate value should be ignored
++example.com:10.2.3.4
 
 Ccname.other.foo:www.other.foo
 
@@ -65,5 +67,8 @@ Ccname.other.foo:www.other.foo
 # SRV
 S_a._tcp.example.com:56.57.58.59:target:8888
 S_a._tcp.example.com::target.somewhere.else:8080:10:50:43
-# TODO: add an IP so it tries to create a record that already exists
-S_b._tcp.example.com::target.srv.example.com.:9999
+# will try and re-create an already existing A with the same IP, should be a
+# noop
+S_b._tcp.example.com:56.57.58.59:target.srv.example.com.:9999
+# complete duplicate should be ignored
+S_b._tcp.example.com:56.57.58.59:target.srv.example.com.:9999

--- a/tests/zones/tinydns/other.foo
+++ b/tests/zones/tinydns/other.foo
@@ -3,5 +3,6 @@
 
 # CNAME with trailing comment
 Ccname.example.com:www.example.com # this is a comment
+Ccname2.example.com:www2.example.com.:48
 
 +www.other.foo:14.2.3.6


### PR DESCRIPTION
Completely rewrites the TinyDNS source to be fully/completely spec compliant for all of the base types and IPv6 extensions. Specifically handles all the auto-creation of `NS`/`MX` `A`s and such that previously wasn't implemented.

For the most part the original unit tests haven't changed with the exception of now expecting the auto-created As and exercising more of the edge cases: trailing dots, w/wo IPs etc.

Won't be surprised if there's problems/details in here, but it should be in at least as good a shape now as it was before and much more complete/powerful. 

/cc https://github.com/octodns/octodns/issues/999
/cc @dbuenoparedes