### PR TITLE
Version 1.0.0rc1 version bump and changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.0.0.rc2 - 2023-??-?? -
+## v1.0.0.rc1 - 2023-07-20 - The last one before the 1s
 
 * Record and Zone validation now ensures there's no whitespace in names
 * OwnershipProcessor managed records always add w/lenient=True, this allows

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -1,3 +1,3 @@
 'OctoDNS: DNS as code - Tools for managing DNS across multiple providers'
 
-__VERSION__ = '1.0.0rc0'
+__VERSION__ = '1.0.0rc1'


### PR DESCRIPTION
## v1.0.0.rc1 - 2023-07-20 - The last one before the 1s

* Record and Zone validation now ensures there's no whitespace in names
* OwnershipProcessor managed records always add w/lenient=True, this allows
  ownership to be marked in the same zone for delegation NS records.
* octodns-report access --lenient flag to allow running reports with records
  sourced from providers with non-compliant record data.
* Correctly handle FQDNs in TinyDNS config files that end with trailing .'s
* Complete rewrite of TinyDnsBaseSource to fully implement the spec and the ipv6
  extensions
* Allow relative target, nameserver, or exchange values
