### PR TITLE
Add ASCII validation to ChunkedValue, TXT/SPF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   a plan with a single change type with a single value, e.g. CNAME.
 * Support added for config env variable expansion on nested levels, not just
   top-level provider/processor keys
+* _ChunkedValue ASCII validation added, SPF & TXT
 
 ## v1.4.0 - 2023-12-04 - Minor Meta
 

--- a/octodns/record/chunked.py
+++ b/octodns/record/chunked.py
@@ -52,6 +52,10 @@ class _ChunkedValue(str):
         for value in data:
             if cls._unescaped_semicolon_re.search(value):
                 reasons.append(f'unescaped ; in "{value}"')
+            try:
+                value.encode('ascii')
+            except UnicodeEncodeError:
+                reasons.append(f'non ASCII character in "{value}"')
         return reasons
 
     @classmethod


### PR DESCRIPTION
It appears that TXT values can only contain ASCII characters. This PR adds a validation ensuring that's the case. See https://github.com/octodns/octodns/issues/1126 for more info.

/cc Fixes https://github.com/octodns/octodns/issues/1126