### PR TITLE
ZoneNameFilter processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.3.0 - 2023-??-?? - ???
+
+* Added ZoneNameFilter processor to enable ignoring/alerting on type-os like
+  octodns.com.octodns.com
+
 ## v1.2.1 - 2023-09-29 - Now with fewer stale files
 
 * Update script/release to do clean room dist builds

--- a/octodns/processor/filter.py
+++ b/octodns/processor/filter.py
@@ -7,7 +7,41 @@ from re import compile as re_compile
 from .base import BaseProcessor
 
 
-class TypeAllowlistFilter(BaseProcessor):
+class AllowsMixin:
+    def matches(self, zone, record):
+        pass
+
+    def doesnt_match(self, zone, record):
+        zone.remove_record(record)
+
+
+class RejectsMixin:
+    def matches(self, zone, record):
+        zone.remove_record(record)
+
+    def doesnt_match(self, zone, record):
+        pass
+
+
+class _TypeBaseFilter(BaseProcessor):
+    def __init__(self, name, _list):
+        super().__init__(name)
+        self._list = set(_list)
+
+    def _process(self, zone, *args, **kwargs):
+        for record in zone.records:
+            if record._type in self._list:
+                self.matches(zone, record)
+            else:
+                self.doesnt_match(zone, record)
+
+        return zone
+
+    process_source_zone = _process
+    process_target_zone = _process
+
+
+class TypeAllowlistFilter(_TypeBaseFilter, AllowsMixin):
     '''Only manage records of the specified type(s).
 
     Example usage:
@@ -30,21 +64,10 @@ class TypeAllowlistFilter(BaseProcessor):
     '''
 
     def __init__(self, name, allowlist):
-        super().__init__(name)
-        self.allowlist = set(allowlist)
-
-    def _process(self, zone, *args, **kwargs):
-        for record in zone.records:
-            if record._type not in self.allowlist:
-                zone.remove_record(record)
-
-        return zone
-
-    process_source_zone = _process
-    process_target_zone = _process
+        super().__init__(name, allowlist)
 
 
-class TypeRejectlistFilter(BaseProcessor):
+class TypeRejectlistFilter(_TypeBaseFilter, RejectsMixin):
     '''Ignore records of the specified type(s).
 
     Example usage:
@@ -66,18 +89,7 @@ class TypeRejectlistFilter(BaseProcessor):
     '''
 
     def __init__(self, name, rejectlist):
-        super().__init__(name)
-        self.rejectlist = set(rejectlist)
-
-    def _process(self, zone, *args, **kwargs):
-        for record in zone.records:
-            if record._type in self.rejectlist:
-                zone.remove_record(record)
-
-        return zone
-
-    process_source_zone = _process
-    process_target_zone = _process
+        super().__init__(name, rejectlist)
 
 
 class _NameBaseFilter(BaseProcessor):
@@ -93,8 +105,25 @@ class _NameBaseFilter(BaseProcessor):
         self.exact = exact
         self.regex = regex
 
+    def _process(self, zone, *args, **kwargs):
+        for record in zone.records:
+            name = record.name
+            if name in self.exact:
+                self.matches(zone, record)
+                continue
+            elif any(r.search(name) for r in self.regex):
+                self.matches(zone, record)
+                continue
 
-class NameAllowlistFilter(_NameBaseFilter):
+            self.doesnt_match(zone, record)
+
+        return zone
+
+    process_source_zone = _process
+    process_target_zone = _process
+
+
+class NameAllowlistFilter(_NameBaseFilter, AllowsMixin):
     '''Only manage records with names that match the provider patterns
 
     Example usage:
@@ -125,23 +154,8 @@ class NameAllowlistFilter(_NameBaseFilter):
     def __init__(self, name, allowlist):
         super().__init__(name, allowlist)
 
-    def _process(self, zone, *args, **kwargs):
-        for record in zone.records:
-            name = record.name
-            if name in self.exact:
-                continue
-            elif any(r.search(name) for r in self.regex):
-                continue
 
-            zone.remove_record(record)
-
-        return zone
-
-    process_source_zone = _process
-    process_target_zone = _process
-
-
-class NameRejectlistFilter(_NameBaseFilter):
+class NameRejectlistFilter(_NameBaseFilter, RejectsMixin):
     '''Reject managing records with names that match the provider patterns
 
     Example usage:
@@ -171,23 +185,6 @@ class NameRejectlistFilter(_NameBaseFilter):
 
     def __init__(self, name, rejectlist):
         super().__init__(name, rejectlist)
-
-    def _process(self, zone, *args, **kwargs):
-        for record in zone.records:
-            name = record.name
-            if name in self.exact:
-                zone.remove_record(record)
-                continue
-
-            for regex in self.regex:
-                if regex.search(name):
-                    zone.remove_record(record)
-                    break
-
-        return zone
-
-    process_source_zone = _process
-    process_target_zone = _process
 
 
 class IgnoreRootNsFilter(BaseProcessor):

--- a/octodns/processor/filter.py
+++ b/octodns/processor/filter.py
@@ -228,7 +228,7 @@ class ZoneNameFilter(BaseProcessor):
         class: octodns.processor.filter.ZoneNameFilter
         # If true a ValidationError will be throw when such records are
         # encouterd, if false the records will just be ignored/omitted.
-        # (default: false)
+        # (default: true)
 
     zones:
       exxampled.com.:
@@ -240,7 +240,7 @@ class ZoneNameFilter(BaseProcessor):
           - azure
     '''
 
-    def __init__(self, name, error=False):
+    def __init__(self, name, error=True):
         super().__init__(name)
         self.error = error
 

--- a/tests/test_octodns_processor_filter.py
+++ b/tests/test_octodns_processor_filter.py
@@ -186,7 +186,7 @@ class TestIgnoreRootNsFilter(TestCase):
 
 class TestZoneNameFilter(TestCase):
     def test_ends_with_zone(self):
-        zone_name_filter = ZoneNameFilter('zone-name')
+        zone_name_filter = ZoneNameFilter('zone-name', error=False)
 
         zone = Zone('unit.tests.', [])
 


### PR DESCRIPTION

Helps avoid type-os where someone does:

```yaml
www.zone.name.:
  type: A
  value: 1.2.3.4
```

When they meant to define `www`. By default it throws a `ValidationError`, but can be configured to just ignore/omit them.

/cc Fixes https://github.com/octodns/octodns/issues/1080