### PR TITLE
Version 1.5.1 bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.5.1 - 2024-03-08 - env/* type conversion fix
+
+* Improved env variable to parameter type conversion logic, avoid converting
+  all numbers to float which caused some formatting issues in things that
+  weren't being careful enough.
+
 ## v1.5.0 - 2024-02-26 - Checksums, nested expansion, & flexable values
 
 * Beta support for Manager.enable_checksum and octodns-sync --checksum Allows a

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -1,4 +1,4 @@
 'OctoDNS: DNS as code - Tools for managing DNS across multiple providers'
 
 # TODO: remove __VERSION__ w/2.x
-__version__ = __VERSION__ = '1.5.0'
+__version__ = __VERSION__ = '1.5.1'


### PR DESCRIPTION
## v1.5.1 - 2024-03-08 - env/* type conversion fix

* Improved env variable to parameter type conversion logic, avoid converting
  all numbers to float which caused some formatting issues in things that
  weren't being careful enough.