### PR TITLE
Add Plan.meta support for making non-record changes to zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   the default when enforce_order=True and simple `sort`.
 * Fix type-o in _build_kwargs handler notification
 * Add support for configuring OwnershipProcessor TXT record's TTL
+* Add Plan.meta to allow providers to indicate they need to make changes to the
+  zone that are not record specific
 
 ## v1.10.0 - 2024-10-06 - Lots of little stuff
 

--- a/octodns/provider/base.py
+++ b/octodns/provider/base.py
@@ -217,8 +217,10 @@ class BaseProvider(BaseSource):
     def _plan_meta(self, existing, desired, changes):
         '''
         An opportunity for providers to indicate they have "meta" changes
-        to the zone which are unrelated to records. Examples may include servive
-        plan changes, replication settings, and notes.
+        to the zone which are unrelated to records. Examples may include service
+        plan changes, replication settings, and notes. The returned data is
+        arbitrary/opaque to octoDNS, with the only requirement being that
+        pprint.pformat can display it. A dict is recommended.
         '''
         return None
 

--- a/octodns/provider/base.py
+++ b/octodns/provider/base.py
@@ -214,6 +214,14 @@ class BaseProvider(BaseSource):
         '''
         return []
 
+    def _plan_meta(self, existing, desired, changes):
+        '''
+        An opportunity for providers to indicate they have "meta" changes
+        to the zone which are unrelated to records. Examples may include servive
+        plan changes, replication settings, and notes.
+        '''
+        return None
+
     def supports_warn_or_except(self, msg, fallback):
         if self.strict_supports:
             raise SupportsException(f'{self.id}: {msg}')
@@ -269,14 +277,19 @@ class BaseProvider(BaseSource):
             )
             changes += extra
 
-        if changes:
+        meta = self._plan_meta(
+            existing=existing, desired=desired, changes=changes
+        )
+
+        if changes or meta:
             plan = Plan(
                 existing,
                 desired,
                 changes,
                 exists,
-                self.update_pcent_threshold,
-                self.delete_pcent_threshold,
+                update_pcent_threshold=self.update_pcent_threshold,
+                delete_pcent_threshold=self.delete_pcent_threshold,
+                meta=meta,
             )
             self.log.info('plan:   %s', plan)
             return plan

--- a/tests/test_octodns_plan.py
+++ b/tests/test_octodns_plan.py
@@ -64,6 +64,7 @@ changes = [create, create2, delete, update]
 plans = [
     (simple, Plan(zone, zone, changes, True)),
     (simple, Plan(zone, zone, changes, False)),
+    (simple, Plan(zone, zone, changes, False, meta={'key': 'val'})),
 ]
 
 
@@ -105,8 +106,8 @@ class TestPlanLogger(TestCase):
         PlanLogger('logger').run(log, plans)
         out = log.out.getvalue()
         self.assertTrue(
-            'Summary: Creates=2, Updates=1, '
-            'Deletes=1, Existing Records=0' in out
+            'Summary: Creates=2, Updates=1, Deletes=1, Existing=0, Meta=False'
+            in out
         )
 
 
@@ -123,8 +124,8 @@ class TestPlanHtml(TestCase):
         PlanHtml('html').run(plans, fh=out)
         out = out.getvalue()
         self.assertTrue(
-            '    <td colspan=6>Summary: Creates=2, Updates=1, '
-            'Deletes=1, Existing Records=0</td>' in out
+            '    <td colspan=6>Summary: Creates=2, Updates=1, Deletes=1, Existing=0, Meta=False</td>'
+            in out
         )
 
 
@@ -398,7 +399,7 @@ class TestPlanSafety(TestCase):
     def test_data(self):
         data = plans[0][1].data
         # plans should have a single key, changes
-        self.assertEqual(('changes',), tuple(data.keys()))
+        self.assertEqual(('changes', 'meta'), tuple(data.keys()))
         # it should be a list
         self.assertIsInstance(data['changes'], list)
         # w/4 elements

--- a/tests/test_octodns_provider_base.py
+++ b/tests/test_octodns_provider_base.py
@@ -177,6 +177,29 @@ class TestBaseProvider(TestCase):
         plan = provider.plan(ignored)
         self.assertTrue(plan)
         self.assertEqual(1, len(plan.changes))
+        self.assertIsNone(plan.meta)
+
+    def test_plan_meta(self):
+        class HasMetaProvider(HelperProvider):
+            def _plan_meta(self, *args, **kwargs):
+                return 42
+
+        provider = HasMetaProvider([])
+        ignored = Zone('unit.tests.', [])
+        # we will get a plan even without any changes b/c there's a meta change
+        plan = provider.plan(ignored)
+        self.assertTrue(plan)
+        self.assertEqual(42, plan.meta)
+
+        # with a change we get meta & and change
+        record = Record.new(
+            ignored, 'a', {'ttl': 30, 'type': 'A', 'value': '1.2.3.4'}
+        )
+        provider = HasMetaProvider([Create(record)])
+        plan = provider.plan(ignored)
+        self.assertTrue(plan)
+        self.assertEqual(1, len(plan.changes))
+        self.assertEqual(42, plan.meta)
 
     def test_plan_with_process_desired_zone_kwarg_fallback(self):
         ignored = Zone('unit.tests.', [])


### PR DESCRIPTION
Adds support for providers to indicate they have meta changes that need to be made to a zone outside of any records. This should allow them to manage and modify things like Cloudflare's plan as was being worked on in https://github.com/octodns/octodns-cloudflare/pull/123

/cc https://github.com/octodns/octodns-cloudflare/pull/123 @oikarinen which lead to this being created