### PR TITLE
v1.3.0 bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 #### Noteworthy changes
 
-* Added octodns.__version__ to replace octodns.__VERSION__ as the former is more
-  of a standard, per pep-8. __VERSION__ is deprecated and will go away in 2.x
+* Added `octodns.__version__` to replace `octodns.__VERSION__` as the former is
+  more of a standard, per pep-8. `__VERSION__` is deprecated and will go away
+  in 2.x
 * Fixed issues with handling of chunking large TXT values for providers that use
   the in-built `rrs` method
 * Removed code that included sha in module version number when installing from
@@ -20,7 +21,7 @@
   horizon)
 * ExcludeRootNsChanges processor that will error (or warn) if plan includes a
   change to root NS records
-* Include the octodns special section info in Record __repr__, makes it easier
+* Include the octodns special section info in `Record.__repr__`, makes it easier
   to debug things with providers that have special functionality configured
   there.
 * Most processor.filter processors now support an include_target flag that can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.3.0 - 2023-??-?? - ???
+## v1.3.0 - 2023-11-14 - New and improved processors
 
 #### Noteworthy changes
 

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -1,4 +1,4 @@
 'OctoDNS: DNS as code - Tools for managing DNS across multiple providers'
 
 # TODO: remove __VERSION__ w/2.x
-__version__ = __VERSION__ = '1.2.1'
+__version__ = __VERSION__ = '1.3.0'


### PR DESCRIPTION
## v1.3.0 - 2023-11-14 - New and improved processors

#### Noteworthy changes

* Added `octodns.__version__` to replace `octodns.__VERSION__` as the former is more
  of a standard, per pep-8. `__VERSION__` is deprecated and will go away in 2.x
* Fixed issues with handling of chunking large TXT values for providers that use
  the in-built `rrs` method
* Removed code that included sha in module version number when installing from
  repo as it caused problems with non-binary installs.

#### Stuff

* Added ZoneNameFilter processor to enable ignoring/alerting on type-os like
  octodns.com.octodns.com
* NetworkValueAllowlistFilter/NetworkValueRejectlistFilter added to
  processors.filter to enable filtering A/AAAA records based on value. Can be
  useful if you have records with non-routable values in an internal copy of a
  zone, but want to exclude them when pushing the same zone publically (split
  horizon)
* ExcludeRootNsChanges processor that will error (or warn) if plan includes a
  change to root NS records
* Include the octodns special section info in Record __repr__, makes it easier
  to debug things with providers that have special functionality configured
  there.
* Most processor.filter processors now support an include_target flag that can
  be set to False to leave the target zone data untouched, thus remove any
  existing filtered records. Default behavior is unchanged and filtered records
  will be completely invisible to octoDNS
