### PR TITLE
Move HTTPS to its own file, import them in octodns.record

### DIFF
--- a/octodns/record/__init__.py
+++ b/octodns/record/__init__.py
@@ -14,6 +14,7 @@ from .dname import DnameRecord, DnameValue
 from .ds import DsRecord, DsValue
 from .exception import RecordException, ValidationError
 from .geo import GeoCodes, GeoValue
+from .https import HttpsRecord, HttpsValue
 from .loc import LocRecord, LocValue
 from .mx import MxRecord, MxValue
 from .naptr import NaptrRecord, NaptrValue
@@ -23,6 +24,7 @@ from .rr import Rr, RrParseError
 from .spf import SpfRecord
 from .srv import SrvRecord, SrvValue
 from .sshfp import SshfpRecord, SshfpValue
+from .svcb import SvcbRecord, SvcbValue
 from .tlsa import TlsaRecord, TlsaValue
 from .txt import TxtRecord, TxtValue
 from .urlfwd import UrlfwdRecord, UrlfwdValue
@@ -45,6 +47,8 @@ DsRecord
 DsValue
 GeoCodes
 GeoValue
+HttpsRecord
+HttpsValue
 Ipv4Address
 Ipv4Value
 Ipv6Address
@@ -68,6 +72,8 @@ SrvRecord
 SrvValue
 SshfpRecord
 SshfpValue
+SvcbRecord
+SvcbValue
 TlsaRecord
 TlsaValue
 TxtRecord

--- a/octodns/record/https.py
+++ b/octodns/record/https.py
@@ -1,0 +1,19 @@
+#
+# This file describes the HTTPS records as defined in RFC 9460
+# It also supports the 'ech' SvcParam as defined in draft-ietf-tls-svcb-ech-02
+#
+
+from .base import Record, ValuesMixin
+from .svcb import SvcbValue
+
+
+class HttpsValue(SvcbValue):
+    pass
+
+
+class HttpsRecord(ValuesMixin, Record):
+    _type = 'HTTPS'
+    _value_type = HttpsValue
+
+
+Record.register_type(HttpsRecord)

--- a/octodns/record/svcb.py
+++ b/octodns/record/svcb.py
@@ -1,5 +1,5 @@
 #
-# This file describes the SVCB and HTTPS records as defined in RFC 9460
+# This file describes the SVCB records as defined in RFC 9460
 # It also supports the 'ech' SvcParam as defined in draft-ietf-tls-svcb-ech-02
 #
 
@@ -305,10 +305,4 @@ class SvcbRecord(ValuesMixin, Record):
     _value_type = SvcbValue
 
 
-class HttpsRecord(ValuesMixin, Record):
-    _type = 'HTTPS'
-    _value_type = SvcbValue
-
-
 Record.register_type(SvcbRecord)
-Record.register_type(HttpsRecord)


### PR DESCRIPTION
The types need to be imoprted into `octodns.record` so that they're registered and supported by default. Ran into this problem when adding support in https://github.com/octodns/octodns-powerdns/pull/70.

Splitting the HTTPS type out into it's own file is just a minor tweak to make it work/look a little more like all the rest of the types. It also adds a no-op HttpsValue just to make things more consistent.

/cc https://github.com/octodns/octodns-powerdns/pull/70 which lead me to hit part of this.
/cc https://github.com/octodns/octodns/pull/1176 which this builds on/tweaks slightly