### PR TITLE
deprecation.deprecated, use official mechinism for deprecations

### DIFF
--- a/octodns/deprecation.py
+++ b/octodns/deprecation.py
@@ -1,0 +1,9 @@
+#
+#
+#
+
+from warnings import warn
+
+
+def deprecated(message, stacklevel=2):
+    warn(message, DeprecationWarning, stacklevel=stacklevel)

--- a/octodns/processor/spf.py
+++ b/octodns/processor/spf.py
@@ -10,6 +10,7 @@ from dns.resolver import Answer
 
 from octodns.record.base import Record
 
+from ..deprecation import deprecated
 from .base import BaseProcessor, ProcessorException
 
 
@@ -55,7 +56,7 @@ class SpfDnsLookupProcessor(BaseProcessor):
 
     def __init__(self, name):
         self.log.debug(f"SpfDnsLookupProcessor: {name}")
-        self.log.warning(
+        deprecated(
             'SpfDnsLookupProcessor is DEPRECATED in favor of the version relocated into octodns-spf and will be removed in 2.0'
         )
         super().__init__(name)

--- a/octodns/processor/spf.py
+++ b/octodns/processor/spf.py
@@ -57,7 +57,8 @@ class SpfDnsLookupProcessor(BaseProcessor):
     def __init__(self, name):
         self.log.debug(f"SpfDnsLookupProcessor: {name}")
         deprecated(
-            'SpfDnsLookupProcessor is DEPRECATED in favor of the version relocated into octodns-spf and will be removed in 2.0'
+            'SpfDnsLookupProcessor is DEPRECATED in favor of the version relocated into octodns-spf and will be removed in 2.0',
+            stacklevel=99,
         )
         super().__init__(name)
 

--- a/octodns/provider/yaml.py
+++ b/octodns/provider/yaml.py
@@ -468,5 +468,6 @@ class SplitYamlProvider(YamlProvider):
         )
         super().__init__(id, directory, *args, **kwargs)
         deprecated(
-            'SplitYamlProvider is DEPRECATED, use YamlProvider with split_extension, split_catchall, and disable_zonefile instead, will go away in v2.0'
+            'SplitYamlProvider is DEPRECATED, use YamlProvider with split_extension, split_catchall, and disable_zonefile instead, will go away in v2.0',
+            stacklevel=99,
         )

--- a/octodns/provider/yaml.py
+++ b/octodns/provider/yaml.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from os import listdir, makedirs
 from os.path import isdir, isfile, join
 
+from ..deprecation import deprecated
 from ..record import Record
 from ..yaml import safe_dump, safe_load
 from . import ProviderException
@@ -466,6 +467,6 @@ class SplitYamlProvider(YamlProvider):
             }
         )
         super().__init__(id, directory, *args, **kwargs)
