### PR TITLE
Fall back to repr() in value filters and keep list names

### DIFF
--- a/octodns/processor/filter.py
+++ b/octodns/processor/filter.py
@@ -280,6 +280,9 @@ class ValueAllowlistFilter(_ValueBaseFilter, AllowsMixin):
           - route53
     '''
 
+    def __init__(self, name, allowlist):
+        super().__init__(name, allowlist)
+
 
 class ValueRejectlistFilter(_ValueBaseFilter, RejectsMixin):
     '''Reject managing records with names that match the provider patterns
@@ -312,6 +315,9 @@ class ValueRejectlistFilter(_ValueBaseFilter, RejectsMixin):
         targets:
           - route53
     '''
+
+    def __init__(self, name, rejectlist):
+        super().__init__(name, rejectlist)
 
 
 class _NetworkValueBaseFilter(BaseProcessor):


### PR DESCRIPTION
Follow up to #1132

I figured out why the seemly redundant constructors are included in filters.  The yaml files use `allowlist` and `rejectlist`, without the constructor it wants to use `_list` instead.  This doesn't match the behavior of other filters and would break backwards compatibility if changed.

Also found that `URLFWD` and a few other records don't actually have an `rdata_text` field and I couldn't find anything in the DNS spec about how those should be formatted.  Changed it to fall back to calling `repr()` if it can't find `rdata_text`, added a test case and updated the documentation.
