### PR TITLE
Simplify versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   of a standard, per pep-8. __VERSION__ is deprecated and will go away in 2.x
 * Fixed issues with handling of chunking large TXT values for providers that use
   the in-built `rrs` method
+* Removed code that included sha in module version number when installing from
+  repo a it caused problems with non-binary installs.
 
 #### Stuff
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Fixed issues with handling of chunking large TXT values for providers that use
   the in-built `rrs` method
 * Removed code that included sha in module version number when installing from
-  repo a it caused problems with non-binary installs.
+  repo as it caused problems with non-binary installs.
 
 #### Stuff
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 ## v1.3.0 - 2023-??-?? - ???
 
-* Added ZoneNameFilter processor to enable ignoring/alerting on type-os like
-  octodns.com.octodns.com
+#### Noteworthy changes
+
+* Added octodns.__version__ to replace octodns.__VERSION__ as the former is more
+  of a standard, per pep-8. __VERSION__ is deprecated and will go away in 2.x
 * Fixed issues with handling of chunking large TXT values for providers that use
   the in-built `rrs` method
+
+#### Stuff
+
+* Added ZoneNameFilter processor to enable ignoring/alerting on type-os like
+  octodns.com.octodns.com
 * ExcludeRootNsChanges processor that will error (or warn) if plan includes a
   change to root NS records
 * Include the octodns special section info in Record __repr__, makes it easier

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -1,3 +1,4 @@
 'OctoDNS: DNS as code - Tools for managing DNS across multiple providers'
 
-__VERSION__ = '1.2.1'
+# TODO: remove __VERSION__ w/2.x
+__version__ = __VERSION__ = '1.2.1'

--- a/setup.py
+++ b/setup.py
@@ -47,10 +47,6 @@ def long_description():
     return buf.getvalue()
 
 
-def version():
-    return octodns.__VERSION__
-
-
 tests_require = ('pytest>=6.2.5', 'pytest-cov>=3.0.0', 'pytest-network>=0.0.1')
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
 from io import StringIO
-from os import environ
 from os.path import dirname, join
-from subprocess import CalledProcessError, check_output
 
 import octodns
 
@@ -50,16 +48,7 @@ def long_description():
 
 
 def version():
-    # pep440 style public & local version numbers
-    if environ.get('OCTODNS_RELEASE', False):
-        # public
-        return octodns.__VERSION__
-    try:
-        sha = check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8')[:8]
-    except (CalledProcessError, FileNotFoundError):
-        sha = 'unknown'
-    # local
-    return f'{octodns.__VERSION__}+{sha}'
+    return octodns.__VERSION__
 
 
 tests_require = ('pytest>=6.2.5', 'pytest-cov>=3.0.0', 'pytest-network>=0.0.1')
@@ -102,5 +91,5 @@ setup(
     python_requires='>=3.8',
     tests_require=tests_require,
     url='https://github.com/octodns/octodns',
-    version=version(),
+    version=octodns.__version__,
 )


### PR DESCRIPTION
setup.py had non-trivial logic in it to try and stick a portion of the commit SHA onto the end of the version number when things were installed from the repo. This was fragile and had issues in cases like https://github.com/octodns/octodns/issues/1096 so this PR drops that logic and just uses the current version number. 

It also add `__version__` which in my research/testing for https://github.com/octodns/octodns/issues/1096 I ran into as being a (more) standard/recommended name for the version, per pep8.

/cc https://peps.python.org/pep-0008/#module-level-dunder-names which mentions __version__
/cc Fixes https://github.com/octodns/octodns/issues/1096 @viranch 