### PR TITLE
v1.1.1 version bump and changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.1.0 - 2023-09-16 - Doh! Fix that one little thing
+## v1.1.1 - 2023-09-16 - Doh! Fix that one little thing
 
 * Address a bug in the handling of loading auto-arpa manager configuration.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.1.0 - 2023-09-16 - Doh! Fix that one little thing
+
+* Address a bug in the handling of loading auto-arpa manager configuration.
+
 ## v1.1.0 - 2023-09-13 - More than enough for a minor release
 
 #### Noteworthy changes

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -1,3 +1,3 @@
 'OctoDNS: DNS as code - Tools for managing DNS across multiple providers'
 
-__VERSION__ = '1.1.0'
+__VERSION__ = '1.1.1'


### PR DESCRIPTION
## v1.1.1 - 2023-09-16 - Doh! Fix that one little thing

* Address a bug in the handling of loading auto-arpa manager configuration.