### PR TITLE
Add support for checksum matching for safer plan & apply 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## v1.?.0 - 2023-??-?? -
 
+* Beta support for Manager.enable_checksum and octodns-sync --checksum Allows a
+  safer plan & apply workflow where the apply only moves forward if the apply
+  phase plan exactly matches the previous round's planning.
 * Fix for bug in MetaProcessor _up_to_date check that was failing when there was
   a plan with a single change type with a single value, e.g. CNAME.
 * Support added for config env variable expansion on nested levels, not just

--- a/octodns/cmds/sync.py
+++ b/octodns/cmds/sync.py
@@ -19,7 +19,7 @@ def main():
         '--doit',
         action='store_true',
         default=False,
-        help='Whether to take action or just show what would change',
+        help='Whether to take action or just show what would change, ignored when Manager.enable_checksum is used',
     )
     parser.add_argument(
         '--force',
@@ -27,6 +27,11 @@ def main():
         default=False,
         help='Acknowledge that significant changes are being '
         'made and do them',
+    )
+    parser.add_argument(
+        '--checksum',
+        default=None,
+        help="Provide the expected checksum, apply will only continue if it matches the plan's computed checksum",
     )
 
     parser.add_argument(
@@ -60,6 +65,7 @@ def main():
         eligible_targets=args.target,
         dry_run=not args.doit,
         force=args.force,
+        checksum=args.checksum,
     )
 
 

--- a/octodns/provider/plan.py
+++ b/octodns/provider/plan.py
@@ -78,6 +78,10 @@ class Plan(object):
             existing_n,
         )
 
+    @property
+    def data(self):
+        return {'changes': [c.data for c in self.changes]}
+
     def raise_if_unsafe(self):
         if (
             self.existing

--- a/octodns/record/change.py
+++ b/octodns/record/change.py
@@ -25,6 +25,10 @@ class Create(Change):
     def __init__(self, new):
         super().__init__(None, new)
 
+    @property
+    def data(self):
+        return {'type': 'create', 'new': self.new.data}
+
     def __repr__(self, leader=''):
         source = self.new.source.id if self.new.source else ''
         return f'Create {self.new} ({source})'
@@ -32,6 +36,14 @@ class Create(Change):
 
 class Update(Change):
     CLASS_ORDERING = 2
+
+    @property
+    def data(self):
+        return {
+            'type': 'update',
+            'existing': self.existing.data,
+            'new': self.new.data,
+        }
 
     # Leader is just to allow us to work around heven eating leading whitespace
     # in our output. When we call this from the Manager.sync plan summary
@@ -50,6 +62,10 @@ class Delete(Change):
 
     def __init__(self, existing):
         super().__init__(existing, None)
+
+    @property
+    def data(self):
+        return {'type': 'delete', 'existing': self.existing.data}
 
     def __repr__(self, leader=''):
         return f'Delete {self.existing}'

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -177,6 +177,36 @@ class TestManager(TestCase):
             ).sync(dry_run=False, force=True)
             self.assertEqual(33, tc)
 
+    def test_enable_checksum(self):
+        with TemporaryDirectory() as tmpdir:
+            environ['YAML_TMP_DIR'] = tmpdir.dirname
+            environ['YAML_TMP_DIR2'] = tmpdir.dirname
+            manager = Manager(
+                get_config_filename('simple.yaml'), enable_checksum=True
+            )
+
+            # initial/dry run is fine w/o checksum
+            tc = manager.sync(dry_run=True)
+            self.assertEqual(0, tc)
+
+            # trying to apply it fails w/o required checksum
+            with self.assertRaises(ManagerException) as ctx:
+                manager.sync(dry_run=False)
+            msg, checksum = str(ctx.exception).rsplit('=', 1)
+            self.assertEqual('checksum=None does not match computed', msg)
+            self.assertTrue(checksum)
+
+            # wrong checksum fails
+            with self.assertRaises(ManagerException) as ctx:
+                manager.sync(checksum='xyz')
+            msg, checksum = str(ctx.exception).rsplit('=', 1)
+            self.assertEqual('checksum=xyz does not match computed', msg)
+            self.assertTrue(checksum)
+
+            # correct checksum applies (w/o dry_run=False)
+            tc = manager.sync(checksum=checksum)
+            self.assertEqual(28, tc)
+
     def test_idna_eligible_zones(self):
         # loading w/simple, but we'll be blowing it away and doing some manual
         # stuff

