### PR TITLE
Version 1.11.0 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.?.? - 2024-??-?? - ???
+## v1.11.0 - 2025-02-03 - Cleanup & deprecations with meta planning
 
 * Deprecation warning for Source.populate w/o the lenient param, to be removed
   in 2.x

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -1,4 +1,4 @@
 'OctoDNS: DNS as code - Tools for managing DNS across multiple providers'
 
 # TODO: remove __VERSION__ w/2.x
-__version__ = __VERSION__ = '1.10.0'
+__version__ = __VERSION__ = '1.11.0'


### PR DESCRIPTION
## v1.11.0 - 2025-02-03 - Cleanup & deprecations with meta planning

* Deprecation warning for Source.populate w/o the lenient param, to be removed
  in 2.x
* Deprecation warning for Provider.populate w/o the processors param, to be
  removed in 2.x
* Add YamlProvider.order_mode to allow picking between natural (human)
  the default when enforce_order=True and simple `sort`.
* Fix type-o in _build_kwargs handler notification
* Add support for configuring OwnershipProcessor TXT record's TTL
* Add Plan.meta to allow providers to indicate they need to make changes to the
  zone that are not record specific