### PR TITLE
Fix CAA value handling to support tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.?.? - 2024-??-?? - ???
+
+* Fix CAA rdata parsing to allow values with tags
+
 ## v1.7.0 - 2024-04-29 - All the knobs and dials
 
 * Support for specifying per-zone change thresholds, to allow for zones

--- a/octodns/record/caa.py
+++ b/octodns/record/caa.py
@@ -13,7 +13,8 @@ class CaaValue(EqualityTupleMixin, dict):
     @classmethod
     def parse_rdata_text(cls, value):
         try:
-            flags, tag, value = value.split(' ')
+            # value may contain whitepsace
+            flags, tag, value = value.split(' ', 2)
         except ValueError:
             raise RrParseError()
         try:


### PR DESCRIPTION
Fix CAA rdata parsing to allow values with tags/properties. 

/cc https://github.com/octodns/octodns-route53/pull/92 @jmittermair