### PR TITLE
_build_kwargs fix, don't convert int-y things to floats

### DIFF
--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -388,10 +388,14 @@ class Manager(object):
                             f'Incorrect provider config, missing env var {env_var}, {source.context}'
                         )
                     try:
-                        # try converting the value to a number to see if it
-                        # converts
-                        v = float(v)
+                        if '.' in v:
+                            # has a dot, try converting it to a float
+                            v = float(v)
+                        else:
+                            # no dot, try converting it to an int
+                            v = int(v)
                     except ValueError:
+                        # just leave it as a string
                         pass
 
             kwargs[k] = v

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -1133,6 +1133,7 @@ class TestManager(TestCase):
 
         environ['OCTODNS_TEST_1'] = '42'
         environ['OCTODNS_TEST_2'] = 'string'
+        environ['OCTODNS_TEST_3'] = '43.44'
 
         # empty
         self.assertEqual({}, manager._build_kwargs({}))
@@ -1198,6 +1199,18 @@ class TestManager(TestCase):
                             'f': 43,
                         }
                     }
+                }
+            ),
+        )
+
+        # types/conversion
+        self.assertEqual(
+            {'int': 42, 'string': 'string', 'float': 43.44},
+            manager._build_kwargs(
+                {
+                    'int': 'env/OCTODNS_TEST_1',
+                    'string': 'env/OCTODNS_TEST_2',
+                    'float': 'env/OCTODNS_TEST_3',
                 }
             ),
         )


### PR DESCRIPTION
Only try converting things to float when there's a `.` in them to avoid int-y things having being a float (even if it's with .0)

/cc Fixes https://github.com/octodns/octodns/issues/1148#issuecomment-1984919619 @wjgauthier
/cc https://github.com/octodns/octodns/pull/1118 which introduced the issue
/cc https://github.com/octodns/octodns-powerdns/pull/63 which was turned up b/c of this