### PR TITLE
Fix handling of chunked values (TXT) when escapes land on boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * MetaProcessor.include_extra to add support for arbitrary extra values to be
   set on the meta record.
 * Correctly handled quoted svcparams when parsing SVCB/HTTPS rdata text
+* Fix handling of chunked values (TXT, SPF) when escaped characters land at the
+  split boundaries, don't split escapes from their following chars
 
 ## v1.9.1 - 2024-06-21 - What's in a name
 

--- a/octodns/record/chunked.py
+++ b/octodns/record/chunked.py
@@ -13,10 +13,20 @@ class _ChunkedValuesMixin(ValuesMixin):
 
     def chunked_value(self, value):
         value = value.replace('"', '\\"')
-        vs = [
-            value[i : i + self.CHUNK_SIZE]
-            for i in range(0, len(value), self.CHUNK_SIZE)
-        ]
+        vs = []
+        i = 0
+        n = len(value)
+        # until we've processed the whole string
+        while i < n:
+            # start with a full chunk size
+            c = min(self.CHUNK_SIZE, n - i)
+            # make sure that we don't break on escape chars
+            while value[i + c - 1] == '\\':
+                c -= 1
+            # we have our chunk now
+            vs.append(value[i : i + c])
+            # and can step over if
+            i += c
         vs = '" "'.join(vs)
         return self._value_type(f'"{vs}"')
 


### PR DESCRIPTION
Details of the issue in https://github.com/octodns/octodns/issues/1196

/cc Fixes https://github.com/octodns/octodns/issues/1196 @tomotaro-uejima  