### PR TITLE
Read only type

### DIFF
--- a/octodns/record/a.py
+++ b/octodns/record/a.py
@@ -4,7 +4,7 @@
 
 from ipaddress import IPv4Address as _IPv4Address
 
-from .base import Record
+from .base import Record, readonly
 from .dynamic import _DynamicMixin
 from .geo import _GeoMixin
 from .ip import _IpValue
@@ -19,7 +19,7 @@ Ipv4Address = Ipv4Value
 
 
 class ARecord(_DynamicMixin, _GeoMixin, Record):
-    _type = 'A'
+    _type = readonly('A')
     _value_type = Ipv4Value
 
 

--- a/octodns/record/aaaa.py
+++ b/octodns/record/aaaa.py
@@ -4,7 +4,7 @@
 
 from ipaddress import IPv6Address as _IPv6Address
 
-from .base import Record
+from .base import Record, readonly
 from .dynamic import _DynamicMixin
 from .geo import _GeoMixin
 from .ip import _IpValue
@@ -19,7 +19,7 @@ Ipv6Address = Ipv6Value
 
 
 class AaaaRecord(_DynamicMixin, _GeoMixin, Record):
-    _type = 'AAAA'
+    _type = readonly('AAAA')
     _value_type = Ipv6Address
 
 

--- a/octodns/record/alias.py
+++ b/octodns/record/alias.py
@@ -2,7 +2,7 @@
 #
 #
 
-from .base import Record, ValueMixin
+from .base import Record, ValueMixin, readonly
 from .target import _TargetValue
 
 
@@ -11,7 +11,7 @@ class AliasValue(_TargetValue):
 
 
 class AliasRecord(ValueMixin, Record):
-    _type = 'ALIAS'
+    _type = readonly('ALIAS')
     _value_type = AliasValue
 
     @classmethod

--- a/octodns/record/base.py
+++ b/octodns/record/base.py
@@ -19,6 +19,19 @@ def unquote(s):
     return s
 
 
+class readonly:
+    def __init__(self, value):
+        self.value = value
+
+    def __get__(self, *args, **kwargs):
+        return self.value
+
+    def __set__(self, obj, *args, **kwargs):
+        raise AttributeError(
+            f"property of '{obj.__class__.__name__}' is read-only"
+        )
+
+
 class Record(EqualityTupleMixin):
     log = getLogger('Record')
 

--- a/octodns/record/caa.py
+++ b/octodns/record/caa.py
@@ -3,7 +3,7 @@
 #
 
 from ..equality import EqualityTupleMixin
-from .base import Record, ValuesMixin, unquote
+from .base import Record, ValuesMixin, readonly, unquote
 from .rr import RrParseError
 
 
@@ -96,7 +96,7 @@ class CaaValue(EqualityTupleMixin, dict):
 
 
 class CaaRecord(ValuesMixin, Record):
-    _type = 'CAA'
+    _type = readonly('CAA')
     _value_type = CaaValue
 
 

--- a/octodns/record/cname.py
+++ b/octodns/record/cname.py
@@ -2,7 +2,7 @@
 #
 #
 
-from .base import Record, ValueMixin
+from .base import Record, ValueMixin, readonly
 from .dynamic import _DynamicMixin
 from .target import _TargetValue
 
@@ -12,7 +12,7 @@ class CnameValue(_TargetValue):
 
 
 class CnameRecord(_DynamicMixin, ValueMixin, Record):
-    _type = 'CNAME'
+    _type = readonly('CNAME')
     _value_type = CnameValue
 
     @classmethod

--- a/octodns/record/dname.py
+++ b/octodns/record/dname.py
@@ -2,7 +2,7 @@
 #
 #
 
-from .base import Record, ValueMixin
+from .base import Record, ValueMixin, readonly
 from .dynamic import _DynamicMixin
 from .target import _TargetValue
 
@@ -12,7 +12,7 @@ class DnameValue(_TargetValue):
 
 
 class DnameRecord(_DynamicMixin, ValueMixin, Record):
-    _type = 'DNAME'
+    _type = readonly('DNAME')
     _value_type = DnameValue
 
 

