### PR TITLE
Quick pass at implementing PlanJson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Allow DS records to be specified for managed sub-zones, same as NS
 * Fix CAA rdata parsing to allow values with tags
+* Include `record_type` in Change data
+* Add PlanJson plan_output support
 
 ## v1.7.0 - 2024-04-29 - All the knobs and dials
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 * Improved handling of present, but empty/None config file values.
 * Add PlanJson plan_output support
-
+* Include `record_type` in Change data
+ 
 ## v1.8.0 - 2024-06-10 - Set the records straight
 
 * Add support for SVCB and HTTPS records
 * Allow DS records to be specified for managed sub-zones, same as NS
 * Fix CAA rdata parsing to allow values with tags
-* Include `record_type` in Change data
 
 ## v1.7.0 - 2024-04-29 - All the knobs and dials
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
+## v1.?.? - 2024-??-?? - ???
+
+* Add PlanJson plan_output support
+
 ## v1.8.0 - 2024-06-10 - Set the records straight
 
 * Add support for SVCB and HTTPS records
 * Allow DS records to be specified for managed sub-zones, same as NS
 * Fix CAA rdata parsing to allow values with tags
 * Include `record_type` in Change data
-* Add PlanJson plan_output support
 
 ## v1.7.0 - 2024-04-29 - All the knobs and dials
 

--- a/octodns/provider/plan.py
+++ b/octodns/provider/plan.py
@@ -2,7 +2,9 @@
 #
 #
 
+from collections import defaultdict
 from io import StringIO
+from json import dumps
 from logging import DEBUG, ERROR, INFO, WARN, getLogger
 from sys import stdout
 
@@ -218,6 +220,20 @@ def _value_stringifier(record, sep):
         vs = ', '.join([str(v) for v in gv.values])
         values.append(f'{code}: {vs}')
     return sep.join(values)
+
+
+class PlanJson(_PlanOutput):
+    def __init__(self, name, indent=None, sort_keys=True):
+        super().__init__(name)
+        self.indent = indent
+        self.sort_keys = sort_keys
+
+    def run(self, plans, fh=stdout, *args, **kwargs):
+        data = defaultdict(dict)
+        for target, plan in plans:
+            data[target.id][plan.desired.name] = plan.data
+
+        fh.write(dumps(data, indent=self.indent, sort_keys=self.sort_keys))
 
 
 class PlanMarkdown(_PlanOutput):

--- a/octodns/provider/plan.py
+++ b/octodns/provider/plan.py
@@ -234,6 +234,7 @@ class PlanJson(_PlanOutput):
             data[target.id][plan.desired.name] = plan.data
 
         fh.write(dumps(data, indent=self.indent, sort_keys=self.sort_keys))
+        fh.write('\n')
 
 
 class PlanMarkdown(_PlanOutput):

--- a/octodns/record/change.py
+++ b/octodns/record/change.py
@@ -27,7 +27,11 @@ class Create(Change):
 
     @property
     def data(self):
-        return {'type': 'create', 'new': self.new.data}
+        return {
+            'type': 'create',
+            'new': self.new.data,
+            'record_type': self.new._type,
+        }
 
     def __repr__(self, leader=''):
         source = self.new.source.id if self.new.source else ''
@@ -43,6 +47,7 @@ class Update(Change):
             'type': 'update',
             'existing': self.existing.data,
             'new': self.new.data,
+            'record_type': self.new._type,
         }
 
     # Leader is just to allow us to work around heven eating leading whitespace
@@ -65,7 +70,11 @@ class Delete(Change):
 
     @property
     def data(self):
-        return {'type': 'delete', 'existing': self.existing.data}
+        return {
+            'type': 'delete',
+            'existing': self.existing.data,
+            'record_type': self.existing._type,
+        }
 
     def __repr__(self, leader=''):
         return f'Delete {self.existing}'

--- a/tests/test_octodns_plan.py
+++ b/tests/test_octodns_plan.py
@@ -407,18 +407,25 @@ class TestPlanSafety(TestCase):
         # we'll test the change .data's here while we're at it since they don't
         # have a dedicated test (file)
         delete_data = data['changes'][0]  # delete
-        self.assertEqual(['existing', 'type'], sorted(delete_data.keys()))
+        self.assertEqual(
+            ['existing', 'record_type', 'type'], sorted(delete_data.keys())
+        )
         self.assertEqual('delete', delete_data['type'])
+        self.assertEqual('A', delete_data['record_type'])
         self.assertEqual(delete.existing.data, delete_data['existing'])
 
         create_data = data['changes'][1]  # create
-        self.assertEqual(['new', 'type'], sorted(create_data.keys()))
+        self.assertEqual(
+            ['new', 'record_type', 'type'], sorted(create_data.keys())
+        )
         self.assertEqual('create', create_data['type'])
+        self.assertEqual('CNAME', create_data['record_type'])
         self.assertEqual(create.new.data, create_data['new'])
 
         update_data = data['changes'][3]  # update
         self.assertEqual(
-            ['existing', 'new', 'type'], sorted(update_data.keys())
+            ['existing', 'new', 'record_type', 'type'],
+            sorted(update_data.keys()),
         )
         self.assertEqual('update', update_data['type'])
         self.assertEqual(update.existing.data, update_data['existing'])

--- a/tests/test_octodns_plan.py
+++ b/tests/test_octodns_plan.py
@@ -3,6 +3,7 @@
 #
 
 from io import StringIO
+from json import loads
 from logging import getLogger
 from unittest import TestCase
 
@@ -11,6 +12,7 @@ from helpers import SimpleProvider
 from octodns.provider.plan import (
     Plan,
     PlanHtml,
+    PlanJson,
     PlanLogger,
     PlanMarkdown,
     RootNsChange,
@@ -124,6 +126,17 @@ class TestPlanHtml(TestCase):
             '    <td colspan=6>Summary: Creates=2, Updates=1, '
             'Deletes=1, Existing Records=0</td>' in out
         )
+
+
+class TestPlanJson(TestCase):
+    def test_basics(self):
+        out = StringIO()
+        PlanJson('json').run(plans, fh=out)
+        data = loads(out.getvalue())
+        for key in ('test', 'unit.tests.', 'changes'):
+            self.assertTrue(key in data)
+            data = data[key]
+        self.assertEqual(4, len(data))
 
 
 class TestPlanMarkdown(TestCase):


### PR DESCRIPTION
```yaml
manager:
  plan_outputs:
    json:
      class: octodns.provider.plan.PlanJson
      indent: '  '
```

Plan output schema is `"<target>": "<zone>": "changes"`, default is `indent=None` which would be more easily machine parsable. 

```json
{
  "out": {
    "exxampled.com.": {
      "changes": [
        {
          "new": {
            "ttl": 3600,
            "value": "1.2.3.4"
          },
          "type": "create"
        },
        {
          "new": {
            "ttl": 60,
            "values": [
              "octodns-version=1.7.0",
              "time=2024-06-04T20:59:50.929216+00:00",
              "uuid=c6613a81-2ba9-44ac-b378-9b4c59ffb04c"
            ]
          },
          "type": "create"
        },
        {
          "new": {
            "ttl": 3600,
            "value": "www.foo2."
          },
          "type": "create"
        }
      ]
    }
  }
}
```

/cc Fixes https://github.com/octodns/octodns/issues/1177 @olivergondza 