### PR TITLE
Fix add_record() lenient check to allow managed sub-zone DS records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v1.?.? - 2024-??-?? - ???
 
+* Allow DS records to be specified for managed sub-zones, same as NS
 * Fix CAA rdata parsing to allow values with tags
 
 ## v1.7.0 - 2024-04-29 - All the knobs and dials

--- a/docs/records.md
+++ b/docs/records.md
@@ -10,6 +10,7 @@ octoDNS supports the following record types:
 * `CAA`
 * `CNAME`
 * `DNAME`
+* `DS`
 * `LOC`
 * `MX`
 * `NAPTR`

--- a/octodns/zone.py
+++ b/octodns/zone.py
@@ -150,10 +150,10 @@ class Zone(object):
         if not lenient:
             if name in self.sub_zones:
                 # It's an exact match for a sub-zone
-                if not record._type == 'NS':
-                    # and not a NS record, this should be in the sub
+                if not (record._type == 'NS' or record._type == 'DS'):
+                    # and not a NS or DS record, this should be in the sub
                     raise SubzoneRecordException(
-                        f'Record {record.fqdn} is a managed sub-zone and not of type NS',
+                        f'Record {record.fqdn} is a managed sub-zone and not of type NS or DS',
                         record,
                     )
             else:

--- a/tests/test_octodns_zone.py
+++ b/tests/test_octodns_zone.py
@@ -346,6 +346,91 @@ class TestZone(TestCase):
         zone.add_record(record)
         self.assertEqual(1, len(zone.records))
 
+        # DS record for exactly the sub is allowed
+        zone = Zone('unit.tests.', set(['sub', 'barred']))
+        record = Record.new(
+            zone,
+            'sub',
+            {
+                'ttl': 3600,
+                'type': 'DS',
+                'values': [
+                    {
+                        'key_tag': 60485,
+                        'algorithm': 5,
+                        'digest_type': 1,
+                        'digest': '2BB183AF5F22588179A53B0A 98631FAD1A292118',
+                    },
+                    {
+                        'key_tag': 60485,
+                        'algorithm': 5,
+                        'digest_type': 1,
+                        'digest': '2BB183AF5F22588179A53B0A 98631FAD1A292119',
+                    },
+                ],
+            },
+        )
+        zone.add_record(record)
+        self.assertEqual(set([record]), zone.records)
+
+        # DS record for something below the sub is rejected
+        zone = Zone('unit.tests.', set(['sub', 'barred']))
+        record = Record.new(
+            zone,
+            'foo.bar.sub',
+            {
+                'ttl': 3600,
+                'type': 'DS',
+                'values': [
+                    {
+                        'key_tag': 60485,
+                        'algorithm': 5,
+                        'digest_type': 1,
+                        'digest': '2BB183AF5F22588179A53B0A 98631FAD1A292118',
+                    },
+                    {
+                        'key_tag': 60485,
+                        'algorithm': 5,
+                        'digest_type': 1,
+                        'digest': '2BB183AF5F22588179A53B0A 98631FAD1A292119',
+                    },
+                ],
+            },
+        )
+        with self.assertRaises(SubzoneRecordException) as ctx:
+            zone.add_record(record)
+        self.assertTrue('under a managed sub-zone', str(ctx.exception))
+        # Can add it w/lenient
+        zone.add_record(record, lenient=True)
+        self.assertEqual(set([record]), zone.records)
+
+        # DS record that happens to end with a string that matches a sub (no .) is OK
+        zone = Zone('unit.tests.', set(['sub', 'barred']))
+        record = Record.new(
+            zone,
+            'foo.bar_sub',
+            {
+                'ttl': 3600,
+                'type': 'DS',
+                'values': [
+                    {
+                        'key_tag': 60485,
+                        'algorithm': 5,
+                        'digest_type': 1,
+                        'digest': '2BB183AF5F22588179A53B0A 98631FAD1A292118',
+                    },
+                    {
+                        'key_tag': 60485,
+                        'algorithm': 5,
+                        'digest_type': 1,
+                        'digest': '2BB183AF5F22588179A53B0A 98631FAD1A292119',
+                    },
+                ],
+            },
+        )
+        zone.add_record(record)
+        self.assertEqual(1, len(zone.records))
+
     def test_ignored_records(self):
         zone_normal = Zone('unit.tests.', [])
         zone_ignored = Zone('unit.tests.', [])


### PR DESCRIPTION
Like NS records, it's valid to have a sub-zone record name as zone being managed.
