### PR TITLE
Include octodns special section in record __repr__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   the in-built `rrs` method
 * ExcludeRootNsChanges processor that will error (or warn) if plan includes a
   change to root NS records
+* Include the octodns special section info in Record __repr__, makes it easier
+  to debug things with providers that have special functionality configured
+  there.
 
 ## v1.2.1 - 2023-09-29 - Now with fewer stale files
 

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -328,7 +328,10 @@ class ValuesMixin(object):
     def __repr__(self):
         values = "', '".join([str(v) for v in self.values])
         klass = self.__class__.__name__
-        return f"<{klass} {self._type} {self.ttl}, {self.decoded_fqdn}, ['{values}']>"
+        octodns = ''
+        if self._octodns:
+            octodns = f', {self._octodns}'
+        return f"<{klass} {self._type} {self.ttl}, {self.decoded_fqdn}, ['{values}']{octodns}>"
 
 
 class ValueMixin(object):
@@ -371,4 +374,7 @@ class ValueMixin(object):
 
     def __repr__(self):
         klass = self.__class__.__name__
-        return f'<{klass} {self._type} {self.ttl}, {self.decoded_fqdn}, {self.value}>'
+        octodns = ''
+        if self._octodns:
+            octodns = f', {self._octodns}'
+        return f'<{klass} {self._type} {self.ttl}, {self.decoded_fqdn}, {self.value}{octodns}>'

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -654,3 +654,51 @@ class TestRecordValidation(TestCase):
             ),
         )
         self.assertEqual('needle', record.context)
+
+    def test_values_mixin_repr(self):
+        # ValuesMixin
+        record = Record.new(
+            self.zone,
+            'www',
+            {
+                'ttl': 42,
+                'type': 'A',
+                'values': ['1.2.3.4', '2.3.4.5'],
+                'octodns': {'key': 'value'},
+            },
+        )
+        # has the octodns special section
+        self.assertEqual(
+            "<ARecord A 42, www.unit.tests., ['1.2.3.4', '2.3.4.5'], {'key': 'value'}>",
+            record.__repr__(),
+        )
+        # no special section
+        record._octodns = {}
+        self.assertEqual(
+            "<ARecord A 42, www.unit.tests., ['1.2.3.4', '2.3.4.5']>",
+            record.__repr__(),
+        )
+
+    def test_value_mixin_repr(self):
+        # ValueMixin
+        record = Record.new(
+            self.zone,
+            'pointer',
+            {
+                'ttl': 43,
+                'type': 'CNAME',
+                'value': 'unit.tests.',
+                'octodns': {'key': 42},
+            },
+        )
+        # has the octodns special section
+        self.assertEqual(
+            "<CnameRecord CNAME 43, pointer.unit.tests., unit.tests., {'key': 42}>",
+            record.__repr__(),
+        )
+        # no special section
+        record._octodns = {}
+        self.assertEqual(
+            '<CnameRecord CNAME 43, pointer.unit.tests., unit.tests.>',
+            record.__repr__(),
+        )


### PR DESCRIPTION
Before:

```
<ARecord A 42, www.unit.tests., ['1.2.3.4', '2.3.4.5']>
```

After: 

```
<ARecord A 42, www.unit.tests., ['1.2.3.4', '2.3.4.5'], {'key': 'value'}>
```




/cc https://github.com/octodns/octodns-cloudflare/pull/65 which lead me to add this to aid in debugging. 