### PR TITLE
AutoArpa: Add an optional inherit_ttl option

### DIFF
--- a/docs/auto_arpa.md
+++ b/docs/auto_arpa.md
@@ -15,12 +15,15 @@ Alternatively the value can be a dictionary with configuration options for the A
 manager:
   auto_arpa:
     # Whether duplicate records should replace rather than error
-    # (optiona, default False)
+    # (optional, default False)
     populate_should_replace: false
     # Explicitly set the TTL of auto-created records, default is 3600s, 1hr
     ttl: 1800
     # Set how many PTR records will be created for the same IP, default: 999
     max_auto_arpa: 1
+    # Inherit the TTL value of the corresponding A/AAAA record (optional,
+    # default False)
+    inherit_ttl: True
 ```
 
 Once enabled, a singleton `AutoArpa` instance, `auto-arpa`, will be added to the pool of providers and globally configured to run as the very last global processor so that it will see all records as they will be seen by targets. Further all zones ending with `arpa.` will be held back and processed after all other zones have been completed so that all `A` and `AAAA` records will have been seen prior to planning the `arpa.` zones.

--- a/tests/test_octodns_processor_arpa.py
+++ b/tests/test_octodns_processor_arpa.py
@@ -27,7 +27,7 @@ class TestAutoArpa(TestCase):
         aa = AutoArpa('auto-arpa')
         aa.process_source_zone(zone, [])
         self.assertEqual(
-            {'4.3.2.1.in-addr.arpa.': [(999, 'a.unit.tests.')]}, aa._records
+            {'4.3.2.1.in-addr.arpa.': [(999, 3600, 'a.unit.tests.')]}, aa._records
         )
 
         # matching zone
@@ -56,8 +56,8 @@ class TestAutoArpa(TestCase):
         aa.process_source_zone(zone, [])
         self.assertEqual(
             {
-                '4.3.2.1.in-addr.arpa.': [(999, 'a.unit.tests.')],
-                '5.3.2.1.in-addr.arpa.': [(999, 'a.unit.tests.')],
+                '4.3.2.1.in-addr.arpa.': [(999, 1600, 'a.unit.tests.')],
+                '5.3.2.1.in-addr.arpa.': [(999, 1600, 'a.unit.tests.')],
             },
             aa._records,
         )
@@ -81,7 +81,7 @@ class TestAutoArpa(TestCase):
         aa = AutoArpa('auto-arpa')
         aa.process_source_zone(zone, [])
         ip6_arpa = '2.0.0.0.4.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.c.0.0.0.f.f.0.0.ip6.arpa.'
-        self.assertEqual({ip6_arpa: [(999, 'aaaa.unit.tests.')]}, aa._records)
+        self.assertEqual({ip6_arpa: [(999, 3600, 'aaaa.unit.tests.')]}, aa._records)
 
         # matching zone
         arpa = Zone('c.0.0.0.f.f.0.0.ip6.arpa.', [])
@@ -117,13 +117,13 @@ class TestAutoArpa(TestCase):
         aa.process_source_zone(zone, [])
         self.assertEqual(
             {
-                '4.3.2.1.in-addr.arpa.': [(999, 'geo.unit.tests.')],
-                '5.3.2.1.in-addr.arpa.': [(999, 'geo.unit.tests.')],
-                '1.1.1.1.in-addr.arpa.': [(999, 'geo.unit.tests.')],
-                '2.2.2.2.in-addr.arpa.': [(999, 'geo.unit.tests.')],
-                '3.3.3.3.in-addr.arpa.': [(999, 'geo.unit.tests.')],
-                '4.4.4.4.in-addr.arpa.': [(999, 'geo.unit.tests.')],
-                '5.5.5.5.in-addr.arpa.': [(999, 'geo.unit.tests.')],
+                '4.3.2.1.in-addr.arpa.': [(999, 3600, 'geo.unit.tests.')],
+                '5.3.2.1.in-addr.arpa.': [(999, 3600, 'geo.unit.tests.')],
+                '1.1.1.1.in-addr.arpa.': [(999, 3600, 'geo.unit.tests.')],
+                '2.2.2.2.in-addr.arpa.': [(999, 3600, 'geo.unit.tests.')],
+                '3.3.3.3.in-addr.arpa.': [(999, 3600, 'geo.unit.tests.')],
+                '4.4.4.4.in-addr.arpa.': [(999, 3600, 'geo.unit.tests.')],
+                '5.5.5.5.in-addr.arpa.': [(999, 3600, 'geo.unit.tests.')],
             },
             aa._records,
         )
@@ -194,8 +194,8 @@ class TestAutoArpa(TestCase):
         self.assertEqual(
             {
                 '4.3.2.1.in-addr.arpa.': [
-                    (999, 'a1.unit.tests.'),
-                    (999, 'a2.unit.tests.'),
+                    (999, 3600, 'a1.unit.tests.'),
+                    (999, 3600, 'a2.unit.tests.'),
                 ]
             },
             {'4.3.2.1.in-addr.arpa.': sorted_records},
@@ -219,7 +219,7 @@ class TestAutoArpa(TestCase):
         aa = AutoArpa('auto-arpa')
         aa.process_source_zone(zone, [])
         self.assertEqual(
-            {'4.3.20.10.in-addr.arpa.': [(999, 'a.unit.tests.')]}, aa._records
+            {'4.3.20.10.in-addr.arpa.': [(999, 3600, 'a.unit.tests.')]}, aa._records
         )
 
         # matching zone
@@ -259,7 +259,7 @@ class TestAutoArpa(TestCase):
         aa = AutoArpa('auto-arpa')
         aa.process_source_zone(zone, [])
         self.assertEqual(
-            {'4.3.2.1.in-addr.arpa.': [(999, 'a with spaces.unit.tests.')]},
+            {'4.3.2.1.in-addr.arpa.': [(999, 3600, 'a with spaces.unit.tests.')]},
             aa._records,
         )
 
@@ -275,18 +275,18 @@ class TestAutoArpa(TestCase):
     def test_arpa_priority(self):
         aa = AutoArpa('auto-arpa')
 
-        duplicate_values = [(999, 'a.unit.tests.'), (1, 'a.unit.tests.')]
+        duplicate_values = [(999, 3600, 'a.unit.tests.'), (1, 3600, 'a.unit.tests.')]
         self.assertEqual(
             ['a.unit.tests.'],
             aa._order_and_unique_fqdns(duplicate_values, max_auto_arpa=999),
         )
 
         duplicate_values = [
-            (50, 'd.unit.tests.'),
-            (999, 'dup.unit.tests.'),
-            (3, 'a.unit.tests.'),
-            (1, 'dup.unit.tests.'),
-            (2, 'c.unit.tests.'),
+            (50, 3600, 'd.unit.tests.'),
+            (999, 3600, 'dup.unit.tests.'),
+            (3, 3600, 'a.unit.tests.'),
+            (1, 3600, 'dup.unit.tests.'),
+            (2, 3600, 'c.unit.tests.'),
         ]
         self.assertEqual(
             [
@@ -298,20 +298,32 @@ class TestAutoArpa(TestCase):
             aa._order_and_unique_fqdns(duplicate_values, max_auto_arpa=999),
         )
 
-        duplicate_values_2 = [(999, 'a.unit.tests.'), (999, 'a.unit.tests.')]
+        duplicate_values_2 = [(999, 3600, 'a.unit.tests.'), (999, 3600, 'a.unit.tests.')]
         self.assertEqual(
             ['a.unit.tests.'],
             aa._order_and_unique_fqdns(duplicate_values_2, max_auto_arpa=999),
         )
 
-        ordered_values = [(999, 'a.unit.tests.'), (1, 'b.unit.tests.')]
+        ordered_values = [(999, 3600, 'a.unit.tests.'), (1, 3600, 'b.unit.tests.')]
         self.assertEqual(
             ['b.unit.tests.', 'a.unit.tests.'],
             aa._order_and_unique_fqdns(ordered_values, max_auto_arpa=999),
         )
 
-        max_one_value = [(999, 'a.unit.tests.'), (1, 'b.unit.tests.')]
+        max_one_value = [(999, 3600, 'a.unit.tests.'), (1, 3600, 'b.unit.tests.')]
         self.assertEqual(
             ['b.unit.tests.'],
             aa._order_and_unique_fqdns(max_one_value, max_auto_arpa=1),
         )
+
+    def test_arpa_inherit_ttl(self):
+        zone = Zone('unit.tests.', [])
+        record = Record.new(
+            zone, 'a1', {'ttl': 32, 'type': 'A', 'value': '1.2.3.4'}
+        )
+        zone.add_record(record)
+
+        aa = AutoArpa('auto-arpa', 3600, 999, True)
+        aa.populate(zone)
+        (ptr,) = zone.records
+        self.assertEqual(32, ptr.ttl)


### PR DESCRIPTION
Hi Ross,

It would be great with some more flexibility for setting the TTL value on AutoArpa PTR records. Right now, it's only possible to set a default value on the auto_arpa provider configuration, which is then used by all records. I would like to be able to set a different value on some of my records.

This pull request adds an optional option, `inherit_ttl`, which takes the TTL value of the corresponding A/AAAA and uses that instead of the default value.

Another possibility could also be to add an `auto_arpa_ttl` option directly on the A/AAAA records, like what we did with `auto_arpa_priority`. But I think it would make more sense to use the same value as the A/AAAA records for the most part.

I hope this feature request makes sense.

Thanks,
William