### PR TITLE
Fix for EnsureTrailingDots reverting value types back to strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
   where lots of changes are expected frequently to live along side zones
   where little or no churn is expected.
 * AutoArpa gained support for prioritizing values
+* Fix for EnsureTrailingDots reverting value types back to strings which then
+  failed when rr methods were used on them (e.g. w/octodns-bind)
 
 ## v1.6.1 - 2024-03-17 - Didn't we do this already
 


### PR DESCRIPTION
The processor was previously altering the types of string-y values by assigning strings over them. Once it was a `str` it no longer supported the rdata methods that providers like bind utilize. This fixes that issue by preserving the value types.

/cc Fixes https://github.com/octodns/octodns/issues/1164 @paxlo  