### PR TITLE
add desec provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ The table below lists the providers octoDNS supports. They are maintained in the
 | [TransIP](https://www.transip.eu/knowledgebase/entry/155-dns-and-nameservers/) | [octodns_transip](https://github.com/octodns/octodns-transip/) | |
 | [UltraDNS](https://vercara.com/authoritative-dns) | [octodns_ultra](https://github.com/octodns/octodns-ultra/) | |
 | [YamlProvider](/octodns/provider/yaml.py) | built-in | Supports all record types and core functionality |
+| [deSEC](https://desec.io/) | [octodns_desec](tbd) | |
 
 ### Updating to use extracted providers
 


### PR DESCRIPTION
https://github.com/TilCreator/octodns-desec

This PR is to show our (@blackdotraven and me) ongoing work on a octodns provider for deSEC.

The current state is working, but is still missing tests and some better handling of some API errors or similar. 

The Github namespace is still to be determined, depends on who wants to maintain the provider (candidates are octodns, desec-io or us)