### PR TITLE
YamlProvider support for shared file, loaded into all zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
   possible. This includes the ability to split some zones and not others and
   even to have partially split zones with some records in the primary zone YAML
   and others in a split directory. See YamlProvider documentation for more info.
+* YamlProvider now supports a `shared_filename` that can be used to add a set of
+  common records across all zones using the provider. It can be used stand-alone
+  or in combination with zone files and/or split configs to aid in DRYing up DNS
+  configs.
 
 #### Stuff
 

--- a/octodns/provider/yaml.py
+++ b/octodns/provider/yaml.py
@@ -57,6 +57,11 @@ class YamlProvider(BaseProvider):
         # (optional, default False)
         split_catchall: false
 
+        # Optional filename with record data to be included in all zones
+        # populated by this provider. Has no effect when used as a target.
+        # (optional, default null)
+        shared_filename: null
+
         # Disable loading of the zone .yaml files.
         # (optional, default False)
         disable_zonefile: false
@@ -171,6 +176,7 @@ class YamlProvider(BaseProvider):
         supports_root_ns=True,
         split_extension=False,
         split_catchall=False,
+        shared_filename=False,
         disable_zonefile=False,
         *args,
         **kwargs,
@@ -178,7 +184,7 @@ class YamlProvider(BaseProvider):
         klass = self.__class__.__name__
         self.log = logging.getLogger(f'{klass}[{id}]')
         self.log.debug(
-            '__init__: id=%s, directory=%s, default_ttl=%d, enforce_order=%d, populate_should_replace=%s, supports_root_ns=%s, split_extension=%s, split_catchall=%s, disable_zonefile=%s',
+            '__init__: id=%s, directory=%s, default_ttl=%d, enforce_order=%d, populate_should_replace=%s, supports_root_ns=%s, split_extension=%s, split_catchall=%s, shared_filename=%s, disable_zonefile=%s',
             id,
             directory,
             default_ttl,
@@ -187,6 +193,7 @@ class YamlProvider(BaseProvider):
             supports_root_ns,
             split_extension,
             split_catchall,
+            shared_filename,
             disable_zonefile,
         )
         super().__init__(id, *args, **kwargs)
@@ -197,6 +204,7 @@ class YamlProvider(BaseProvider):
         self.supports_root_ns = supports_root_ns
         self.split_extension = split_extension
         self.split_catchall = split_catchall
+        self.shared_filename = shared_filename
         self.disable_zonefile = disable_zonefile
 
     def copy(self):
@@ -333,6 +341,9 @@ class YamlProvider(BaseProvider):
 
         if not self.disable_zonefile:
             sources.append(self._zone_sources(zone))
+
+        if self.shared_filename:
+            sources.append(join(self.directory, self.shared_filename))
 
         # determinstically order our sources
         sources.sort()

--- a/tests/config/split/shared.yaml
+++ b/tests/config/split/shared.yaml
@@ -1,0 +1,4 @@
+---
+only-shared:
+  type: TXT
+  value: Only included when shared file processing is enabled

--- a/tests/config/split/unit.tests.yaml
+++ b/tests/config/split/unit.tests.yaml
@@ -2,4 +2,3 @@
 only-zone-file:
   type: TXT
   value: Only included when zone file processing is enabled
-

--- a/tests/test_octodns_provider_yaml.py
+++ b/tests/test_octodns_provider_yaml.py
@@ -511,6 +511,23 @@ class TestSplitYamlProvider(TestCase):
         self.assertEqual(1, n)
         source.disable_zonefile = True
 
+        # temporarily enable shared file processing, we should see one extra
+        # record in the zone
+        source.shared_filename = 'shared.yaml'
+        zone_shared = Zone('unit.tests.', [])
+        source.populate(zone_shared)
+        self.assertEqual(21, len(zone_shared.records))
+        n = len([r for r in zone_shared.records if r.name == 'only-shared'])
+        self.assertEqual(1, n)
+        dynamic_zone_shared = Zone('dynamic.tests.', [])
+        source.populate(dynamic_zone_shared)
+        self.assertEqual(6, len(dynamic_zone_shared.records))
+        n = len(
+            [r for r in dynamic_zone_shared.records if r.name == 'only-shared']
+        )
+        self.assertEqual(1, n)
+        source.shared_filename = None
+
         source.populate(dynamic_zone)
         self.assertEqual(5, len(dynamic_zone.records))
         self.assertFalse(


### PR DESCRIPTION
Add support for a "shared" yaml file in YamlProvider that is loaded for all zones using the provider. There's three main use cases I can imagine:

### Common records across all zones

This would be useful if there's a shared record(s) that should be present in all/many zones as was described in https://github.com/octodns/octodns/issues/962. 

In this case the provider config would likely look something like:

```yaml
  config:
        class: octodns.provider.yaml.YamlProvider
        directory: ./config
        shared_filename: shared.yaml
```

Records for all zones would then be placed in `./config/shared.yaml` and individual zone files with the records specific to the zones would live in `./config/something.com.yaml`.  This route may even be preferable when there are no specific zones since it would allow dynamic zone config.

### Many identical zones

All of the zones configured have exactly the same records.

```yaml
  config:
        class: octodns.provider.yaml.YamlProvider
        directory: ./config
        shared_filename: shared.yaml
        disable_zonefile: true
```

Only `./config/shared.yaml` would exist and all of the zone data would come from it. The list of zones would be explicitly configured in the main octoDNS config file.

### Combination

There's some shared records across some, but not all zones.

```yaml
  config:
        class: octodns.provider.yaml.YamlProvider
        directory: ./config
  common:
        class: octodns.provider.yaml.YamlProvider
        directory: ./config
        shared_filename: shared.yaml
        disable_zonefile: true
```

Zones with only the shared records can list `common` as their sole source. Zones with only specific records can use `config`. Finallyzones with both can list `common` and `config` as their sources. Overriding behaviors could even by achieved with the careful use of `populate_should_replace` and ordering of the sources.

P.S. the fact that this is not a 2-5 line PR shows why the refactoring was best done first :grin:

/cc https://github.com/octodns/octodns/pull/1044 which preceeds this work/change
/cc Fixes https://github.com/octodns/octodns/issues/962 @felixoi 