### PR TITLE
Version 1.6.1 bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.6.1 - 2024-03-17 - Didn't we do this already
+
+* Fix env var type handling that was previously fixed in 1.5.1 and then
+  regressed in 1.6.0.
+
 ## v1.6.0 - 2024-03-11 - It's a secret, if I told you I'd have to kill you
 
 * Add EnsureTrailingDots processor

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -1,4 +1,4 @@
 'OctoDNS: DNS as code - Tools for managing DNS across multiple providers'
 
 # TODO: remove __VERSION__ w/2.x
-__version__ = __VERSION__ = '1.6.0'
+__version__ = __VERSION__ = '1.6.1'


### PR DESCRIPTION
## v1.6.1 - 2024-03-17 - Didn't we do this already

* Fix env var type handling that was previously fixed in 1.5.1 and then
  regressed in 1.6.0.