### PR TITLE
v1.0.0 version bump and changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## v1.0.0 - 2023-??-?? - The One
+## v1.0.0 - 2023-07-30 - The One
+
+1.0 marks a point at which we can formally deprecate things that will be
+going away with 2.0 more than specific functionality that has been added or
+having reached a notable level of stability (beyond what is normal.) It is also
+long (years) overdue.
 
 #### Noteworthy changes
 

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -1,3 +1,3 @@
 'OctoDNS: DNS as code - Tools for managing DNS across multiple providers'
 
-__VERSION__ = '1.0.0rc1'
+__VERSION__ = '1.0.0'


### PR DESCRIPTION
## v1.0.0 - 2023-07-30 - The One

1.0 marks a point at which we can formally deprecate things that will be
going away with 2.0 more than specific functionality that has been added or
having reached a notable level of stability (beyond what is normal.) It is also
long (years) overdue.