### PR TITLE
CI pulls python versions from org secret

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         # Tested versions based on dates in https://devguide.python.org/versions/#versions
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: [${{fromJson(secrets.PYTHON_VERSIONS_ACTIVE)}}]
     steps:
       - uses: actions/checkout@v2
       - name: Setup python

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         # Tested versions based on dates in https://devguide.python.org/versions/#versions
-        python-version: [${{fromJson(secrets.PYTHON_VERSIONS_ACTIVE)}}]
+        python-version: ${{fromJson(secrets.PYTHON_VERSIONS_ACTIVE)}}
     steps:
       - uses: actions/checkout@v2
       - name: Setup python

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.11'
+          python-version: ${{ vars.PYTHON_VERSION_CURRENT }}
           architecture: x64
       - name: CI setup.py
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         # Tested versions based on dates in https://devguide.python.org/versions/#versions
-        python-version: ${{fromJson(secrets.PYTHON_VERSIONS_ACTIVE)}}
+        python-version: ${{fromJson(env.PYTHON_VERSIONS_ACTIVE)}}
     steps:
       - uses: actions/checkout@v2
       - name: Setup python

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,9 @@ jobs:
         # https://devguide.python.org/versions/#versions
         python-version: ${{fromJson(vars.PYTHON_VERSIONS_ACTIVE)}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Defined in an org level variable, based on dates in
+        # https://devguide.python.org/versions/#versions
         python-version: ${{fromJson(vars.PYTHON_VERSIONS_ACTIVE)}}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Tested versions based on dates in https://devguide.python.org/versions/#versions
-        python-version: ${{fromJson(env.PYTHON_VERSIONS_ACTIVE)}}
+        python-version: ${{fromJson(vars.PYTHON_VERSIONS_ACTIVE)}}
     steps:
       - uses: actions/checkout@v2
       - name: Setup python

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -42,9 +42,9 @@ jobs:
           # some point in the future and either re-enable or delete it.
           #- sukiyaki/octodns-netbox
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Setup python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ vars.PYTHON_VERSION_CURRENT }}
           architecture: x64

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -46,11 +46,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v1
         with:
-          # This should generally be the latest stable release of python, but
-          # dyn and ovh don't currently support changes made in 3.10 so we'll
-          # leave it 3.9 for now. Once 3.11 lands though we'll bump to it and
-          # if they haven't updated they'll be removed from the matrix
-          python-version: '3.9'
+          python-version: ${{ vars.PYTHON_VERSION_CURRENT }}
           architecture: x64
       - name: Test Module
         run: |

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v8
         with:
           stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
           days-before-stale: 90


### PR DESCRIPTION
In order to change the versions we build against going forward it'll just be a matter of changing the ORG-level variable `PYTHON_VERSIONS_ACTIVE`. All of the repos that work with the current/up-to-date version list will be pointed at that with PRs similar to this one. 

For the couple of repos that need custom versions we can just leave the versions hard coded into the workflow file until if/when they're back in sync.

/cc @octodns/review as an FYI 