### PR TITLE
Version 1.4.0 bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.?.0 - 2023-??-?? -
+## v1.4.0 - 2023-12-04 - Minor Meta
 
 * Record.lenient property added similar to other common/standard _octodns data
 * Processor.process_source_and_target_zones added to support modifying both the

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -1,4 +1,4 @@
 'OctoDNS: DNS as code - Tools for managing DNS across multiple providers'
 
 # TODO: remove __VERSION__ w/2.x
-__version__ = __VERSION__ = '1.3.0'
+__version__ = __VERSION__ = '1.4.0'


### PR DESCRIPTION
## v1.4.0 - 2023-12-04 - Minor Meta

* Record.lenient property added similar to other common/standard _octodns data
* Processor.process_source_and_target_zones added to support modifying both the
  desired and/or existing zones just prior to computing changes.
* Fix bug with Record.copy when values is an empty list []
* Fix an issue in MetaProcessor/Manager.include_meta where include_provider
  wasn't correctly taking effect