### PR TITLE
Add `name` to Change.data, and thus PlanJson output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.9.? - 2024-??-?? - ???
+
+* Add `name` to Change.data, and thus PlanJson output
+
 ## v1.9.0 - 2024-06-20 - Grab bag
 
 * ICMP & UDP healthcheck protocol support added

--- a/octodns/record/change.py
+++ b/octodns/record/change.py
@@ -29,6 +29,7 @@ class Create(Change):
     def data(self):
         return {
             'type': 'create',
+            'name': self.new.name,
             'new': self.new.data,
             'record_type': self.new._type,
         }
@@ -46,6 +47,7 @@ class Update(Change):
         return {
             'type': 'update',
             'existing': self.existing.data,
+            'name': self.new.name,
             'new': self.new.data,
             'record_type': self.new._type,
         }
@@ -73,6 +75,7 @@ class Delete(Change):
         return {
             'type': 'delete',
             'existing': self.existing.data,
+            'name': self.existing.name,
             'record_type': self.existing._type,
         }
 

--- a/tests/test_octodns_plan.py
+++ b/tests/test_octodns_plan.py
@@ -408,7 +408,8 @@ class TestPlanSafety(TestCase):
         # have a dedicated test (file)
         delete_data = data['changes'][0]  # delete
         self.assertEqual(
-            ['existing', 'record_type', 'type'], sorted(delete_data.keys())
+            ['existing', 'name', 'record_type', 'type'],
+            sorted(delete_data.keys()),
         )
         self.assertEqual('delete', delete_data['type'])
         self.assertEqual('A', delete_data['record_type'])
@@ -416,7 +417,7 @@ class TestPlanSafety(TestCase):
 
         create_data = data['changes'][1]  # create
         self.assertEqual(
-            ['new', 'record_type', 'type'], sorted(create_data.keys())
+            ['name', 'new', 'record_type', 'type'], sorted(create_data.keys())
         )
         self.assertEqual('create', create_data['type'])
         self.assertEqual('CNAME', create_data['record_type'])
@@ -424,7 +425,7 @@ class TestPlanSafety(TestCase):
 
         update_data = data['changes'][3]  # update
         self.assertEqual(
-            ['existing', 'new', 'record_type', 'type'],
+            ['existing', 'name', 'new', 'record_type', 'type'],
             sorted(update_data.keys()),
         )
         self.assertEqual('update', update_data['type'])


### PR DESCRIPTION
```js
{
  "out": {
    "exxampled.com.": {
      "changes": [
        {
          "name": "foo.exxampled.com",
          "new": {
            "ttl": 3600,
            "value": "1.2.3.4"
          },
          "record_type": "A",
          "type": "create"
        },
        {
          "name": "meta",
          "new": {
            "ttl": 60,
            "values": [
              "octodns-version=1.9.0",
              "time=2024-06-21T22:25:13.494773+00:00",
              "uuid=9d9eb776-8af8-4a73-838d-18522ab63c51"
            ]
          },
          "record_type": "TXT",
          "type": "create"
        },
        {
          "name": "relative",
          "new": {
            "ttl": 3600,
            "value": "www.foo2."
          },
          "record_type": "CNAME",
          "type": "create"
        },
        {
          "name": "txt",
          "new": {
            "ttl": 3600,
            "value": "This is a TXT record with \"quotes\" in it to ensure they are handled correctly"
          },
          "record_type": "TXT",
          "type": "create"
        }
      ]
    }
  }
}
```

/cc https://github.com/octodns/octodns/issues/1177#issuecomment-2183417542 @mrwillrobbins