### PR TITLE
Record's carry context, Zone exceptions make use of it to help with error messages

### DIFF
--- a/tests/test_octodns_provider_yaml.py
+++ b/tests/test_octodns_provider_yaml.py
@@ -260,10 +260,13 @@ xn--dj-kia8a:
         zone = Zone('unit.tests.', ['sub'])
         with self.assertRaises(SubzoneRecordException) as ctx:
             source.populate(zone)
-        self.assertEqual(
-            'Record www.sub.unit.tests. is under a managed subzone',
-            str(ctx.exception),
+        msg = str(ctx.exception)
+        self.assertTrue(
+            msg.startswith(
+                'Record www.sub.unit.tests. is under a managed subzone'
+            )
         )
+        self.assertTrue(msg.endswith('unit.tests.yaml, line 201, column 3'))
 
     def test_SUPPORTS(self):
         source = YamlProvider('test', join(dirname(__file__), 'config'))
@@ -536,10 +539,13 @@ class TestSplitYamlProvider(TestCase):
         zone = Zone('unit.tests.', ['sub'])
         with self.assertRaises(SubzoneRecordException) as ctx:
             source.populate(zone)
-        self.assertEqual(
-            'Record www.sub.unit.tests. is under a managed subzone',
-            str(ctx.exception),
+        msg = str(ctx.exception)
+        self.assertTrue(
+            msg.startswith(
+                'Record www.sub.unit.tests. is under a managed subzone'
+            )
         )
+        self.assertTrue(msg.endswith('www.sub.yaml, line 3, column 3'))
 
     def test_copy(self):
         # going to put some sentinal values in here to ensure, these aren't

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -628,3 +628,13 @@ class TestRecordValidation(TestCase):
                 ContextDict({'ttl': 42, 'value': '1.2.3.4'}, context='needle'),
             )
         self.assertTrue('needle' in str(ctx.exception))
+
+    def test_context_copied_to_record(self):
+        record = Record.new(
+            self.zone,
+            'www',
+            ContextDict(
+                {'ttl': 42, 'type': 'A', 'value': '1.2.3.4'}, context='needle'
+            ),
+        )
+        self.assertEqual('needle', record.context)


### PR DESCRIPTION
As a follow on to https://github.com/octodns/octodns/pull/1029 this PR extends the error messages w/more context to Zone based exceptions, e.g.:

```console
octodns.zone.DuplicateRecordException: Duplicate record relative.exxampled.com., type CNAME
  existing: ./config/exxampled.com.yaml, line 30, column 3
  new:      ./config/exxampled.com.yaml, line 30, column 3
...
octodns.zone.SubzoneRecordException: Record foo.both.exxampled.com. is under a managed subzone, ./config/exxampled.com.yaml, line 30, column 3
...
octodns.zone.InvalidNodeException: Invalid state, CNAME at relative.exxampled.com. cannot coexist with other records, ./config/exxampled.com.yaml, line 32, column 5
```

It also extends the general testing of the context bits into a few places that were missing it. 