### PR TITLE
Support for nested config env variable expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.?.0 - 2023-??-?? -
+
+* Support added for config env variable expansion on nested levels, not just
+  top-level provider/processor keys
+
 ## v1.4.0 - 2023-12-04 - Minor Meta
 
 * Record.lenient property added similar to other common/standard _octodns data

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -355,8 +355,11 @@ class Manager(object):
         # Build up the arguments we need to pass to the provider
         kwargs = {}
         for k, v in source.items():
-            try:
+            if isinstance(v, dict):
+                v = self._build_kwargs(v)
+            elif isinstance(v, str):
                 if v.startswith('env/'):
+                    # expand env variables
                     try:
                         env_var = v[4:]
                         v = environ[env_var]
@@ -365,8 +368,13 @@ class Manager(object):
                         raise ManagerException(
                             f'Incorrect provider config, missing env var {env_var}, {source.context}'
                         )
-            except AttributeError:
-                pass
+                    try:
+                        # try converting the value to a number to see if it
+                        # converts
+                        v = float(v)
+                    except ValueError:
+                        pass
+
             kwargs[k] = v
 
         return kwargs


### PR DESCRIPTION
Support added for config env variable expansion on nested levels, not just top-level provider/processor keys. Allows things like:

```yaml
providers:
  mythicbeasts:
    class: octodns_mythicbeasts.MythicBeastsProvider
    password: env/THIS_PASSWORD_WOULD_EXPAND_CORRECTLY
    passwords:
      my.domain.: env/THIS_PASSWORD_DOES_NOT_EXPAND
```

/cc Fixes https://github.com/octodns/octodns-mythicbeasts/issues/31 @fireatwill 