### PR TITLE
Add Zone Specific Threshold Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.?.? - 2024-??-?? - ????
+
+* Support for specifying per-zone change thresholds, to allow for zones
+  where lots of changes are expected frequently to live along side zones
+  where little or no churn is expected.
+
 ## v1.6.1 - 2024-03-17 - Didn't we do this already
 
 * Fix env var type handling that was previously fixed in 1.5.1 and then

--- a/docs/records.md
+++ b/docs/records.md
@@ -126,7 +126,7 @@ If you'd like to enable lenience for a whole zone you can do so with the followi
 #### Restrict Record manipulations
 
 octoDNS currently provides the ability to limit the number of updates/deletes on
-DNS records by configuring a percentage of allowed operations as a threshold.
+DNS records by configuring a percentage of allowed operations as a provider threshold.
 If left unconfigured, suitable defaults take over instead. In the below example,
 the Dyn provider is configured with limits of 40% on both update and
 delete operations over all the records present.
@@ -137,6 +137,17 @@ dyn:
     update_pcent_threshold: 0.4
     delete_pcent_threshold: 0.4
 ````
+
+Additionally, thresholds can be configured at the zone level. Zone thresholds
+take precedence over any provider default or explicit configuration. Zone
+thresholds do not have a default.
+
+```yaml
+zones:
+  example.com.:
+    update_pcent_threshold: 0.2
+    delete_pcent_threshold: 0.1
+```
 
 ## Provider specific record types
 

--- a/octodns/manager.py
+++ b/octodns/manager.py
@@ -1052,6 +1052,13 @@ class Manager(object):
         zone = self.config['zones'].get(zone_name)
         if zone is not None:
             sub_zones = self.configured_sub_zones(zone_name)
-            return Zone(idna_encode(zone_name), sub_zones)
+            update_pcent_threshold = zone.get("update_pcent_threshold", None)
+            delete_pcent_threshold = zone.get("delete_pcent_threshold", None)
+            return Zone(
+                idna_encode(zone_name),
+                sub_zones,
+                update_pcent_threshold,
+                delete_pcent_threshold,
+            )
 
         raise ManagerException(f'Unknown zone name {idna_decode(zone_name)}')

--- a/octodns/provider/plan.py
+++ b/octodns/provider/plan.py
@@ -57,15 +57,16 @@ class Plan(object):
         # them and/or is as safe as possible.
         self.changes = sorted(changes)
         self.exists = exists
-        self.update_pcent_threshold = update_pcent_threshold
-        self.delete_pcent_threshold = delete_pcent_threshold
 
         # Zone thresholds take precedence over provider
         if existing and existing.update_pcent_threshold is not None:
             self.update_pcent_threshold = existing.update_pcent_threshold
+        else:
+            self.update_pcent_threshold = update_pcent_threshold
         if existing and existing.delete_pcent_threshold is not None:
             self.delete_pcent_threshold = existing.delete_pcent_threshold
-
+        else:
+            self.delete_pcent_threshold = delete_pcent_threshold
         change_counts = {'Create': 0, 'Delete': 0, 'Update': 0}
         for change in changes:
             change_counts[change.__class__.__name__] += 1

--- a/octodns/provider/plan.py
+++ b/octodns/provider/plan.py
@@ -60,6 +60,12 @@ class Plan(object):
         self.update_pcent_threshold = update_pcent_threshold
         self.delete_pcent_threshold = delete_pcent_threshold
 
+        # Zone thresholds take precedence over provider
+        if existing and existing.update_pcent_threshold is not None:
+            self.update_pcent_threshold = existing.update_pcent_threshold
+        if existing and existing.delete_pcent_threshold is not None:
+            self.delete_pcent_threshold = existing.delete_pcent_threshold
+
         change_counts = {'Create': 0, 'Delete': 0, 'Update': 0}
         for change in changes:
             change_counts[change.__class__.__name__] += 1

--- a/octodns/zone.py
+++ b/octodns/zone.py
@@ -56,7 +56,13 @@ class InvalidNodeException(Exception):
 class Zone(object):
     log = getLogger('Zone')
 
-    def __init__(self, name, sub_zones):
+    def __init__(
+        self,
+        name,
+        sub_zones,
+        update_pcent_threshold=None,
+        delete_pcent_threshold=None,
+    ):
         if not name[-1] == '.':
             raise Exception(f'Invalid zone name {name}, missing ending dot')
         elif ' ' in name or '\t' in name:
