### PR TITLE
Version 1.8.0 bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.?.? - 2024-??-?? - ???
+## v1.8.0 - 2024-06-10 - Set the records straight
 
 * Add support for SVCB and HTTPS records
 * Allow DS records to be specified for managed sub-zones, same as NS

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -1,4 +1,4 @@
 'OctoDNS: DNS as code - Tools for managing DNS across multiple providers'
 
 # TODO: remove __VERSION__ w/2.x
-__version__ = __VERSION__ = '1.7.0'
+__version__ = __VERSION__ = '1.8.0'


### PR DESCRIPTION
## v1.8.0 - 2024-06-10 - Set the records straight

* Add support for SVCB and HTTPS records
* Allow DS records to be specified for managed sub-zones, same as NS
* Fix CAA rdata parsing to allow values with tags