-        self.log.warning(
-            '__init__: DEPRECATED use YamlProvider with split_extension, split_catchall, and disable_zonefile instead, will go away in v2.0'
+        deprecated(
+            'SplitYamlProvider is DEPRECATED, use YamlProvider with split_extension, split_catchall, and disable_zonefile instead, will go away in v2.0'
         )

--- a/octodns/record/ds.py
+++ b/octodns/record/ds.py
@@ -50,7 +50,8 @@ class DsValue(EqualityTupleMixin, dict):
             # A DS record without public_key doesn't make any sense and shouldn't have validated previously
             if "public_key" in value or "flags" in value:
                 deprecated(
-                    'DS properties "algorithm", "flags", "public_key", and "protocol" support is DEPRECATED and will be removed in 2.0'
+                    'DS properties "algorithm", "flags", "public_key", and "protocol" support is DEPRECATED and will be removed in 2.0',
+                    stacklevel=99,
                 )
                 try:
                     int(value['flags'])

--- a/octodns/record/ds.py
+++ b/octodns/record/ds.py
@@ -4,6 +4,7 @@
 
 from logging import getLogger
 
+from ..deprecation import deprecated
 from ..equality import EqualityTupleMixin
 from .base import Record, ValuesMixin
 from .rr import RrParseError
@@ -48,8 +49,8 @@ class DsValue(EqualityTupleMixin, dict):
             # it is safe to assume if public_key or flags are defined then it is "old" style
             # A DS record without public_key doesn't make any sense and shouldn't have validated previously
             if "public_key" in value or "flags" in value:
-                cls.log.warning(
-                    '"algorithm", "flags", "public_key", and "protocol" support is DEPRECATED and will be removed in 2.0'
+                deprecated(
+                    'DS properties "algorithm", "flags", "public_key", and "protocol" support is DEPRECATED and will be removed in 2.0'
                 )
                 try:
                     int(value['flags'])

--- a/octodns/record/geo.py
+++ b/octodns/record/geo.py
@@ -5,6 +5,7 @@
 import re
 from logging import getLogger
 
+from ..deprecation import deprecated
 from ..equality import EqualityTupleMixin
 from .base import ValuesMixin
 from .change import Update
@@ -141,8 +142,8 @@ class _GeoMixin(ValuesMixin):
         reasons = super().validate(name, fqdn, data)
         try:
             geo = dict(data['geo'])
-            cls.log.warning(
-                'NOTICE: `geo` record support is deprecated and should be migrated to `dynamic` records'
+            deprecated(
+                '`geo` records are DEPRECATED. `dynamic` records should be used instead. Will be removed in 2.0'
             )
             for code, values in geo.items():
                 reasons.extend(GeoValue._validate_geo(code))

--- a/octodns/record/geo.py
+++ b/octodns/record/geo.py
@@ -143,7 +143,8 @@ class _GeoMixin(ValuesMixin):
         try:
             geo = dict(data['geo'])
             deprecated(
-                '`geo` records are DEPRECATED. `dynamic` records should be used instead. Will be removed in 2.0'
+                '`geo` records are DEPRECATED. `dynamic` records should be used instead. Will be removed in 2.0',
+                stacklevel=99,
             )
             for code, values in geo.items():
                 reasons.extend(GeoValue._validate_geo(code))

--- a/octodns/record/spf.py
+++ b/octodns/record/spf.py
@@ -14,7 +14,8 @@ class SpfRecord(_ChunkedValuesMixin, Record):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         deprecated(
-            'The SPF record type is DEPRECATED in favor of TXT values and will become an ValidationError in 2.0'
+            'The SPF record type is DEPRECATED in favor of TXT values and will become an ValidationError in 2.0',
+            stacklevel=99,
         )
 
 

--- a/octodns/record/spf.py
+++ b/octodns/record/spf.py
@@ -2,6 +2,7 @@
 #
 #
 
+from ..deprecation import deprecated
 from .base import Record
 from .chunked import _ChunkedValue, _ChunkedValuesMixin
 
@@ -12,7 +13,7 @@ class SpfRecord(_ChunkedValuesMixin, Record):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.log.warning(
+        deprecated(
             'The SPF record type is DEPRECATED in favor of TXT values and will become an ValidationError in 2.0'
         )
 

--- a/octodns/zone.py
+++ b/octodns/zone.py
@@ -6,6 +6,7 @@ import re
 from collections import defaultdict
 from logging import getLogger
 
+from .deprecation import deprecated
 from .idna import idna_decode, idna_encode
 from .record import Create, Delete
 
@@ -197,8 +198,9 @@ class Zone(object):
 
     # TODO: delete this at v2.0.0rc0
     def _remove_record(self, record):
-        self.log.warning(
-            '_remove_record: method has been deprecated, used remove_record instead'
+        deprecated(
+            '_remove_record has been deprecated, used remove_record instead.  Will be removed in 2.0',
+            stacklevel=3,
         )
         return self.remove_record(record)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,4 +9,7 @@ known_first_party="octodns"
 line_length=80
 
 [tool.pytest.ini_options]
+filterwarnings = [
+    'ignore:.*DEPRECATED.*2.0',
+]
 pythonpath = "."

--- a/tests/test_octodns_record_geo.py
+++ b/tests/test_octodns_record_geo.py
@@ -213,24 +213,6 @@ class TestRecordGeoCodes(TestCase):
         self.assertTrue(c >= b)
 
     def test_validation(self):
-        with self.assertLogs('Record', level='WARNING') as cm:
-            Record.new(
-                self.zone,
-                '',
-                {
-                    'geo': {'NA': ['1.2.3.5'], 'NA-US': ['1.2.3.5', '1.2.3.6']},
-                    'type': 'A',
-                    'ttl': 600,
-                    'value': '1.2.3.4',
-                },
-            )
-        self.assertEqual(
-            [
-                'WARNING:Record:NOTICE: `geo` record support is deprecated and should be migrated to `dynamic` records'
-            ],
-            cm.output,
-        )
-
         # invalid ip address
         with self.assertRaises(ValidationError) as ctx:
             Record.new(


### PR DESCRIPTION
Current output. I'll probably explore quelling the ones coming from octoDNS code during octoDNS tests. They don't show during ./script/coverage, but do during ./script/test.

```console
============================================================================================================== warnings summary ==============================================================================================================
sys:1: 1 warning
tests/test_octodns_manager.py: 31 warnings
tests/test_octodns_processor_arpa.py: 1 warning
tests/test_octodns_provider_yaml.py: 8 warnings
tests/test_octodns_record_dynamic.py: 1 warning
tests/test_octodns_record_geo.py: 4 warnings
  sys:1: DeprecationWarning: `geo` records are DEPRECATED. `dynamic` records should be used instead. Will be removed in 2.0

tests/test_octodns_manager.py: 31 warnings
tests/test_octodns_provider_yaml.py: 8 warnings
tests/test_octodns_record_chunked.py: 1 warning
tests/test_octodns_record_spf.py: 3 warnings
  sys:1: DeprecationWarning: The SPF record type is DEPRECATED in favor of TXT values and will become an ValidationError in 2.0

tests/test_octodns_manager.py: 8 warnings
tests/test_octodns_provider_yaml.py: 8 warnings
  sys:1: DeprecationWarning: SplitYamlProvider is DEPRECATED, use YamlProvider with split_extension, split_catchall, and disable_zonefile instead, will go away in v2.0

tests/test_octodns_processor_spf.py::TestSpfDnsLookupProcessor::test_get_spf_from_txt_values
tests/test_octodns_processor_spf.py::TestSpfDnsLookupProcessor::test_processor
tests/test_octodns_processor_spf.py::TestSpfDnsLookupProcessor::test_processor_errors_on_recursive_include_mechanism
tests/test_octodns_processor_spf.py::TestSpfDnsLookupProcessor::test_processor_errors_on_too_many_spf_values
tests/test_octodns_processor_spf.py::TestSpfDnsLookupProcessor::test_processor_errors_ptr_mechanisms
tests/test_octodns_processor_spf.py::TestSpfDnsLookupProcessor::test_processor_with_lenient_record
tests/test_octodns_processor_spf.py::TestSpfDnsLookupProcessor::test_processor_with_long_txt_value
  sys:1: DeprecationWarning: SpfDnsLookupProcessor is DEPRECATED in favor of the version relocated into octodns-spf and will be removed in 2.0

tests/test_octodns_record_ds.py::TestRecordDs::test_ds
tests/test_octodns_record_ds.py::TestRecordDs::test_ds
tests/test_octodns_record_ds.py::TestRecordDs::test_ds
tests/test_octodns_record_ds.py::TestRecordDs::test_ds
tests/test_octodns_record_ds.py::TestRecordDs::test_ds
tests/test_octodns_record_ds.py::TestRecordDs::test_ds
  sys:1: DeprecationWarning: DS properties "algorithm", "flags", "public_key", and "protocol" support is DEPRECATED and will be removed in 2.0

tests/test_octodns_zone.py::TestZone::test_deprecated__remove_record
  /Users/ross/octodns/octodns/tests/test_octodns_zone.py:219: DeprecationWarning: _remove_record has been deprecated, used remove_record instead.  Will be removed in 2.0
    zone._remove_record(a)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

/cc https://python.readthedocs.io/en/latest/library/warnings.html#warnings.warn
