### PR TITLE
Fixed handling of chunking large TXT values for users of `rrs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Added ZoneNameFilter processor to enable ignoring/alerting on type-os like
   octodns.com.octodns.com
+* Fixed issues with handling of chunking large TXT values for providers that use
+  the in-built `rrs` method
 
 ## v1.2.1 - 2023-09-29 - Now with fewer stale files
 

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -312,13 +312,16 @@ class ValuesMixin(object):
 
         return ret
 
+    def rr_values(self):
+        return self.values
+
     @property
     def rrs(self):
         return (
             self.fqdn,
             self.ttl,
             self._type,
-            [v.rdata_text for v in self.values],
+            [v.rdata_text for v in self.rr_values()],
         )
 
     def __repr__(self):

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -312,6 +312,7 @@ class ValuesMixin(object):
 
         return ret
 
+    @property
     def rr_values(self):
         return self.values
 
@@ -321,7 +322,7 @@ class ValuesMixin(object):
             self.fqdn,
             self.ttl,
             self._type,
-            [v.rdata_text for v in self.rr_values()],
+            [v.rdata_text for v in self.rr_values],
         )
 
     def __repr__(self):

--- a/octodns/record/chunked.py
+++ b/octodns/record/chunked.py
@@ -18,7 +18,7 @@ class _ChunkedValuesMixin(ValuesMixin):
             for i in range(0, len(value), self.CHUNK_SIZE)
         ]
         vs = '" "'.join(vs)
-        return f'"{vs}"'
+        return self._value_type(f'"{vs}"')
 
     @property
     def chunked_values(self):

--- a/octodns/record/chunked.py
+++ b/octodns/record/chunked.py
@@ -27,6 +27,7 @@ class _ChunkedValuesMixin(ValuesMixin):
             values.append(self.chunked_value(v))
         return values
 
+    @property
     def rr_values(self):
         return self.chunked_values
 

--- a/octodns/record/chunked.py
+++ b/octodns/record/chunked.py
@@ -27,6 +27,9 @@ class _ChunkedValuesMixin(ValuesMixin):
             values.append(self.chunked_value(v))
         return values
 
+    def rr_values(self):
+        return self.chunked_values
+
 
 class _ChunkedValue(str):
     _unescaped_semicolon_re = re.compile(r'\w;')

--- a/tests/test_octodns_record_txt.py
+++ b/tests/test_octodns_record_txt.py
@@ -142,3 +142,39 @@ class TestRecordTxt(TestCase):
         self.assertEqual(single.values, chunked.values)
         # should be chunked values, with quoting
         self.assertEqual(single.chunked_values, chunked.chunked_values)
+
+    def test_rr(self):
+        zone = Zone('unit.tests.', [])
+
+        # simple TXT
+        record = Record.new(
+            zone,
+            'txt',
+            {'ttl': 42, 'type': 'TXT', 'values': ['short 1', 'short 2']},
+        )
+        self.assertEqual(
+            ('txt.unit.tests.', 42, 'TXT', ['"short 1"', '"short 2"']),
+            record.rrs,
+        )
+
+        # long chunked text
+        record = Record.new(
+            zone,
+            'txt',
+            {
+                'ttl': 42,
+                'type': 'TXT',
+                'values': [
+                    'before',
+                    'v=DKIM1\\; h=sha256\\; k=rsa\\; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAx78E7PtJvr8vpoNgHdIAe+llFKoy8WuTXDd6Z5mm3D4AUva9MBt5fFetxg/kcRy3KMDnMw6kDybwbpS/oPw1ylk6DL1xit7Cr5xeYYSWKukxXURAlHwT2K72oUsFKRUvN1X9lVysAeo+H8H/22Z9fJ0P30sOuRIRqCaiz+OiUYicxy4xrpfH2s9a+o3yRwX3zhlp8GjRmmmyK5mf7CkQTCfjnKVsYtB7mabXXmClH9tlcymnBMoN9PeXxaS5JRRysVV8RBCC9/wmfp9y//cck8nvE/MavFpSUHvv+TfTTdVKDlsXPjKX8iZQv0nO3xhspgkqFquKjydiR8nf4meHhwIDAQAB',
+                    'z after',
+                ],
+            },
+        )
+        vals = [
+            '"before"',
+            '"v=DKIM1\\; h=sha256\\; k=rsa\\; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAx78E7PtJvr8vpoNgHdIAe+llFKoy8WuTXDd6Z5mm3D4AUva9MBt5fFetxg/kcRy3KMDnMw6kDybwbpS/oPw1ylk6DL1xit7Cr5xeYYSWKukxXURAlHwT2K72oUsFKRUvN1X9lVysAeo+H8H/22Z9fJ0P30sOuRIRqCaiz+OiUYicxy4xrpfH" '
+            '"2s9a+o3yRwX3zhlp8GjRmmmyK5mf7CkQTCfjnKVsYtB7mabXXmClH9tlcymnBMoN9PeXxaS5JRRysVV8RBCC9/wmfp9y//cck8nvE/MavFpSUHvv+TfTTdVKDlsXPjKX8iZQv0nO3xhspgkqFquKjydiR8nf4meHhwIDAQAB"',
+            '"z after"',
+        ]
+        self.assertEqual(('txt.unit.tests.', 42, 'TXT', vals), record.rrs)


### PR DESCRIPTION
Fixed issues with handling of chunking large TXT values for providers that use the in-built `rrs` method

* `chunked_values` returns the type, not plain strings
* `ValuesMixin` adds support for getting special values when `rrs` is used, utilized by `_ChunkedValuesMixin`

/cc Fixes https://github.com/octodns/octodns/issues/1088 @paulgear @yzguy @binlan