### PR TITLE
Add --all option to octodns-validate, to enable showing of all record validation issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
   Some problem at filename.yaml, line 42, column 14. Our custom Yaml Loaders
   attach this context information, arbitrary string. Other providers may do so
   by creating ContextDict to pass as `data` into Record.new.
+* Add --all option to octodns-validate to enable showing all record validation
+  errors (as warnings) rather than exiting on the first. Exit code is non-zero
+  when there are any validation errors.
 
 ## v1.0.0 - 2023-07-30 - The One
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The architecture is pluggable and the tooling is flexible to make it applicable 
     + [Notes](#notes)
 - [Compatibility and Compliance](#compatibilty-and-compliance)
   * [`lenient`](#-lenient-)
-  * [`strict_supports` (Work In Progress)](#-strict-supports---work-in-progress-)
+  * [`strict_supports`](#-strict-supports-)
   * [Configuring `strict_supports`](#configuring--strict-supports-)
 - [Custom Sources and Providers](#custom-sources-and-providers)
 - [Other Uses](#other-uses)
@@ -266,7 +266,7 @@ octoDNS supports automatically generating PTR records from the `A`/`AAAA` record
 
 `lenient` mostly focuses on the details of `Record`s and standards compliance. When set to `true` octoDNS will allow allow non-compliant configurations & values where possible. For example CNAME values that don't end with a `.`, label length restrictions, and invalid geo codes on `dynamic` records. When in lenient mode octoDNS will log validation problems at `WARNING` and try and continue with the configuration or source data as it exists. See [Lenience](/docs/records.md#lenience) for more information on the concept and how it can be configured.
 
-### `strict_supports` (Work In Progress)
+### `strict_supports`
 
 `strict_supports` is a `Provider` level parameter that comes into play when a provider has been asked to create a record that it is unable to support. The simplest case of this would be record type, e.g. `SSHFP` not being supported by `AzureProvider`. If such a record is passed to an `AzureProvider` as a target the provider will take action based on the `strict_supports`. When `true` it will throw an exception saying that it's unable to create the record, when set to `false` it will log at `WARNING` with information about what it's unable to do and how it is attempting to working around it. Other examples of things that cannot be supported would be `dynamic` records on a provider that only supports simple or the lack of support for specific geos in a provider, e.g. Route53Provider does not support `NA-CA-*`.
 

--- a/octodns/cmds/validate.py
+++ b/octodns/cmds/validate.py
@@ -3,10 +3,21 @@
 Octo-DNS Validator
 '''
 
-from logging import WARN
+from logging import WARNING, getLogger
+from sys import exit
 
 from octodns.cmds.args import ArgumentParser
 from octodns.manager import Manager
+
+
+class FlaggingHandler:
+    level = WARNING
+
+    def __init__(self):
+        self.flag = False
+
+    def handle(self, record):
+        self.flag = True
 
 
 def main():
@@ -17,11 +28,23 @@ def main():
         required=True,
         help='The Manager configuration file to use',
     )
+    parser.add_argument(
+        '--all',
+        action='store_true',
+        default=False,
+        help='Validate records in lenient mode, printing warnings so that all validation issues are shown',
+    )
 
-    args = parser.parse_args(WARN)
+    args = parser.parse_args(WARNING)
+
+    flagging = FlaggingHandler()
+    getLogger('Record').addHandler(flagging)
 
     manager = Manager(args.config_file)
-    manager.validate_configs()
+    manager.validate_configs(lenient=args.all)
+
+    if flagging.flag:
+        exit(1)
 
 
 if __name__ == '__main__':

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -807,7 +807,7 @@ class Manager(object):
             plan = Plan(zone, zone, [], False)
         target.apply(plan)
 
-    def validate_configs(self):
+    def validate_configs(self, lenient=False):
         # TODO: this code can probably be shared with stuff in sync
         for zone_name, config in self.config['zones'].items():
             decoded_zone_name = idna_decode(zone_name)
@@ -836,7 +836,6 @@ class Manager(object):
                 source_zone = source_zone
                 continue
 
-            lenient = config.get('lenient', False)
             try:
                 sources = config['sources']
             except KeyError:
@@ -857,6 +856,7 @@ class Manager(object):
                     f'Zone {decoded_zone_name}, unknown source: ' + source
                 )
 
+            lenient = lenient or config.get('lenient', False)
             for source in sources:
                 if isinstance(source, YamlProvider):
                     source.populate(zone, lenient=lenient)


### PR DESCRIPTION
Adds a new option to octodns-validate that validates records in lenient mode so that "all" validation issues can be shown. Reworks the command so that the exit code will still be non-success in the case where record validations were found, and `WARN`ed about rather than exceptions thrown.


### With no problems:

```console
(env) coho:octodns ross$ PYTHONPATH=. ./octodns/cmds/validate.py --config-file=config/dev.yaml --all && echo true || echo false
true
```

### With validation issues:

```console
(env) coho:octodns ross$ PYTHONPATH=. ./octodns/cmds/validate.py --config-file=config/dev.yaml --all && echo true || echo false
2023-08-04T16:02:17  [4575636992] WARNING Record Invalid record "cname.exxampled.com.", ./config/exxampled.com.yaml, line 14, column 3
  - CNAME value "foo.bar" missing trailing .
2023-08-04T16:02:17  [4575636992] WARNING Record Invalid record "other.exxampled.com.", ./config/exxampled.com.yaml, line 17, column 3
  - CNAME value "bar.baz" missing trailing .
2023-08-04T16:02:17  [4575636992] WARNING Record Invalid record "delegated.subdomain.exxampled.com.", ./config/subdomain.exxampled.com.yaml, line 2, column 3
  - NS value "ns1.example.org" missing trailing .
false
```

Primary configuration issues will still except on the first problem encountered, without any record validation happening, but it wouldn't make sense to continue with those sorts of problems since the overall setup is not valid.

This builds on top of https://github.com/octodns/octodns/pull/1029 mostly b/c that's where the idea was raised. 

/cc https://github.com/octodns/octodns/issues/1027 https://github.com/octodns/octodns/pull/1029 @joschi36 for the source of the exploration
/cc @fjaeckel who might find this useful if/when it lands