### PR TITLE
Add filters for checking record values

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,8 @@ Similar to providers, but can only serve to populate records into a zone, cannot
 | [MetaProcessor](/octodns/processor/meta.py) | Adds a special meta record with timing, UUID, providers, and/or version to aid in debugging and monitoring. |
 | [NameAllowlistFilter](/octodns/processor/filter.py) | Filter that ONLY manages records that match specified naming patterns, all others will be ignored |
 | [NameRejectlistFilter](/octodns/processor/filter.py) | Filter that INGORES records that match specified naming patterns, all others will be managed |
+| [ValueAllowlistFilter](/octodns/processor/filter.py) | Filter that ONLY manages records that match specified value patterns, all others will be ignored |
+| [ValueRejectlistFilter](/octodns/processor/filter.py) | Filter that INGORES records that match specified value patterns, all others will be managed |
 | [OwnershipProcessor](/octodns/processor/ownership.py) | Processor that implements ownership in octoDNS so that it can manage only the records in a zone in sources and will ignore all others. |
 | [SpfDnsLookupProcessor](/octodns/processor/spf.py) | Processor that checks SPF values for violations of DNS query limits |
 | [TtlRestrictionFilter](/octodns/processor/restrict.py) | Processor that restricts the allow TTL values to a specified range or list of specific values |

--- a/README.md
+++ b/README.md
@@ -335,8 +335,8 @@ Similar to providers, but can only serve to populate records into a zone, cannot
 | [MetaProcessor](/octodns/processor/meta.py) | Adds a special meta record with timing, UUID, providers, and/or version to aid in debugging and monitoring. |
 | [NameAllowlistFilter](/octodns/processor/filter.py) | Filter that ONLY manages records that match specified naming patterns, all others will be ignored |
 | [NameRejectlistFilter](/octodns/processor/filter.py) | Filter that INGORES records that match specified naming patterns, all others will be managed |
-| [ValueAllowlistFilter](/octodns/processor/filter.py) | Filter that ONLY manages records that match specified value patterns, all others will be ignored |
-| [ValueRejectlistFilter](/octodns/processor/filter.py) | Filter that INGORES records that match specified value patterns, all others will be managed |
+| [ValueAllowlistFilter](/octodns/processor/filter.py) | Filter that ONLY manages records that match specified value patterns based on `rdata_text`, all others will be ignored |
+| [ValueRejectlistFilter](/octodns/processor/filter.py) | Filter that INGORES records that match specified value patterns based on `rdata_text`, all others will be managed |
 | [OwnershipProcessor](/octodns/processor/ownership.py) | Processor that implements ownership in octoDNS so that it can manage only the records in a zone in sources and will ignore all others. |
 | [SpfDnsLookupProcessor](/octodns/processor/spf.py) | Processor that checks SPF values for violations of DNS query limits |
 | [TtlRestrictionFilter](/octodns/processor/restrict.py) | Processor that restricts the allow TTL values to a specified range or list of specific values |

--- a/octodns/processor/filter.py
+++ b/octodns/processor/filter.py
@@ -232,9 +232,9 @@ class _ValueBaseFilter(_FilterProcessor):
         for record in zone.records:
             values = []
             if hasattr(record, 'values'):
-                values = [str(value) for value in record.values]
+                values = [value.rdata_text for value in record.values]
             else:
-                values = [str(record.value)]
+                values = [record.value.rdata_text]
 
             if any(value in self.exact for value in values):
                 self.matches(zone, record)
@@ -280,9 +280,6 @@ class ValueAllowlistFilter(_ValueBaseFilter, AllowsMixin):
           - route53
     '''
 
-    def __init__(self, name, allowlist):
-        super().__init__(name, allowlist)
-
 
 class ValueRejectlistFilter(_ValueBaseFilter, RejectsMixin):
     '''Reject managing records with names that match the provider patterns
@@ -315,9 +312,6 @@ class ValueRejectlistFilter(_ValueBaseFilter, RejectsMixin):
         targets:
           - route53
     '''
-
-    def __init__(self, name, rejectlist):
-        super().__init__(name, rejectlist)
 
 
 class _NetworkValueBaseFilter(BaseProcessor):

--- a/octodns/processor/filter.py
+++ b/octodns/processor/filter.py
@@ -215,6 +215,111 @@ class NameRejectlistFilter(_NameBaseFilter, RejectsMixin):
         super().__init__(name, rejectlist)
 
 
+class _ValueBaseFilter(_FilterProcessor):
+    def __init__(self, name, _list, **kwargs):
+        super().__init__(name, **kwargs)
+        exact = set()
+        regex = []
+        for pattern in _list:
+            if pattern.startswith('/'):
+                regex.append(re_compile(pattern[1:-1]))
+            else:
+                exact.add(pattern)
+        self.exact = exact
+        self.regex = regex
+
+    def _process(self, zone, *args, **kwargs):
+        for record in zone.records:
+            values = []
+            if hasattr(record, 'values'):
+                values = [str(value) for value in record.values]
+            else:
+                values = [str(record.value)]
+
+            if any(value in self.exact for value in values):
+                self.matches(zone, record)
+                continue
+            elif any(r.search(value) for r in self.regex for value in values):
+                self.matches(zone, record)
+                continue
+
+            self.doesnt_match(zone, record)
+
+        return zone
+
+
+class ValueAllowlistFilter(_ValueBaseFilter, AllowsMixin):
+    '''Only manage records with values that match the provider patterns
+
+    Example usage:
+
+    processors:
+      only-these:
+        class: octodns.processor.filter.ValueAllowlistFilter
+        allowlist:
+          # exact string match
+          - www
+          # contains/substring match
+          - /substring/
+          # regex pattern match
+          - /some-pattern-\\d\\+/
+          # regex - anchored so has to match start to end
+          - /^start-.+-end$/
+        # Optional param that can be set to False to leave the target zone
+        # alone, thus allowing deletion of existing records
+        # (default: true)
+        # include_target: True
+
+    zones:
+      exxampled.com.:
+        sources:
+          - config
+        processors:
+          - only-these
+        targets:
+          - route53
+    '''
+
+    def __init__(self, name, allowlist):
+        super().__init__(name, allowlist)
+
+
+class ValueRejectlistFilter(_ValueBaseFilter, RejectsMixin):
+    '''Reject managing records with names that match the provider patterns
+
+    Example usage:
+
+    processors:
+      not-these:
+        class: octodns.processor.filter.ValueRejectlistFilter
+        rejectlist:
+          # exact string match
+          - www
+          # contains/substring match
+          - /substring/
+          # regex pattern match
+          - /some-pattern-\\d\\+/
+          # regex - anchored so has to match start to end
+          - /^start-.+-end$/
+        # Optional param that can be set to False to leave the target zone
+        # alone, thus allowing deletion of existing records
+        # (default: true)
+        # include_target: True
+
+    zones:
+      exxampled.com.:
+        sources:
+          - config
+        processors:
+          - not-these
+        targets:
+          - route53
+    '''
+
+    def __init__(self, name, rejectlist):
+        super().__init__(name, rejectlist)
+
+
 class _NetworkValueBaseFilter(BaseProcessor):
     def __init__(self, name, _list):
         super().__init__(name)


### PR DESCRIPTION
This adds two new filters, `ValueAllowlistFilter` and `ValueRejectlistFilter` that allow checking the value(s) of records to include or exclude, similar to the name filters that already exist.  This was prompted by needing to filter CNAME records that point to a specific domain but is general enough to be used for any record.  Documentation has been updated, tests added and has full coverage.