--- a/octodns/record/ds.py
+++ b/octodns/record/ds.py
@@ -6,7 +6,7 @@ from logging import getLogger
 
 from ..deprecation import deprecated
 from ..equality import EqualityTupleMixin
-from .base import Record, ValuesMixin
+from .base import Record, ValuesMixin, readonly
 from .rr import RrParseError
 
 
@@ -174,7 +174,7 @@ class DsValue(EqualityTupleMixin, dict):
 
 
 class DsRecord(ValuesMixin, Record):
-    _type = 'DS'
+    _type = readonly('DS')
     _value_type = DsValue
 
 

--- a/octodns/record/loc.py
+++ b/octodns/record/loc.py
@@ -3,7 +3,7 @@
 #
 
 from ..equality import EqualityTupleMixin
-from .base import Record, ValuesMixin, unquote
+from .base import Record, ValuesMixin, readonly, unquote
 from .rr import RrParseError
 
 
@@ -353,7 +353,7 @@ class LocValue(EqualityTupleMixin, dict):
 
 
 class LocRecord(ValuesMixin, Record):
-    _type = 'LOC'
+    _type = readonly('LOC')
     _value_type = LocValue
 
 

--- a/octodns/record/mx.py
+++ b/octodns/record/mx.py
@@ -6,7 +6,7 @@ from fqdn import FQDN
 
 from ..equality import EqualityTupleMixin
 from ..idna import idna_encode
-from .base import Record, ValuesMixin, unquote
+from .base import Record, ValuesMixin, readonly, unquote
 from .rr import RrParseError
 
 
@@ -114,7 +114,7 @@ class MxValue(EqualityTupleMixin, dict):
 
 
 class MxRecord(ValuesMixin, Record):
-    _type = 'MX'
+    _type = readonly('MX')
     _value_type = MxValue
 
 

--- a/octodns/record/naptr.py
+++ b/octodns/record/naptr.py
@@ -3,7 +3,7 @@
 #
 
 from ..equality import EqualityTupleMixin
-from .base import Record, ValuesMixin, unquote
+from .base import Record, ValuesMixin, readonly, unquote
 from .rr import RrParseError
 
 
@@ -169,7 +169,7 @@ class NaptrValue(EqualityTupleMixin, dict):
 
 
 class NaptrRecord(ValuesMixin, Record):
-    _type = 'NAPTR'
+    _type = readonly('NAPTR')
     _value_type = NaptrValue
 
 

--- a/octodns/record/ns.py
+++ b/octodns/record/ns.py
@@ -2,7 +2,7 @@
 #
 #
 
-from .base import Record, ValuesMixin
+from .base import Record, ValuesMixin, readonly
 from .target import _TargetsValue
 
 
@@ -11,7 +11,7 @@ class NsValue(_TargetsValue):
 
 
 class NsRecord(ValuesMixin, Record):
-    _type = 'NS'
+    _type = readonly('NS')
     _value_type = NsValue
 
 

--- a/octodns/record/ptr.py
+++ b/octodns/record/ptr.py
@@ -2,7 +2,7 @@
 #
 #
 
-from .base import Record, ValuesMixin
+from .base import Record, ValuesMixin, readonly
 from .target import _TargetsValue
 
 
@@ -11,7 +11,7 @@ class PtrValue(_TargetsValue):
 
 
 class PtrRecord(ValuesMixin, Record):
-    _type = 'PTR'
+    _type = readonly('PTR')
     _value_type = PtrValue
 
     # This is for backward compatibility with providers that don't support

--- a/octodns/record/spf.py
+++ b/octodns/record/spf.py
@@ -3,12 +3,12 @@
 #
 
 from ..deprecation import deprecated
-from .base import Record
+from .base import Record, readonly
 from .chunked import _ChunkedValue, _ChunkedValuesMixin
 
 
 class SpfRecord(_ChunkedValuesMixin, Record):
-    _type = 'SPF'
+    _type = readonly('SPF')
     _value_type = _ChunkedValue
 
     def __init__(self, *args, **kwargs):

--- a/octodns/record/srv.py
+++ b/octodns/record/srv.py
@@ -8,7 +8,7 @@ from fqdn import FQDN
 
 from ..equality import EqualityTupleMixin
 from ..idna import idna_encode
