### PR TITLE
Add Python 3.12 to the ci test matrix and make it the current version

### DIFF
--- a/.ci-config.json
+++ b/.ci-config.json
@@ -1,4 +1,4 @@
 {
-  "python_version_current": "3.11",
-  "python_versions_active": ["3.8", "3.9", "3.10", "3.11"]
+  "python_version_current": "3.12",
+  "python_versions_active": ["3.8", "3.9", "3.10", "3.11", "3.12"]
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -40,6 +40,8 @@ requests-toolbelt==1.0.0
 requests==2.31.0
 rfc3986==2.0.0
 rich==13.6.0
+setuptools==68.2.2
 twine==4.0.2
 urllib3==2.0.6
+wheel==0.41.2
 zipp==3.17.0

--- a/script/cibuild-setup-py
+++ b/script/cibuild-setup-py
@@ -7,6 +7,7 @@ echo "## create test venv ######################################################
 TMP_DIR=$(mktemp -d -t ci-XXXXXXXXXX)
 python3 -m venv $TMP_DIR
 . "$TMP_DIR/bin/activate"
+pip install setuptools
 echo "## environment & versions ######################################################"
 python --version
 pip --version


### PR DESCRIPTION
/cc https://github.com/octodns/octodns-docker/pull/97
/cc Replaces https://github.com/octodns/terraformed/pull/23