### PR TITLE
Add ICMP & UDP healthcheck protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v1.?.? - 2024-??-?? - ???
 
+* ICMP & UDP healthcheck protocol support added
 * Improved handling of present, but empty/None config file values.
 * Add PlanJson plan_output support
 * Include `record_type` in Change data

--- a/tests/test_octodns_record_dynamic.py
+++ b/tests/test_octodns_record_dynamic.py
@@ -82,6 +82,7 @@ class TestRecordDynamic(TestCase):
         )
         self.assertEqual('1.2.3.4', new.healthcheck_host(value="1.2.3.4"))
 
+        # defaults
         new = Record.new(
             self.zone, 'a', {'ttl': 44, 'type': 'A', 'value': '1.2.3.4'}
         )
@@ -89,6 +90,44 @@ class TestRecordDynamic(TestCase):
         self.assertEqual('a.unit.tests', new.healthcheck_host())
         self.assertEqual('HTTPS', new.healthcheck_protocol)
         self.assertEqual(443, new.healthcheck_port)
+
+    def test_healthcheck_icmp(self):
+        new = Record.new(
+            self.zone,
+            'a',
+            {
+                'ttl': 44,
+                'type': 'A',
+                'value': '1.2.3.4',
+                'octodns': {
+                    'healthcheck': {
+                        'path': '/ignored',
+                        'host': 'completely.ignored',
+                        'protocol': 'ICMP',
+                        'port': -99,
+                    }
+                },
+            },
+        )
+        self.assertIsNone(new.healthcheck_path)
+        self.assertIsNone(new.healthcheck_host())
+        self.assertEqual('ICMP', new.healthcheck_protocol)
+        self.assertIsNone(new.healthcheck_port)
+
+        new = Record.new(
+            self.zone,
+            'a',
+            {
+                'ttl': 44,
+                'type': 'A',
+                'value': '1.2.3.4',
+                'octodns': {'healthcheck': {'protocol': 'ICMP'}},
+            },
+        )
+        self.assertIsNone(new.healthcheck_path)
+        self.assertIsNone(new.healthcheck_host())
+        self.assertEqual('ICMP', new.healthcheck_protocol)
+        self.assertIsNone(new.healthcheck_port)
 
     def test_healthcheck_tcp(self):
         new = Record.new(
@@ -126,6 +165,44 @@ class TestRecordDynamic(TestCase):
         self.assertIsNone(new.healthcheck_path)
         self.assertIsNone(new.healthcheck_host())
         self.assertEqual('TCP', new.healthcheck_protocol)
+        self.assertEqual(443, new.healthcheck_port)
+
+    def test_healthcheck_udp(self):
+        new = Record.new(
+            self.zone,
+            'a',
+            {
+                'ttl': 44,
+                'type': 'A',
+                'value': '1.2.3.4',
+                'octodns': {
+                    'healthcheck': {
+                        'path': '/ignored',
+                        'host': 'completely.ignored',
+                        'protocol': 'UDP',
+                        'port': 8081,
+                    }
+                },
+            },
+        )
+        self.assertIsNone(new.healthcheck_path)
+        self.assertIsNone(new.healthcheck_host())
+        self.assertEqual('UDP', new.healthcheck_protocol)
+        self.assertEqual(8081, new.healthcheck_port)
+
+        new = Record.new(
+            self.zone,
+            'a',
+            {
+                'ttl': 44,
+                'type': 'A',
+                'value': '1.2.3.4',
+                'octodns': {'healthcheck': {'protocol': 'UDP'}},
+            },
+        )
+        self.assertIsNone(new.healthcheck_path)
+        self.assertIsNone(new.healthcheck_host())
+        self.assertEqual('UDP', new.healthcheck_protocol)
         self.assertEqual(443, new.healthcheck_port)
 
     def test_simple_a_weighted(self):


### PR DESCRIPTION
See https://github.com/octodns/octodns-edgecenter/pull/29#issuecomment-2175969883 for some related background & research

/cc https://github.com/octodns/octodns-edgecenter/pull/29#issuecomment-2175969883 which lead to these being added @Beellzebub