### PR TITLE
readme: add NixOS-DNS to mentioned projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,7 @@ If you have a problem or suggestion, please [open an issue](https://github.com/o
 ## Related Projects and Resources
 
 - **GitHub Action:** [octoDNS-Sync](https://github.com/marketplace/actions/octodns-sync)
+- **NixOS Integration:** [NixOS-DNS](https://github.com/Janik-Haag/nixos-dns/)
 - **Sample Implementations.** See how others are using it
   - [`hackclub/dns`](https://github.com/hackclub/dns)
   - [`kubernetes/k8s.io:/dns`](https://github.com/kubernetes/k8s.io/tree/main/dns)


### PR DESCRIPTION
Hi over the last month or so I wrote a NixOS tool that has a native octodns integration, and also added a octodns package and some providers to [nixpkgs](https://github.com/nixos/nixpkgs) and would like to mention the tool in the `Related Projects and Resources` if that's fine with you. There is a announcement blog post over at the nixos discourse forums: https://discourse.nixos.org/t/announcing-nixos-dns/36702