### PR TITLE
Add test_records_have_rdata_methods, implement them for URLFWD

### DIFF
--- a/octodns/record/urlfwd.py
+++ b/octodns/record/urlfwd.py
@@ -3,13 +3,42 @@
 #
 
 from ..equality import EqualityTupleMixin
-from .base import Record, ValuesMixin
+from .base import Record, ValuesMixin, unquote
+from .rr import RrParseError
 
 
 class UrlfwdValue(EqualityTupleMixin, dict):
     VALID_CODES = (301, 302)
     VALID_MASKS = (0, 1, 2)
     VALID_QUERY = (0, 1)
+
+    @classmethod
+    def parse_rdata_text(self, value):
+        try:
+            path, target, code, masking, query = value.split(' ')
+        except ValueError:
+            raise RrParseError()
+        try:
+            code = int(code)
+        except ValueError:
+            pass
+        try:
+            masking = int(masking)
+        except ValueError:
+            pass
+        try:
+            query = int(query)
+        except ValueError:
+            pass
+        path = unquote(path)
+        target = unquote(target)
+        return {
+            'path': path,
+            'target': target,
+            'code': code,
+            'masking': masking,
+            'query': query,
+        }
 
     @classmethod
     def validate(cls, data, _type):
@@ -98,6 +127,10 @@ class UrlfwdValue(EqualityTupleMixin, dict):
     @query.setter
     def query(self, value):
         self['query'] = value
+
+    @property
+    def rdata_text(self):
+        return f'"{self.path}" "{self.target}" {self.code} {self.masking} {self.query}'
 
     def _equality_tuple(self):
         return (self.path, self.target, self.code, self.masking, self.query)

--- a/tests/test_octodns_record.py
+++ b/tests/test_octodns_record.py
@@ -846,3 +846,30 @@ class TestRecordValidation(TestCase):
             '<CnameRecord CNAME 43, pointer.unit.tests., unit.tests.>',
             record.__repr__(),
         )
+
+    def test_records_have_rdata_methods(self):
+        for _type, cls in Record.registered_types().items():
+            print(f'{_type} {cls}')
+            attr = 'parse_rdata_texts'
+            print(f'  {attr}')
+            method = getattr(cls, attr)
+            self.assertTrue(method, f'{_type}, {cls} has {attr}')
+            self.assertTrue(
+                callable(method), f'{_type}, {cls} {attr} is callable'
+            )
+
+            value_type = getattr(cls, '_value_type')
+            self.assertTrue(value_type, f'{_type}, {cls} has _value_type')
+
+            attr = 'parse_rdata_text'
+            print(f'  {attr}')
+            method = getattr(value_type, attr)
+            self.assertTrue(method, f'{_type}, {cls} has {attr}')
+            self.assertTrue(
+                callable(method), f'{_type}, {cls} {attr} is callable'
+            )
+
+            attr = 'rdata_text'
+            method = getattr(value_type, attr)
+            self.assertTrue(method, f'{_type}, {cls} has {attr}')
+            # this one is a @property so not callable


### PR DESCRIPTION
Add a unit tests that checks that all (core) registered record types have the rdata methods/property. Implement those methods for `UrlfwdRecord` 

/cc https://github.com/octodns/octodns/pull/1135#issuecomment-1894498799 @Nullreff 