### PR TITLE
Deprecate geo records in favor of dynamic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## v1.0.0 - 2023-??-?? - The One
 
+#### Noteworthy changes
+
+* `geo` records are deprecated.
+
 #### Stuff
 
 * Removal of a Python 3.7 specific import work-around now that it's no longer an

--- a/octodns/record/geo.py
+++ b/octodns/record/geo.py
@@ -141,6 +141,9 @@ class _GeoMixin(ValuesMixin):
         reasons = super().validate(name, fqdn, data)
         try:
             geo = dict(data['geo'])
+            cls.log.warning(
+                'NOTICE: `geo` record support is deprecated and should be migrated to `dynamic` records'
+            )
             for code, values in geo.items():
                 reasons.extend(GeoValue._validate_geo(code))
                 reasons.extend(cls._value_type.validate(values, cls._type))

--- a/tests/test_octodns_record_geo.py
+++ b/tests/test_octodns_record_geo.py
@@ -213,15 +213,22 @@ class TestRecordGeoCodes(TestCase):
         self.assertTrue(c >= b)
 
     def test_validation(self):
-        Record.new(
-            self.zone,
-            '',
-            {
-                'geo': {'NA': ['1.2.3.5'], 'NA-US': ['1.2.3.5', '1.2.3.6']},
-                'type': 'A',
-                'ttl': 600,
-                'value': '1.2.3.4',
-            },
+        with self.assertLogs('Record', level='WARNING') as cm:
+            Record.new(
+                self.zone,
+                '',
+                {
+                    'geo': {'NA': ['1.2.3.5'], 'NA-US': ['1.2.3.5', '1.2.3.6']},
+                    'type': 'A',
+                    'ttl': 600,
+                    'value': '1.2.3.4',
+                },
+            )
+        self.assertEqual(
+            [
+                'WARNING:Record:NOTICE: `geo` record support is deprecated and should be migrated to `dynamic` records'
+            ],
+            cm.output,
         )
 
         # invalid ip address


### PR DESCRIPTION
`dynamic` has been around a long long time now and is far superior to the old geo setup. Formally deprecating them as we move into 1.0 with the plan to remove the functionality when we hit 2.x.