### PR TITLE
config/validation errors with source context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.1.0 - 2023-??-?? - ???
+
+* Add context to general configuration and Record validation, e.g.
+  Some problem at filename.yaml, line 42, column 14. Our custom Yaml Loaders
+  attach this context information, arbitrary string. Other providers may do so
+  by creating ContextDict to pass as `data` into Record.new.
+
 ## v1.0.0 - 2023-07-30 - The One
 
 1.0 marks a point at which we can formally deprecate things that will be

--- a/octodns/context.py
+++ b/octodns/context.py
@@ -1,0 +1,20 @@
+#
+#
+#
+
+
+class ContextDict(dict):
+    '''
+    This is used by things that call `Record.new` to pass in a `data`
+    dictionary that includes some context as to where the data came from to be
+    printed along with exceptions or validations of the record.
+
+    It breaks lots of stuff if we stored the context in an extra key and the
+    python `dict` object doesn't allow you to set attributes on the object so
+    this is a very thin wrapper around `dict` that allows us to have a context
+    attribute.
+    '''
+
+    def __init__(self, *args, context=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.context = context

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -254,15 +254,14 @@ class Manager(object):
     def _config_plan_outputs(self, plan_outputs_config):
         plan_outputs = {}
         for plan_output_name, plan_output_config in plan_outputs_config.items():
-            context = getattr(plan_output_config, 'context', None)
+            context = getattr(plan_output_config, 'context', '')
             try:
                 _class = plan_output_config.pop('class')
             except KeyError:
                 self.log.exception('Invalid plan_output class')
-                msg = f'plan_output {plan_output_name} is missing class'
-                if context:
-                    msg += f', {context}'
-                raise ManagerException(msg)
+                raise ManagerException(
+                    f'plan_output {plan_output_name} is missing class, {context}'
+                )
             _class, module, version = self._get_named_class(
                 'plan_output', _class, context
             )
@@ -281,10 +280,9 @@ class Manager(object):
                     )
             except TypeError:
                 self.log.exception('Invalid plan_output config')
-                msg = f'Incorrect plan_output config for {plan_output_name}'
-                if context:
-                    msg += f', {plan_output_config.context}'
-                raise ManagerException(msg)
+                raise ManagerException(
+                    f'Incorrect plan_output config for {plan_output_name}, {context}'
+                )
 
         return plan_outputs
 
@@ -324,10 +322,9 @@ class Manager(object):
             self.log.exception(
                 '_get_{}_class: Unable to import module %s', _class
             )
-            msg = f'Unknown {_type} class: {_class}'
-            if context:
-                msg += f', {context}'
-            raise ManagerException(msg)
+            raise ManagerException(
+                f'Unknown {_type} class: {_class}, {context}'
+            )
 
         try:
             return getattr(module, class_name), module_name, version
@@ -344,7 +341,6 @@ class Manager(object):
     def _build_kwargs(self, source):
         # Build up the arguments we need to pass to the provider
         kwargs = {}
-        context = getattr(source, 'context', None)
         for k, v in source.items():
             try:
                 if v.startswith('env/'):
@@ -353,10 +349,9 @@ class Manager(object):
                         v = environ[env_var]
                     except KeyError:
                         self.log.exception('Invalid provider config')
-                        msg = f'Incorrect provider config, missing env var {env_var}'
-                        if context:
-                            msg += f', {context}'
-                        raise ManagerException(msg)
+                        raise ManagerException(
+                            f'Incorrect provider config, missing env var {env_var}, {source.context}'
+                        )
             except AttributeError:
                 pass
             kwargs[k] = v

--- a/octodns/record/exception.py
+++ b/octodns/record/exception.py
@@ -11,11 +11,16 @@ class RecordException(Exception):
 
 class ValidationError(RecordException):
     @classmethod
-    def build_message(cls, fqdn, reasons):
+    def build_message(cls, fqdn, reasons, context=None):
         reasons = '\n  - '.join(reasons)
-        return f'Invalid record "{idna_decode(fqdn)}"\n  - {reasons}'
+        msg = f'Invalid record "{idna_decode(fqdn)}"'
+        if context:
+            msg += f', {context}'
+        msg += f'\n  - {reasons}'
+        return msg
 
-    def __init__(self, fqdn, reasons):
-        super().__init__(self.build_message(fqdn, reasons))
+    def __init__(self, fqdn, reasons, context=None):
+        super().__init__(self.build_message(fqdn, reasons, context))
         self.fqdn = fqdn
         self.reasons = reasons
