### PR TITLE
Add python 3.13, remove 3.8

### DIFF
--- a/.ci-config.json
+++ b/.ci-config.json
@@ -1,4 +1,4 @@
 {
-  "python_version_current": "3.12",
-  "python_versions_active": ["3.8", "3.9", "3.10", "3.11", "3.12"]
+  "python_version_current": "3.13",
+  "python_versions_active": ["3.9", "3.10", "3.11", "3.12", "3.13"]
 }


### PR DESCRIPTION
3.13 has been released and 3.8 has gone out of its security window.

/cc https://devguide.python.org/versions/