### PR TITLE
v1.2.1 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.2.1 - 2023-09-29 - Now with fewer stale files
+
+* Update script/release to do clean room dist builds
+
 ## v1.2.0 - 2023-09-28 - Bunch more bug fixes
 
 * Record.from_rrs supports `source` parameter

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -1,3 +1,3 @@
 'OctoDNS: DNS as code - Tools for managing DNS across multiple providers'
 
-__VERSION__ = '1.2.0'
+__VERSION__ = '1.2.1'


### PR DESCRIPTION
## v1.2.1 - 2023-09-29 - Now with fewer stale files

* Update script/release to do clean room dist builds

/cc https://github.com/octodns/octodns/issues/1075