### PR TITLE
Archive code coverage data

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,8 +29,11 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: code-coverage
-          path: .coverage
+          name: code-coverage-${{ matrix.python-version }}
+          path: |
+            .coverage
+            coverage.xml
+            htmlcov
   setup-py:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,11 @@ jobs:
       - name: CI Build
         run: |
           ./script/cibuild
+      - name: Storage Code Coverage Data
+        uses: actions/upload-artifact@v3
+        with:
+          name: code-coverage
+          path: .coverage
   setup-py:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,9 @@ jobs:
       - name: CI Build
         run: |
           ./script/cibuild
-      - name: Storage Code Coverage Data
+      - name: Store Code Coverage Data
+        # if the previous step(s) failed try anyways
+        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: code-coverage


### PR DESCRIPTION
Bringing context over from #1045 

OK this works. Tries to create the articfact regardless of whether previous steps succeeded or failed so any time things fail tests etc it'll also fail this since no coverage will have been created, but that seems fine.

<img width="1081" alt="Screen Shot 2023-08-17 at 12 43 46 PM" src="https://github.com/octodns/octodns/assets/12789/5b7b15b1-ad29-4b37-9432-02b737fdc04a">

There's more we could do with archiving, e.g. upload the dists built in setup-py etc, but this solves the immediate need and we can add those things if/when they're required.

/cc Replaces https://github.com/octodns/octodns/pull/1045 which seems to be in a busted state