### PR TITLE
Update script/release to do clean room dist builds

### DIFF
--- a/script/release
+++ b/script/release
@@ -37,7 +37,16 @@ VERSION="$(grep "^__VERSION__" "$ROOT/octodns/__init__.py" | sed -e "s/.* = '//"
 git tag -s "v$VERSION" -m "Release $VERSION"
 git push origin "v$VERSION"
 echo "Tagged and pushed v$VERSION"
-python -m build --sdist --wheel
+
+TMP_DIR=$(mktemp -d -t ci-XXXXXXXXXX)
+git archive --format tar v1.2.0 | tar xv -C $TMP_DIR
+echo "Created clean room $TMP_DIR and archived $VERSION into it"
+
+(cd "$TMP_DIR" && python -m build --sdist --wheel)
+
+cp $TMP_DIR/dist/*$VERSION.tar.gz $TMP_DIR/dist/*$VERSION*.whl dist/
+echo "Copied $TMP_DIR/dists into ./dist"
+
 twine check dist/*$VERSION.tar.gz dist/*$VERSION*.whl
 twine upload dist/*$VERSION.tar.gz dist/*$VERSION*.whl
 echo "Uploaded $VERSION"

--- a/script/release
+++ b/script/release
@@ -39,7 +39,7 @@ git push origin "v$VERSION"
 echo "Tagged and pushed v$VERSION"
 
 TMP_DIR=$(mktemp -d -t ci-XXXXXXXXXX)
-git archive --format tar v1.2.0 | tar xv -C $TMP_DIR
+git archive --format tar "v$VERSION" | tar xv -C $TMP_DIR
 echo "Created clean room $TMP_DIR and archived $VERSION into it"
 
 (cd "$TMP_DIR" && python -m build --sdist --wheel)


### PR DESCRIPTION
Use `git archive` to create a clean checkout of the release tag before building dists to ensure that what was tagged is exactly what is released and no extra/stale files or local modifications get included.

This will need to be ported into all the providers' script/release scripts as well.

/cc Fixes https://github.com/octodns/octodns/issues/1075 @hanazuki 