@@ -77,6 +83,9 @@ class Zone(object):
         # optional trailing . b/c some sources don't have it on their fqdn
         self._utf8_name_re = re.compile(fr'\.?{idna_decode(name)}?$')
         self._idna_name_re = re.compile(fr'\.?{self.name}?$')
+
+        self.update_pcent_threshold = update_pcent_threshold
+        self.delete_pcent_threshold = delete_pcent_threshold
 
         # Copy-on-write semantics support, when `not None` this property will
         # point to a location with records for this `Zone`. Once `hydrated`
@@ -352,7 +361,12 @@ class Zone(object):
         copying the records when required. The actual record copy will not be
         "deep" meaning that records should not be modified directly.
         '''
-        copy = Zone(self.name, self.sub_zones)
+        copy = Zone(
+            self.name,
+            self.sub_zones,
+            self.update_pcent_threshold,
+            self.delete_pcent_threshold,
+        )
         copy._origin = self
         return copy
 

--- a/tests/config/zone-threshold.yaml
+++ b/tests/config/zone-threshold.yaml
@@ -26,3 +26,9 @@ zones:
     - in
     targets:
     - dump
+
+  defaultthresholds.tests.:
+    sources:
+    - in
+    targets:
+    - dump

--- a/tests/config/zone-threshold.yaml
+++ b/tests/config/zone-threshold.yaml
@@ -1,0 +1,28 @@
+manager:
+  max_workers: 2
+providers:
+  in:
+    class: octodns.provider.yaml.YamlProvider
+    directory: tests/config
+    strict_supports: False
+  dump:
+    class: octodns.provider.yaml.YamlProvider
+    directory: env/YAML_TMP_DIR
+    supports_root_ns: False
+    strict_supports: False
+zones:
+  unit.tests.:
+    update_pcent_threshold: 0.2
+    delete_pcent_threshold: 0.1
+    sources:
+      - in
+    targets:
+      - dump
+
+  subzone.unit.tests.:
+    update_pcent_threshold: 0.02
+    delete_pcent_threshold: 0.01
+    sources:
+    - in
+    targets:
+    - dump

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -1311,6 +1311,12 @@ class TestManager(TestCase):
             self.assertEqual(0.02, subzone.update_pcent_threshold)
             self.assertEqual(0.01, subzone.delete_pcent_threshold)
 
+            # test default of None to ensure Provider precedence
+            zone_with_defaults = manager.get_zone('defaultthresholds.tests.')
+
+            self.assertIsNone(zone_with_defaults.update_pcent_threshold)
+            self.assertIsNone(zone_with_defaults.delete_pcent_threshold)
+
 
 class TestMainThreadExecutor(TestCase):
     def test_success(self):

--- a/tests/test_octodns_manager.py
+++ b/tests/test_octodns_manager.py
@@ -1294,6 +1294,23 @@ class TestManager(TestCase):
             requires_dummy.fetch(':hello', None),
         )
 
+    def test_zone_threshold(self):
+        with TemporaryDirectory() as tmpdir:
+            environ['YAML_TMP_DIR'] = tmpdir.dirname
+
+            manager = Manager(get_config_filename('zone-threshold.yaml'))
+
+            zone = manager.get_zone('unit.tests.')
+
+            self.assertEqual(0.2, zone.update_pcent_threshold)
+            self.assertEqual(0.1, zone.delete_pcent_threshold)
+
+            # subzone has different threshold
+            subzone = manager.get_zone('subzone.unit.tests.')
+
+            self.assertEqual(0.02, subzone.update_pcent_threshold)
+            self.assertEqual(0.01, subzone.delete_pcent_threshold)
+
 
 class TestMainThreadExecutor(TestCase):
     def test_success(self):


### PR DESCRIPTION
As users of OctoDNS, we have quite a complex configuration that's being both partially populated by automation. We'd like to add an additional level of protection for zones that we do not expect to change, so that folks deploying OctoDNS have an additional guard rail in place.

This PR adds a Zone specific threshold that:
* Has no defaults
* Takes precedence over the provider defaults or explicitly specified provider configuration

In building this PR, the one thing that seemed strange to me was having to guard against `existing` not being `None`, since the `Manager` looks like it would be constructing any existing `Zone` from configuration. As in this line:
```
if existing and existing.update_pcent_threshold is not None:
```

I expected to be simply
```
if existing.update_pcent_threshold is not None:
```

So I might be missing some flows about how `Plan` is being used.