### PR TITLE
Add support for relative target/exchange/nameserver values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.0.0.rc2 - 2023-??-?? -
+## v1.0.0.rc1 - 2023-07-20 - The last one before the 1s
 
 * Record and Zone validation now ensures there's no whitespace in names
 * OwnershipProcessor managed records always add w/lenient=True, this allows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Correctly handle FQDNs in TinyDNS config files that end with trailing .'s
 * Complete rewrite of TinyDnsBaseSource to fully implement the spec and the ipv6
   extensions
+* Allow relative target, nameserver, or exchange values
 
 ## v1.0.0.rc0 - 2023-05-16 - First of the ones
 

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -1,3 +1,3 @@
 'OctoDNS: DNS as code - Tools for managing DNS across multiple providers'
 
-__VERSION__ = '1.0.0rc0'
+__VERSION__ = '1.0.0rc1'

--- a/octodns/record/mx.py
+++ b/octodns/record/mx.py
@@ -45,16 +45,21 @@ class MxValue(EqualityTupleMixin, dict):
                     reasons.append('missing exchange')
                     continue
                 exchange = idna_encode(exchange)
-                if (
-                    exchange != '.'
-                    and not FQDN(exchange, allow_underscores=True).is_valid
-                ):
-                    reasons.append(
-                        f'Invalid MX exchange "{exchange}" is not '
-                        'a valid FQDN.'
-                    )
-                elif not exchange.endswith('.'):
-                    reasons.append(f'MX value "{exchange}" missing trailing .')
+                if '.' not in exchange:
+                    reasons.append(f'MX exchange "{exchange}" is relative')
+                else:
+                    if (
+                        exchange != '.'
+                        and not FQDN(exchange, allow_underscores=True).is_valid
+                    ):
+                        reasons.append(
+                            f'Invalid MX exchange "{exchange}" is not '
+                            'a valid FQDN.'
+                        )
+                    elif not exchange.endswith('.'):
+                        reasons.append(
+                            f'MX value "{exchange}" missing trailing .'
+                        )
             except KeyError:
                 reasons.append('missing exchange')
         return reasons

--- a/octodns/record/srv.py
+++ b/octodns/record/srv.py
@@ -69,15 +69,20 @@ class SrvValue(EqualityTupleMixin, dict):
                     reasons.append('missing target')
                     continue
                 target = idna_encode(target)
-                if not target.endswith('.'):
-                    reasons.append(f'SRV value "{target}" missing trailing .')
-                if (
-                    target != '.'
-                    and not FQDN(target, allow_underscores=True).is_valid
-                ):
-                    reasons.append(
-                        f'Invalid SRV target "{target}" is not a valid FQDN.'
-                    )
+                if '.' not in target:
+                    reasons.append(f'SRV value "{target}" is relative')
+                else:
+                    if not target.endswith('.'):
+                        reasons.append(
+                            f'SRV value "{target}" missing trailing .'
+                        )
+                    if (
+                        target != '.'
+                        and not FQDN(target, allow_underscores=True).is_valid
+                    ):
+                        reasons.append(
+                            f'Invalid SRV target "{target}" is not a valid FQDN.'
+                        )
             except KeyError:
                 reasons.append('missing target')
         return reasons

--- a/octodns/record/target.py
+++ b/octodns/record/target.py
@@ -19,6 +19,8 @@ class _TargetValue(str):
             reasons.append('empty value')
         elif not data:
             reasons.append('missing value')
+        elif '.' not in data:
+            reasons.append(f'{_type} value "{data}" is relative')
         else:
             data = idna_encode(data)
             if not FQDN(str(data), allow_underscores=True).is_valid:
@@ -58,7 +60,9 @@ class _TargetsValue(str):
         reasons = []
         for value in data:
             value = idna_encode(value)
-            if not FQDN(value, allow_underscores=True).is_valid:
+            if '.' not in value:
+                reasons.append(f'{_type} value "{value}" is relative')
+            elif not FQDN(value, allow_underscores=True).is_valid:
                 reasons.append(
                     f'Invalid {_type} value "{value}" is not a valid FQDN.'
                 )

--- a/tests/test_octodns_record_mx.py
+++ b/tests/test_octodns_record_mx.py
@@ -262,3 +262,18 @@ class TestRecordMx(TestCase):
             },
         )
         self.assertEqual('.', record.values[0].exchange)
+
+        # relative exchange
+        with self.assertRaises(ValidationError) as ctx:
+            Record.new(
+                self.zone,
+                '',
+                {
+                    'type': 'MX',
+                    'ttl': 600,
+                    'value': {'preference': 10, 'value': 'isrelative'},
+                },
+            )
+        self.assertEqual(
+            ['MX exchange "isrelative" is relative'], ctx.exception.reasons
+        )

--- a/tests/test_octodns_record_srv.py
+++ b/tests/test_octodns_record_srv.py
@@ -429,3 +429,23 @@ class TestRecordSrv(TestCase):
             ['Invalid SRV target "100 foo.bar.com." is not a valid FQDN.'],
             ctx.exception.reasons,
         )
+
+        # relative target
+        with self.assertRaises(ValidationError) as ctx:
+            Record.new(
+                self.zone,
+                '_srv._tcp',
+                {
+                    'type': 'SRV',
+                    'ttl': 600,
+                    'value': {
+                        'priority': 1,
+                        'weight': 2,
+                        'port': 3,
+                        'target': 'isrelative',
+                    },
+                },
+            )
+        self.assertEqual(
+            ['SRV value "isrelative" is relative'], ctx.exception.reasons
+        )

--- a/tests/test_octodns_record_target.py
+++ b/tests/test_octodns_record_target.py
@@ -4,6 +4,7 @@
 
 from unittest import TestCase
 
+from octodns.record import Record, ValidationError
 from octodns.record.alias import AliasRecord
 from octodns.record.target import _TargetValue
 from octodns.zone import Zone
@@ -28,3 +29,32 @@ class TestRecordTarget(TestCase):
         zone = Zone('unit.tests.', [])
         a = AliasRecord(zone, 'a', {'ttl': 42, 'value': 'some.target.'})
         self.assertEqual('some.target.', a.value.rdata_text)
+
+    def test_relative_target(self):
+        zone = Zone('unit.tests.', [])
+
+        data = {'ttl': 43, 'type': 'CNAME', 'value': 'isrelative'}
+        with self.assertRaises(ValidationError) as ctx:
+            Record.new(zone, 'cname', data)
+        self.assertEqual(
+            ['CNAME value "isrelative" is relative'], ctx.exception.reasons
+        )
+        cname = Record.new(zone, 'cname', data, lenient=True)
+        self.assertEqual(data['value'], cname.value)
+
+        data = {
+            'ttl': 43,
+            'type': 'NS',
+            'values': ['isrelative1', 'isrelative2'],
+        }
+        with self.assertRaises(ValidationError) as ctx:
+            Record.new(zone, 'ns', data)
+        self.assertEqual(
+            [
+                'NS value "isrelative1" is relative',
+                'NS value "isrelative2" is relative',
+            ],
+            ctx.exception.reasons,
+        )
+        cname = Record.new(zone, 'ns', data, lenient=True)
+        self.assertEqual(data['values'], cname.values)


### PR DESCRIPTION
This adds support and tests for relative values as target (CNAME, NS, ...), exchanges (MX), etc. 

They are validations that will object by default and can be turned into warnings with `lenient`. This should be completely backwards compatible.

/cc Fixes https://github.com/octodns/octodns/issues/987 @rafaelfuchsbr