### PR TITLE
docs: update README with custom pi-hole provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ If you have a problem or suggestion, please [open an issue](https://github.com/o
   - [`jcollie/octodns-netbox-dns`](https://github.com/jcollie/octodns-netbox-dns): [NetBox-DNS Plugin](https://github.com/auroraresearchlab/netbox-dns) provider.
   - [`kompetenzbolzen/octodns-custom-provider`](https://github.com/kompetenzbolzen/octodns-custom-provider): zonefile provider & phpIPAM source.
   - [`Financial-Times/octodns-fastly`](https://github.com/Financial-Times/octodns-fastly): An octoDNS source for Fastly.
+  - [`jvoss/octodns-pihole`](https://github.com/jvoss/octodns-pihole): [Pi-hole](https://pi-hole.net/) provider.
 - **Resources.**
   - Article: [Visualising DNS records with Neo4j](https://medium.com/@costask/querying-and-visualising-octodns-records-with-neo4j-f4f72ab2d474) + code
   - Video: [FOSDEM 2019 - DNS as code with octodns](https://archive.fosdem.org/2019/schedule/event/dns_octodns/)


### PR DESCRIPTION
Adding [octodns-pihole](https://github.com/jvoss/octodns-pihole) to the list of custom providers.

I have created a simple [Pi-hole](https://pi-hole.net/) provider to sync A/AAAA and CNAME records with Pi-hole's built in `Local DNS Records`. I am open to transferring this provider to the OctoDNS organization if interested.

The provider is compatible with the newly released Pi-hole version 6 and includes a `docker-compose.yml` and example environment to support easy [local development](https://github.com/jvoss/octodns-pihole?tab=readme-ov-file#development).

