### PR TITLE
YamlProvider rework to be fully plan and apply compliant

### DIFF
--- a/octodns/provider/yaml.py
+++ b/octodns/provider/yaml.py
@@ -342,11 +342,6 @@ class YamlProvider(BaseProvider):
             lenient,
         )
 
-        if target:
-            # When acting as a target we ignore any existing records so that we
-            # create a completely new copy
-            return False
-
         before = len(zone.records)
 
         sources = []
@@ -363,20 +358,22 @@ class YamlProvider(BaseProvider):
         if self.shared_filename:
             sources.append(join(self.directory, self.shared_filename))
 
-        if not sources:
+        if not sources and not target:
             raise ProviderException(f'no YAMLs found for {zone.decoded_name}')
 
-        # determinstically order our sources
+        # deterministically order our sources
         sources.sort()
 
         for source in sources:
             self._populate_from_file(source, zone, lenient)
 
+        exists = len(sources) > 0
         self.log.info(
-            'populate:   found %s records, exists=False',
+            'populate:   found %s records, exists=%s',
             len(zone.records) - before,
+            exists,
         )
-        return False
+        return exists
 
     def _apply(self, plan):
         # make a copy of existing we can muck with

--- a/octodns/provider/yaml.py
+++ b/octodns/provider/yaml.py
@@ -73,6 +73,12 @@ class YamlProvider(BaseProvider):
         # (optional, default False)
         disable_zonefile: false
 
+    Note
+    ----
+
+    When using this provider as a target any existing comments or formatting
+    in the zone files will be lost when changes are applyed.
+
     Split Details
     -------------
 

--- a/octodns/zone.py
+++ b/octodns/zone.py
@@ -340,6 +340,16 @@ class Zone(object):
 
         return changes
 
+    def apply(self, changes):
+        '''
+        Apply the provided changes to the zone.
+        '''
+        for change in changes:
+            if isinstance(change, Delete):
+                self.remove_record(change.existing)
+            else:
+                self.add_record(change.new, replace=True, lenient=True)
+
     def hydrate(self):
         '''
         Take a shallow copy Zone and make it a deeper copy holding its own

--- a/tests/test_octodns_zone.py
+++ b/tests/test_octodns_zone.py
@@ -179,6 +179,9 @@ class TestZone(TestCase):
 
         # before == after -> no changes
         self.assertFalse(before.changes(after, target))
+        copy = before.copy()
+        copy.apply([])
+        self.assertEqual(copy.records, before.records)
 
         # add a record, delete a record -> [Delete, Create]
         c = ARecord(before, 'c', {'ttl': 42, 'value': '1.1.1.1'})
@@ -198,6 +201,15 @@ class TestZone(TestCase):
         self.assertFalse(create.existing)
         delete.__repr__()
         create.__repr__()
+
+        # make a copy of before
+        copy = before.copy()
+        # apply the changes to it
+        copy.apply(changes)
+        # copy should not match it's origin any longer
+        self.assertNotEqual(copy.records, before.records)
+        # and it should now match the target
+        self.assertEqual(copy.records, after.records)
 
         after = Zone('unit.tests.', [])
         changed = ARecord(before, 'a', {'ttl': 42, 'value': '2.2.2.2'})


### PR DESCRIPTION

On the 🚌 today I realized there was actually a way to pull off a YamlProvider that fully complies with the provider spec/behavior. When things were first written the infrastructure to do this cleanly wasn't yet in place, but it is now.

The main caveot here is that any existing comments or formatting in the YAML file will be overwritten, but otherwise this should be fully spec compliant and result in a true plan when syncing to a YamlProvider as well as support syncing an empty zone into it.

The changes are actually fairly small and self contained. There were a decent number of tests that were previously making assumptions based on the `populate(target=True)` results in an empty zone. Most of the changes here are around that. 

/cc https://github.com/octodns/octodns/issues/1222 which lead to me thinking about this and coding up these changes.