+        self.context = context

--- a/octodns/yaml.py
+++ b/octodns/yaml.py
@@ -7,17 +7,9 @@ from yaml import SafeDumper, SafeLoader, dump, load
 from yaml.constructor import ConstructorError
 from yaml.representer import SafeRepresenter
 
+from .context import ContextDict
+
 _natsort_key = natsort_keygen()
-
-
-# TODO: where should this live
-class ContextDict(dict):
-    # can't assign attributes to plain dict objects and it breaks lots of stuff
-    # if we put the context into the dict data itself
-
-    def __init__(self, *args, context=None, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.context = context
 
 
 class ContextLoader(SafeLoader):

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -104,13 +104,13 @@ class TestManager(TestCase):
         with self.assertRaises(ManagerException) as ctx:
             name = 'bad-plan-output-missing-class.yaml'
             Manager(get_config_filename(name)).sync()
-        self.assertEqual('plan_output bad is missing class', str(ctx.exception))
+        self.assertTrue('plan_output bad is missing class' in str(ctx.exception))
 
     def test_bad_plan_output_config(self):
         with self.assertRaises(ManagerException) as ctx:
             Manager(get_config_filename('bad-plan-output-config.yaml')).sync()
-        self.assertEqual(
-            'Incorrect plan_output config for bad', str(ctx.exception)
+        self.assertTrue(
+            'Incorrect plan_output config for bad' in str(ctx.exception)
         )
 
     def test_source_only_as_a_target(self):

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -104,7 +104,9 @@ class TestManager(TestCase):
         with self.assertRaises(ManagerException) as ctx:
             name = 'bad-plan-output-missing-class.yaml'
             Manager(get_config_filename(name)).sync()
-        self.assertTrue('plan_output bad is missing class' in str(ctx.exception))
+        self.assertTrue(
+            'plan_output bad is missing class' in str(ctx.exception)
+        )
 
     def test_bad_plan_output_config(self):
         with self.assertRaises(ManagerException) as ctx:


### PR DESCRIPTION
This sketches out a system for including context in error messages about configuration or validation. It's implemented for YamlProvider here, but nothing would stop other providers from passing in context if there's something useful for them to provide, maybe things like account ids or provider specific/internal ids...

For now this is just a POC. It needs a bunch of cleanup and testing before it'd be ready to move forward. Definitely a post 1.0 release change. Pretty happy with how it's working though and was cleaner to get going that I expected.

## Examples

### Invalid Provider Config

```console
...
  File "/Users/ross/octodns/octodns/octodns/manager.py", line 202, in _config_providers
    raise ManagerException(
octodns.manager.ManagerException: Provider ns1 is missing class, config/dev.yaml, line 26, column 5
```

```console
...
  File "/Users/ross/octodns/octodns/octodns/manager.py", line 219, in _config_providers
    raise ManagerException(
octodns.manager.ManagerException: Incorrect provider config for ns1, config/dev.yaml, line 26, column 5
```

### Record errors and validation

```console
...
  File "/Users/ross/octodns/octodns/env/lib/python3.10/site-packages/yaml/constructor.py", line 100, in construct_object
    data = constructor(self, node)
  File "/Users/ross/octodns/octodns/octodns/yaml.py", line 55, in _construct
    raise ConstructorError(
yaml.constructor.ConstructorError: keys out of order: expected ttl got type at ./config/exxampled.com.yaml, line 3, column 5
```

```console
...
    self._populate_from_file(filename, zone, lenient)
  File "/Users/ross/octodns/octodns/octodns/provider/yaml.py", line 175, in _populate_from_file
    record = Record.new(
  File "/Users/ross/octodns/octodns/octodns/record/base.py", line 63, in new
    raise Exception(msg)
Exception: Unknown record type: "AAAAA", ./config/exxampled.com.yaml, line 7, column 5
```

```console
...
  File "/Users/ross/octodns/octodns/octodns/record/base.py", line 75, in new
    raise ValidationError(fqdn, reasons, context)
octodns.record.exception.ValidationError: Invalid record "cname.exxampled.com.", ./config/exxampled.com.yaml, line 14, column 3
  - CNAME value "foo.bar" missing trailing .
```

/cc https://github.com/octodns/octodns/issues/1027 which lead to this work
/cc @joschi36 who suggested it