--- a/tests/test_octodns_plan.py
+++ b/tests/test_octodns_plan.py
@@ -295,3 +295,32 @@ class TestPlanSafety(TestCase):
         with self.assertRaises(RootNsChange) as ctx:
             plan.raise_if_unsafe()
         self.assertTrue('Root Ns record change', str(ctx.exception))
+
+    def test_data(self):
+        data = plans[0][1].data
+        # plans should have a single key, changes
+        self.assertEqual(('changes',), tuple(data.keys()))
+        # it should be a list
+        self.assertIsInstance(data['changes'], list)
+        # w/4 elements
+        self.assertEqual(4, len(data['changes']))
+
+        # we'll test the change .data's here while we're at it since they don't
+        # have a dedicated test (file)
+        delete_data = data['changes'][0]  # delete
+        self.assertEqual(['existing', 'type'], sorted(delete_data.keys()))
+        self.assertEqual('delete', delete_data['type'])
+        self.assertEqual(delete.existing.data, delete_data['existing'])
+
+        create_data = data['changes'][1]  # create
+        self.assertEqual(['new', 'type'], sorted(create_data.keys()))
+        self.assertEqual('create', create_data['type'])
+        self.assertEqual(create.new.data, create_data['new'])
+
+        update_data = data['changes'][3]  # update
+        self.assertEqual(
+            ['existing', 'new', 'type'], sorted(update_data.keys())
+        )
+        self.assertEqual('update', update_data['type'])
+        self.assertEqual(update.existing.data, update_data['existing'])
+        self.assertEqual(update.new.data, update_data['new'])


### PR DESCRIPTION
This has literally been on the TODO list since octoDNS was first created and I've finally got around to implementing it. Truth is it wasn't as important/critical as I thought it was going to be since as far as I know no one has ever run into problems w/o it, but it's straightforward enough to implement and use that I see no reason not to add it.

TL;DR you can add the following to your config file:

```yaml
manager:
  enable_checksum: true
```

To turn on the functionality. Once you do that a checksum will be computed for the generated plan any time there are changes:

```console
$ octodns-sync --config-file=config.yaml
...
2023-12-11T13:32:36  [140704644451968] INFO  Plan
********************************************************************************
* xormedia.com.
********************************************************************************
* azure (AzureProvider)
*   Create <TxtRecord TXT 3600, testing.xormedia.com., ['Hello World!']> (config)
*   Summary: Creates=1, Updates=0, Deletes=0, Existing Records=4
********************************************************************************


2023-12-11T13:32:36  [140704644451968] INFO  Manager sync: checksum=1f8dcbecd47f4eedf2d35cdb39d55197b2e27b24c59962d7fe6f9497839ed253
```

If you try to `--doit` to apply the changes you'll get an error about the checksum mismatch:

```
$ octodns-sync --config-file=config.yaml --doit
...
2023-12-11T13:33:17  [140704644451968] INFO  Manager sync: checksum=1f8dcbecd47f4eedf2d35cdb39d55197b2e27b24c59962d7fe6f9497839ed253
Traceback (most recent call last):
  File "/Users/ross/lib/octodnsed/env/bin/octodns-sync", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/ross/octodns/octodns/octodns/cmds/sync.py", line 62, in main
    manager.sync(
  File "/Users/ross/octodns/octodns/octodns/manager.py", line 799, in sync
    raise ManagerException(
octodns.manager.ManagerException: checksum=None does not match computed=1f8dcbecd47f4eedf2d35cdb39d55197b2e27b24c59962d7fe6f9497839ed253
```

You'll get the same error if you have an actual mismatch `--checksum not-a-match`.

When you provide the correct checksum the chages are applied as normal.

```
$ octodns-sync --config-file=config.yaml --checksum 1f8dcbecd47f4eedf2d35cdb39d55197b2e27b24c59962d7fe6f9497839ed253
...
2023-12-11T13:35:09  [140704644451968] INFO  Manager sync:   1 total changes
```

/cc @octodns/review fyi and for 💭 