### PR TITLE
Ns1 filter chain patch

### DIFF
--- a/octodns/processor/filter.py
+++ b/octodns/processor/filter.py
@@ -234,8 +234,10 @@ class _ValueBaseFilter(_FilterProcessor):
             if hasattr(record, 'values'):
                 values = [value.rdata_text for value in record.values]
             else:
-                values = [record.value.rdata_text]
-
+                try:
+                    values = [record.value.rdata_text]
+                except AttributeError:
+                    self.log.warning(f"Record value is NoneType: {record.fqdn}")
             if any(value in self.exact for value in values):
                 self.matches(zone, record)
                 continue
@@ -317,6 +319,7 @@ class ValueRejectlistFilter(_ValueBaseFilter, RejectsMixin):
     '''
 
     def __init__(self, name, rejectlist):
+        self.log = getLogger(f'ValueRejectlistFilter[{name}]')
         super().__init__(name, rejectlist)
 
 

--- a/octodns/processor/filter.py
+++ b/octodns/processor/filter.py
@@ -233,13 +233,13 @@ class _ValueBaseFilter(_FilterProcessor):
             values = []
             if hasattr(record, 'values'):
                 values = [value.rdata_text for value in record.values]
+            elif record.value is not None:
+                values = [record.value.rdata_text]
             else:
-                try:
-                    values = [record.value.rdata_text]
-                except AttributeError:
-                    self.log.warning(
-                        f"Value processor ignoring record, value is NoneType: {record.fqdn}"
-                    )
+                self.log.warning(
+                    'value for %s is NoneType, ignoring', record.fqdn
+                )
+
             if any(value in self.exact for value in values):
                 self.matches(zone, record)
                 continue

--- a/octodns/processor/filter.py
+++ b/octodns/processor/filter.py
@@ -237,7 +237,9 @@ class _ValueBaseFilter(_FilterProcessor):
                 try:
                     values = [record.value.rdata_text]
                 except AttributeError:
-                    self.log.warning(f"Record value is NoneType: {record.fqdn}")
+                    self.log.warning(
+                        f"Value processor ignoring record, value is NoneType: {record.fqdn}"
+                    )
             if any(value in self.exact for value in values):
                 self.matches(zone, record)
                 continue

--- a/octodns/processor/filter.py
+++ b/octodns/processor/filter.py
@@ -283,6 +283,7 @@ class ValueAllowlistFilter(_ValueBaseFilter, AllowsMixin):
     '''
 
     def __init__(self, name, allowlist):
+        self.log = getLogger(f'ValueAllowlistFilter[{name}]')
         super().__init__(name, allowlist)
 
 

--- a/tests/test_octodns_processor_filter.py
+++ b/tests/test_octodns_processor_filter.py
@@ -319,7 +319,13 @@ class TestValueRejectListFilter(TestCase):
         filtered = rejects.process_source_zone(self.zone.copy())
         self.assertEqual(5, len(filtered.records))
         self.assertEqual(
-            ['bad.compare', 'bad.values', 'first.regex', 'no.values', 'second.regex'],
+            [
+                'bad.compare',
+                'bad.values',
+                'first.regex',
+                'no.values',
+                'second.regex',
+            ],
             sorted([r.name for r in filtered.records]),
         )
 
@@ -330,7 +336,13 @@ class TestValueRejectListFilter(TestCase):
         filtered = rejects.process_source_zone(self.zone.copy())
         self.assertEqual(5, len(filtered.records))
         self.assertEqual(
-            ['bad.compare', 'bad.values', 'good.compare', 'good.values', 'no.values'],
+            [
+                'bad.compare',
+                'bad.values',
+                'good.compare',
+                'good.values',
+                'no.values',
+            ],
             sorted([r.name for r in filtered.records]),
         )
 

--- a/tests/test_octodns_processor_filter.py
+++ b/tests/test_octodns_processor_filter.py
@@ -227,11 +227,18 @@ class TestValueAllowListFilter(TestCase):
         {'type': 'CNAME', 'ttl': 42, 'value': 'start.a3b444c.end.'},
     )
     zone.add_record(matchable2)
+    empty_val = Record.new(
+        zone,
+        'no.values',
+        {'type': 'CNAME', 'ttl': 42, 'value': None},
+        lenient=True,
+    )
+    zone.add_record(empty_val)
 
     def test_exact(self):
         allows = ValueAllowlistFilter('exact', ('matches.example.com.',))
 
-        self.assertEqual(6, len(self.zone.records))
+        self.assertEqual(7, len(self.zone.records))
         filtered = allows.process_source_zone(self.zone.copy())
         self.assertEqual(2, len(filtered.records))
         self.assertEqual(
@@ -242,7 +249,7 @@ class TestValueAllowListFilter(TestCase):
     def test_regex(self):
         allows = ValueAllowlistFilter('exact', ('/^start\\..+\\.end\\.$/',))
 
-        self.assertEqual(6, len(self.zone.records))
+        self.assertEqual(7, len(self.zone.records))
         filtered = allows.process_source_zone(self.zone.copy())
         self.assertEqual(2, len(filtered.records))
         self.assertEqual(
@@ -297,26 +304,33 @@ class TestValueRejectListFilter(TestCase):
         {'type': 'CNAME', 'ttl': 42, 'value': 'start.a3b444c.end.'},
     )
     zone.add_record(matchable2)
+    empty_val = Record.new(
+        zone,
+        'no.values',
+        {'type': 'CNAME', 'ttl': 42, 'value': None},
+        lenient=True,
+    )
+    zone.add_record(empty_val)
 
     def test_exact(self):
         rejects = ValueRejectlistFilter('exact', ('matches.example.com.',))
 
-        self.assertEqual(6, len(self.zone.records))
+        self.assertEqual(7, len(self.zone.records))
         filtered = rejects.process_source_zone(self.zone.copy())
-        self.assertEqual(4, len(filtered.records))
+        self.assertEqual(5, len(filtered.records))
         self.assertEqual(
-            ['bad.compare', 'bad.values', 'first.regex', 'second.regex'],
+            ['bad.compare', 'bad.values', 'first.regex', 'no.values', 'second.regex'],
             sorted([r.name for r in filtered.records]),
         )
 
     def test_regex(self):
         rejects = ValueRejectlistFilter('exact', ('/^start\\..+\\.end\\.$/',))
 
-        self.assertEqual(6, len(self.zone.records))
+        self.assertEqual(7, len(self.zone.records))
         filtered = rejects.process_source_zone(self.zone.copy())
-        self.assertEqual(4, len(filtered.records))
+        self.assertEqual(5, len(filtered.records))
         self.assertEqual(
-            ['bad.compare', 'bad.values', 'good.compare', 'good.values'],
+            ['bad.compare', 'bad.values', 'good.compare', 'good.values', 'no.values'],
             sorted([r.name for r in filtered.records]),
         )
 


### PR DESCRIPTION
In OctoDNS NS1, filter chain records are created as lenient null records with no values associated with them. When also using a value filter processor this caused OctoDNS to crash as there was no value to parse, even when the record is lenient. I added a warning for when a value filter tries to process a null record, and then ignores the record. If the record is not lenient then OctoDNS will not allow a blank record so this does not cause issues with creating invalid records.