### PR TITLE
Fix env var int handling regression

### DIFF
--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -434,18 +434,6 @@ class Manager(object):
                     else:
                         v = handler.fetch(name, source)
 
-                    if isinstance(v, str):
-                        try:
-                            if '.' in v:
-                                # has a dot, try converting it to a float
-                                v = float(v)
-                            else:
-                                # no dot, try converting it to an int
-                                v = int(v)
-                        except ValueError:
-                            # just leave it as a string
-                            pass
-
             kwargs[k] = v
 
         return kwargs

--- a/octodns/secret/environ.py
+++ b/octodns/secret/environ.py
@@ -22,11 +22,16 @@ class EnvironSecrets(BaseSecrets):
             raise EnvironSecretsException(
                 f'Incorrect provider config, missing env var {name}, {source.context}'
             )
+
         try:
-            # try converting the value to a number to see if it
-            # converts
-            v = float(v)
+            if '.' in v:
+                # has a dot, try converting it to a float
+                v = float(v)
+            else:
+                # no dot, try converting it to an int
+                v = int(v)
         except ValueError:
+            # just leave it as a string
             pass
 
         return v

--- a/tests/test_octodns_secret_environ.py
+++ b/tests/test_octodns_secret_environ.py
@@ -19,9 +19,17 @@ class TestEnvironSecrets(TestCase):
         es = EnvironSecrets('env')
 
         source = ContextDict({}, context='xyz')
-        self.assertEqual('and has a val', es.fetch('THIS_EXISTS', source))
-        self.assertEqual(42, es.fetch('THIS_IS_AN_INT', source))
-        self.assertEqual(43.44, es.fetch('THIS_IS_A_FLOAT', source))
+        v = es.fetch('THIS_EXISTS', source)
+        self.assertEqual('and has a val', v)
+        self.assertIsInstance(v, str)
+
+        v = es.fetch('THIS_IS_AN_INT', source)
+        self.assertEqual(42, v)
+        self.assertIsInstance(v, int)
+
+        v = es.fetch('THIS_IS_A_FLOAT', source)
+        self.assertEqual(43.44, v)
+        self.assertIsInstance(v, float)
 
         with self.assertRaises(EnvironSecretsException) as ctx:
             es.fetch('DOES_NOT_EXIST', source)


### PR DESCRIPTION
The `Manager` version should have gone away once the secret handler was extracted.

/cc Fixes https://github.com/octodns/octodns/issues/1149