### PR TITLE
Add include_target option to most processor.filter processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * Include the octodns special section info in Record __repr__, makes it easier
   to debug things with providers that have special functionality configured
   there.
+* Most processor.filter processors now support an include_target flag that can
+  be set to False to leave the target zone data untouched, thus remove any
+  existing filtered records. Default behavior is unchanged and filtered records
+  will be completely invisible to octoDNS
 
 ## v1.2.1 - 2023-09-29 - Now with fewer stale files
 

--- a/octodns/processor/filter.py
+++ b/octodns/processor/filter.py
@@ -65,6 +65,10 @@ class TypeAllowlistFilter(_TypeBaseFilter, AllowsMixin):
         allowlist:
           - A
           - AAAA
+        # Optional param that can be set to False to leave the target zone
+        # alone, thus allowing deletion of existing records
+        # (default: true)
+        # include_target: True
 
     zones:
       exxampled.com.:
@@ -90,6 +94,10 @@ class TypeRejectlistFilter(_TypeBaseFilter, RejectsMixin):
         class: octodns.processor.filter.TypeRejectlistFilter
         rejectlist:
           - CNAME
+        # Optional param that can be set to False to leave the target zone
+        # alone, thus allowing deletion of existing records
+        # (default: true)
+        # include_target: True
 
     zones:
       exxampled.com.:
@@ -150,6 +158,10 @@ class NameAllowlistFilter(_NameBaseFilter, AllowsMixin):
           - /some-pattern-\\d\\+/
           # regex - anchored so has to match start to end
           - /^start-.+-end$/
+        # Optional param that can be set to False to leave the target zone
+        # alone, thus allowing deletion of existing records
+        # (default: true)
+        # include_target: True
 
     zones:
       exxampled.com.:
@@ -182,6 +194,10 @@ class NameRejectlistFilter(_NameBaseFilter, RejectsMixin):
           - /some-pattern-\\d\\+/
           # regex - anchored so has to match start to end
           - /^start-.+-end$/
+        # Optional param that can be set to False to leave the target zone
+        # alone, thus allowing deletion of existing records
+        # (default: true)
+        # include_target: True
 
     zones:
       exxampled.com.:
@@ -288,6 +304,10 @@ class ZoneNameFilter(_FilterProcessor):
         # If true a ValidationError will be throw when such records are
         # encouterd, if false the records will just be ignored/omitted.
         # (default: true)
+        # Optional param that can be set to False to leave the target zone
+        # alone, thus allowing deletion of existing records
+        # (default: true)
+        # include_target: True
 
     zones:
       exxampled.com.:

--- a/tests/test_octodns_processor_filter.py
+++ b/tests/test_octodns_processor_filter.py
@@ -54,6 +54,22 @@ class TestTypeAllowListFilter(TestCase):
             ['a', 'a2', 'aaaa'], sorted([r.name for r in got.records])
         )
 
+    def test_include_target(self):
+        filter_txt = TypeAllowlistFilter(
+            'only-txt', ['TXT'], include_target=False
+        )
+
+        # as a source we don't see them
+        got = filter_txt.process_source_zone(zone.copy())
+        self.assertEqual(['txt', 'txt2'], sorted([r.name for r in got.records]))
+
+        # but as a target we do b/c it's not included
+        got = filter_txt.process_target_zone(zone.copy())
+        self.assertEqual(
+            ['a', 'a2', 'aaaa', 'txt', 'txt2'],
+            sorted([r.name for r in got.records]),
+        )
+
 
 class TestTypeRejectListFilter(TestCase):
     def test_basics(self):


### PR DESCRIPTION
Most processor.filter processors now support an include_target flag that can be set to False to leave the target zone data untouched, thus remove any existing filtered records. Default behavior is unchanged and filtered records will be completely invisible to octoDNS

/cc https://github.com/octodns/octodns/pull/1094#issuecomment-1806595582 which spawned the idea