### PR TITLE
ExcludeRootNsChanges processor that will error (or warn) if plan includes a   change to root NS records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
   octodns.com.octodns.com
 * Fixed issues with handling of chunking large TXT values for providers that use
   the in-built `rrs` method
+* ExcludeRootNsChanges processor that will error (or warn) if plan includes a
+  change to root NS records
 
 ## v1.2.1 - 2023-09-29 - Now with fewer stale files
 

--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Similar to providers, but can only serve to populate records into a zone, cannot
 |--|--|
 | [AcmeMangingProcessor](/octodns/processor/acme.py) | Useful when processes external to octoDNS are managing acme challenge DNS records, e.g. LetsEncrypt |
 | [AutoArpa](/octodns/processor/arpa.py) | See [Automatic PTR generation](#automatic-ptr-generation) below |
+| [ExcludeRootNsChanges](/octodns/processor/filter.py) | Filter that errors or warns on planned root/APEX NS records changes. |
 | [IgnoreRootNsFilter](/octodns/processor/filter.py) | Filter that INGORES root/APEX NS records and prevents octoDNS from trying to manage them (where supported.) |
 | [MetaProcessor](/octodns/processor/meta.py) | Adds a special meta record with timing, UUID, providers, and/or version to aid in debugging and monitoring. |
 | [NameAllowlistFilter](/octodns/processor/filter.py) | Filter that ONLY manages records that match specified naming patterns, all others will be ignored |


### PR DESCRIPTION
/cc https://github.com/octodns/octodns-route53/issues/75
/cc @lbrachet