-from .base import Record, ValuesMixin, unquote
+from .base import Record, ValuesMixin, readonly, unquote
 from .rr import RrParseError
 
 
@@ -148,7 +148,7 @@ class SrvValue(EqualityTupleMixin, dict):
 
 
 class SrvRecord(ValuesMixin, Record):
-    _type = 'SRV'
+    _type = readonly('SRV')
     _value_type = SrvValue
     _name_re = re.compile(r'^(\*|_[^\.]+)\.[^\.]+')
 

--- a/octodns/record/sshfp.py
+++ b/octodns/record/sshfp.py
@@ -3,7 +3,7 @@
 #
 
 from ..equality import EqualityTupleMixin
-from .base import Record, ValuesMixin, unquote
+from .base import Record, ValuesMixin, readonly, unquote
 from .rr import RrParseError
 
 
@@ -118,7 +118,7 @@ class SshfpValue(EqualityTupleMixin, dict):
 
 
 class SshfpRecord(ValuesMixin, Record):
-    _type = 'SSHFP'
+    _type = readonly('SSHFP')
     _value_type = SshfpValue
 
 

--- a/octodns/record/tlsa.py
+++ b/octodns/record/tlsa.py
@@ -3,7 +3,7 @@
 #
 
 from ..equality import EqualityTupleMixin
-from .base import Record, ValuesMixin, unquote
+from .base import Record, ValuesMixin, readonly, unquote
 from .rr import RrParseError
 
 
@@ -154,7 +154,7 @@ class TlsaValue(EqualityTupleMixin, dict):
 
 
 class TlsaRecord(ValuesMixin, Record):
-    _type = 'TLSA'
+    _type = readonly('TLSA')
     _value_type = TlsaValue
 
 

--- a/octodns/record/txt.py
+++ b/octodns/record/txt.py
@@ -2,7 +2,7 @@
 #
 #
 
-from .base import Record
+from .base import Record, readonly
 from .chunked import _ChunkedValue, _ChunkedValuesMixin
 
 
@@ -11,7 +11,7 @@ class TxtValue(_ChunkedValue):
 
 
 class TxtRecord(_ChunkedValuesMixin, Record):
-    _type = 'TXT'
+    _type = readonly('TXT')
     _value_type = TxtValue
 
 

--- a/octodns/record/urlfwd.py
+++ b/octodns/record/urlfwd.py
@@ -3,7 +3,7 @@
 #
 
 from ..equality import EqualityTupleMixin
-from .base import Record, ValuesMixin
+from .base import Record, ValuesMixin, readonly
 
 
 class UrlfwdValue(EqualityTupleMixin, dict):
@@ -114,7 +114,7 @@ class UrlfwdValue(EqualityTupleMixin, dict):
 
 
 class UrlfwdRecord(ValuesMixin, Record):
-    _type = 'URLFWD'
+    _type = readonly('URLFWD')
     _value_type = UrlfwdValue
 
 

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -30,6 +30,21 @@ from octodns.zone import Zone
 class TestRecord(TestCase):
     zone = Zone('unit.tests.', [])
 
+    def test_type_is_readonly(self):
+        record = ARecord(
+            self.zone, 'MiXeDcAsE', {'ttl': 30, 'type': 'A', 'value': '1.2.3.4'}
+        )
+        self.assertEqual('A', record._type)
+
+        with self.assertRaises(AttributeError) as ctx:
+            record._type = 42
+        self.assertEqual(
+            "property of 'ARecord' is read-only", str(ctx.exception)
+        )
+
+        # value didn't change
+        self.assertEqual('A', record._type)
+
     def test_registration(self):
         with self.assertRaises(RecordException) as ctx:
             Record.register_type(None, 'A')


### PR DESCRIPTION
Over in https://github.com/octodns/octodns/issues/1130#issuecomment-1892721006 `_type` was being set with the expectation that it would alter the type of the record object, but it will not and it could potentially mess things up by changing the class-static `_type` vars on things. This PR adds a `readonly` decorator` and uses it on the `_type` (class) property for all of the record subtypes. Any 3rd party types would be free to start using the readonly bit once they require a new enough octoDNS, but it shouldn't hurt much of anything if they don't.

/cc https://github.com/octodns/octodns/issues/1130#issuecomment-1892721006 which lead to this PR