### PR TITLE
Fix typo in AcmeManagingProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.11.? - 2025-??-?? - ???
+
+* Correct type-o in name of AcmeManagingProcessor, backwards compatible alias
+  in place
+
 ## v1.11.0 - 2025-02-03 - Cleanup & deprecations with meta planning
 
 * Deprecation warning for Source.populate w/o the lenient param, to be removed

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Similar to providers, but can only serve to populate records into a zone, cannot
 
 | Processor | Description |
 |--|--|
-| [AcmeMangingProcessor](/octodns/processor/acme.py) | Useful when processes external to octoDNS are managing acme challenge DNS records, e.g. LetsEncrypt |
+| [AcmeManagingProcessor](/octodns/processor/acme.py) | Useful when processes external to octoDNS are managing acme challenge DNS records, e.g. LetsEncrypt |
 | [AutoArpa](/octodns/processor/arpa.py) | See [Automatic PTR generation](#automatic-ptr-generation) below |
 | [EnsureTrailingDots](/octodns/processor/trailing_dots.py) | Processor that ensures ALIAS, CNAME, DNAME, MX, NS, PTR, and SRVs have trailing dots |
 | [ExcludeRootNsChanges](/octodns/processor/filter.py) | Filter that errors or warns on planned root/APEX NS records changes. |

--- a/octodns/processor/acme.py
+++ b/octodns/processor/acme.py
@@ -59,3 +59,6 @@ class AcmeManagingProcessor(BaseProcessor):
                 existing.remove_record(record)
 
         return existing
+
+
+AcmeMangingProcessor = AcmeManagingProcessor

--- a/octodns/processor/acme.py
+++ b/octodns/processor/acme.py
@@ -7,14 +7,14 @@ from logging import getLogger
 from .base import BaseProcessor
 
 
-class AcmeMangingProcessor(BaseProcessor):
-    log = getLogger('AcmeMangingProcessor')
+class AcmeManagingProcessor(BaseProcessor):
+    log = getLogger('AcmeManagingProcessor')
 
     def __init__(self, name):
         '''
         processors:
           acme:
-            class: octodns.processor.acme.AcmeMangingProcessor
+            class: octodns.processor.acme.AcmeManagingProcessor
 
         ...
 

--- a/tests/test_octodns_processor_acme.py
+++ b/tests/test_octodns_processor_acme.py
@@ -4,7 +4,7 @@
 
 from unittest import TestCase
 
-from octodns.processor.acme import AcmeMangingProcessor
+from octodns.processor.acme import AcmeManagingProcessor
 from octodns.record import Record
 from octodns.zone import Zone
 
@@ -46,9 +46,9 @@ records = {
 }
 
 
-class TestAcmeMangingProcessor(TestCase):
+class TestAcmeManagingProcessor(TestCase):
     def test_process_zones(self):
-        acme = AcmeMangingProcessor('acme')
+        acme = AcmeManagingProcessor('acme')
 
         source = Zone(zone.name, [])
         # Unrelated stuff that should be untouched


### PR DESCRIPTION
There appears to be a typo in the name of the ACME processor.

Renames "AcmeMangingProcessor" to "AcmeManagingProcessor".