### PR TITLE
Fix typo when loading auto-arpa config

### DIFF
--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -129,7 +129,7 @@ class Manager(object):
             self.log.info(
                 '__init__: adding auto-arpa to processors and providers, prepending it to global_post_processors list'
             )
-            kwargs = self.auto_arpa if isinstance(auto_arpa, dict) else {}
+            kwargs = self.auto_arpa if isinstance(self.auto_arpa, dict) else {}
             auto_arpa = AutoArpa('auto-arpa', **kwargs)
             self.providers[auto_arpa.name] = auto_arpa
             self.processors[auto_arpa.name] = auto_arpa

--- a/tests/config/simple-arpa.yaml
+++ b/tests/config/simple-arpa.yaml
@@ -1,6 +1,7 @@
 manager:
   max_workers: 2
   auto_arpa:
+    populate_should_replace: True
     ttl: 1800
 
 providers:

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -928,6 +928,18 @@ class TestManager(TestCase):
     def test_auto_arpa(self):
         manager = Manager(get_config_filename('simple-arpa.yaml'))
 
+        # provider config
+        self.assertEqual(
+            True, manager.providers.get("auto-arpa").populate_should_replace
+        )
+        self.assertEqual(1800, manager.providers.get("auto-arpa").ttl)
+
+        # processor config
+        self.assertEqual(
+            True, manager.processors.get("auto-arpa").populate_should_replace
+        )
+        self.assertEqual(1800, manager.processors.get("auto-arpa").ttl)
+
         with TemporaryDirectory() as tmpdir:
             environ['YAML_TMP_DIR'] = tmpdir.dirname
 


### PR DESCRIPTION
Resolved a typo that prevented the auto-arpa configuration options from loading.