### PR TITLE
Update LICENSE details

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,6 @@
+MIT License
+
+Copyright (c) 2021 Ross McFarland & the octoDNS Maintainers
 Copyright (c) 2017 GitHub, Inc.
 
 Permission is hereby granted, free of charge, to any person


### PR DESCRIPTION
Note that it's MIT and add post GitHub copyright info.

/cc https://github.com/octodns/octodns-hetzner/issues/27