### PR TITLE
Address datetime.utcnow deprecation in py 3.12

### DIFF
--- a/octodns/processor/meta.py
+++ b/octodns/processor/meta.py
@@ -10,6 +10,14 @@ from .. import __version__
 from ..record import Record
 from .base import BaseProcessor
 
+# TODO: remove once we require python >= 3.11
+try:  # pragma: no cover
+    from datetime import UTC
+except ImportError:  # pragma: no cover
+    from datetime import timedelta, timezone
+
+    UTC = timezone(timedelta())
+
 
 def _keys(values):
     return set(v.split('=', 1)[0] for v in values)
@@ -55,7 +63,7 @@ class MetaProcessor(BaseProcessor):
 
     @classmethod
     def now(cls):
-        return datetime.utcnow().isoformat()
+        return datetime.now(UTC).isoformat()
 
     @classmethod
     def uuid(cls):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,4 +9,7 @@ known_first_party="octodns"
 line_length=80
 
 [tool.pytest.ini_options]
+filterwarnings = [
+    'error',
+]
 pythonpath = "."


### PR DESCRIPTION
Use `now(UTC)` with a backwards compatible way of getting UTC prior or py 3.11. 

/cc https://github.com/octodns/octodns/pull/1107 which lead to seeing the deprecation