### PR TITLE
Pass at adding a changelog management script/system

### DIFF
--- a/.changelog/acc2596fb367494db070e6c06abf705a.md
+++ b/.changelog/acc2596fb367494db070e6c06abf705a.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Adding changelog management infra and doc

--- a/.changelog/acc2596fb367494db070e6c06abf705a.md
+++ b/.changelog/acc2596fb367494db070e6c06abf705a.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+Adding changelog management infra and doc

--- a/.git_hooks_pre-commit
+++ b/.git_hooks_pre-commit
@@ -10,3 +10,4 @@ ROOT=$(dirname "$GIT")
 "$ROOT/script/lint"
 "$ROOT/script/format" --check --quiet || (echo "Formatting check failed, run ./script/format" && exit 1)
 "$ROOT/script/coverage"
+"$ROOT/script/changelog" check

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,28 @@
+name: OctoDNS Changelog
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  config:
+    runs-on: ubuntu-latest
+    outputs:
+      json: ${{ steps.load.outputs.json }}
+    steps:
+    - uses: actions/checkout@v4
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Changelog Check
+        run: |
+          ./script/changelog check

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        ref: main
       - name: Setup python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
-        ref: main
+      - name: Fetch main
+        run: git fetch origin main --depth 1
       - name: Setup python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,12 +4,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  config:
-    runs-on: ubuntu-latest
-    outputs:
-      json: ${{ steps.load.outputs.json }}
-    steps:
-    - uses: actions/checkout@v4
   changelog:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,11 @@ This project uses the [GitHub Flow](https://guides.github.com/introduction/flow/
 0. Create a new branch: `git checkout -b my-branch-name`
 0. Make your change, add tests, and make sure the tests still pass
 0. Make sure that `./script/lint` passes without any warnings
+0. Run `./script/format` to make sure your changes follow Python's preferred
+   coding style
+0. Run `./script/changelog create ...` to add a changelog entry to your PR
 0. Make sure that coverage is at :100:% `./script/coverage` and open `htmlcov/index.html`
-   * You can open PRs for :eyes: & discussion prior to this
+   * You can open a draft PR for :eyes: & discussion prior to this
 0. Push to your fork and submit a pull request
 
 We will handle updating the version, tagging the release, and releasing the gem. Please don't bump the version or otherwise attempt to take on these administrative internal tasks as part of your pull request.

--- a/script/changelog
+++ b/script/changelog
@@ -1,7 +1,238 @@
-#!/bin/bash
+#!/usr/bin/env python
 
-set -e
+from argparse import ArgumentParser
+from datetime import datetime
+from importlib import import_module
+from io import StringIO
+from json import loads
+from os import getcwd, listdir, makedirs
+from os.path import basename, isdir, join
+from subprocess import PIPE, run
+from sys import argv, exit, path
+from uuid import uuid4
 
-VERSION=v$(grep __version__ octodns/__init__.py | sed -e "s/^[^']*'//" -e "s/'$//")
-echo $VERSION
-git log --pretty="%h - %cr - %s (%an)" "${VERSION}..HEAD"
+from yaml import safe_load_all
+
+
+def create(argv):
+    prog = basename(argv.pop(0))
+    parser = ArgumentParser(
+        prog=f'{prog} create',
+        description='TODO: description',
+        epilog='TODO: epilog',
+        add_help=True,
+    )
+
+    parser.add_argument(
+        '-t',
+        '--type',
+        choices=('none', 'patch', 'minor', 'major'),
+        required=True,
+        help='TODO: type',
+    )
+    parser.add_argument('md', metavar='change-description-markdown', nargs='+')
+
+    args = parser.parse_args(argv)
+
+    if not isdir('.changelog'):
+        makedirs('.changelog')
+    with open(join('.changelog', f'{uuid4().hex}.md'), 'w') as fh:
+        fh.write('---\ntype: ')
+        fh.write(args.type)
+        fh.write('\n---\n')
+        fh.write(' '.join(args.md))
+
+
+def check(argv):
+    if isdir('.changelog'):
+        result = run(
+            ['git', 'diff', '--name-only', 'origin/main', '.changelog/'],
+            check=False,
+            stdout=PIPE,
+        )
+        if not result.returncode and result.stdout != b'':
+            exit(0)
+
+    print(
+        'PR is missing required changelog file, run ./script/changelog create'
+    )
+    exit(1)
+
+
+def _get_current_version(module_name):
+    cwd = getcwd()
+    path.append(cwd)
+    module = import_module(module_name)
+    return tuple(int(v) for v in module.__version__.split('.', 2))
+
+
+class _ChangeMeta:
+    _pr_cache = None
+
+    @classmethod
+    def get(cls, filepath):
+        if cls._pr_cache is None:
+            result = run(
+                [
+                    'gh',
+                    'pr',
+                    'list',
+                    '--base',
+                    'main',
+                    '--state',
+                    'merged',
+                    '--limit=50',
+                    '--json',
+                    'files,mergedAt,number',
+                ],
+                check=True,
+                stdout=PIPE,
+            )
+            cls._pr_cache = {}
+            for pr in loads(result.stdout):
+                for file in pr['files']:
+                    path = file['path']
+                    if path.startswith('.changelog'):
+                        cls._pr_cache[path] = (
+                            pr['number'],
+                            datetime.fromisoformat(pr['mergedAt']).replace(
+                                tzinfo=None
+                            ),
+                        )
+
+        try:
+            return cls._pr_cache[filepath]
+        except KeyError:
+            return None, datetime(year=1970, month=1, day=1)
+
+
+def _get_changelogs():
+    ret = []
+    dirname = '.changelog'
+    for filename in listdir(dirname):
+        if not filename.endswith('.md'):
+            continue
+        filepath = join(dirname, filename)
+        with open(filepath) as fh:
+            data, md = safe_load_all(fh)
+        pr, time = _ChangeMeta.get(filepath)
+        ret.append(
+            {
+                'type': data.get('type', None),
+                'md': md,
+                'pr': pr,
+                'time': time,
+                'ordering': {
+                    'major': 0,
+                    'minor': 1,
+                    'patch': 2,
+                    'none': 3,
+                    '': 3,
+                }[data.get('type', '').lower()],
+            }
+        )
+
+    ret.sort(key=lambda c: (c['ordering'], c['time']))
+    return ret
+
+
+def _get_new_version(current_version, changelogs):
+    try:
+        bump_type = changelogs[0]['type']
+    except IndexError:
+        return None
+    new_version = list(current_version)
+    if bump_type == 'major':
+        new_version[0] += 1
+        new_version[1] = 0
+        new_version[2] = 0
+    elif bump_type == 'minor':
+        new_version[1] += 1
+        new_version[2] = 0
+    else:
+        new_version[2] += 1
+    return tuple(new_version)
+
+
+def _format_version(version):
+    return '.'.join(str(v) for v in version)
+
+
+def bump(argv):
+    buf = StringIO()
+
+    cwd = getcwd()
+    module_name = basename(cwd).replace('-', '_')
+
+    buf.write('## ')
+    current_version = _get_current_version(module_name)
+    changelogs = _get_changelogs()
+    new_version = _get_new_version(current_version, changelogs)
+    new_version = _format_version(new_version)
+    buf.write(new_version)
+    buf.write(' - ')
+    buf.write(datetime.now().strftime('%Y-%m-%d'))
+    buf.write(' - ')
+    buf.write(' '.join(argv[1:]))
+    buf.write('\n')
+
+    current_type = None
+    for changelog in changelogs:
+        md = changelog['md']
+        if not md:
+            continue
+
+        _type = changelog['type']
+        if _type != current_type:
+            buf.write('\n')
+            buf.write(_type.capitalize())
+            buf.write(':\n')
+            current_type = _type
+        buf.write('* ')
+        buf.write(md)
+
+        pr = changelog['pr']
+        if pr:
+            pr = str(pr)
+            buf.write(' [#')
+            buf.write(pr)
+            buf.write('](https://github.com/octodns/')
+            buf.write(module_name)
+            buf.write('/pull/')
+            buf.write(pr)
+            buf.write(')')
+
+        buf.write('\n')
+
+    buf.write('\n')
+
+    with open('CHANGELOG.md') as fh:
+        existing = fh.read()
+
+    with open('CHANGELOG.md', 'w') as fh:
+        fh.write(buf.getvalue())
+        fh.write(existing)
+
+    with open(f'{module_name}/__init__.py') as fh:
+        existing = fh.read()
+
+    current_version = _format_version(current_version)
+    with open(f'{module_name}/__init__.py', 'w') as fh:
+        fh.write(existing.replace(current_version, new_version))
+
+
+cmds = {'create': create, 'check': check, 'bump': bump}
+
+try:
+    cmd = cmds[argv.pop(1).lower()]
+except IndexError:
+    cmd = None
+    print('TODO: command usage (missing)')
+    exit(1)
+except KeyError:
+    cmd = None
+    print('TODO: command usage (unknown)')
+    exit(1)
+
+
+cmd(argv)

--- a/script/changelog
+++ b/script/changelog
@@ -71,7 +71,12 @@ def check(argv):
             check=False,
             stdout=PIPE,
         )
-        if not result.returncode and result.stdout != b'':
+        entries = {
+            l
+            for l in result.stdout.decode('utf-8').split()
+            if l.endswith('.md')
+        }
+        if not result.returncode and entries:
             exit(0)
 
     print(
@@ -178,6 +183,21 @@ def _format_version(version):
 
 
 def bump(argv):
+    prog = basename(argv.pop(0))
+    parser = ArgumentParser(
+        prog=f'{prog} bump',
+        description='Builds a changelog update and calculates a new version number.',
+        add_help=True,
+    )
+
+    parser.add_argument(
+        '--make-changes',
+        action='store_true',
+        help='Write changelog update and bump version number',
+    )
+
+    args = parser.parse_args(argv)
+
     buf = StringIO()
 
     cwd = getcwd()
@@ -187,6 +207,9 @@ def bump(argv):
     current_version = _get_current_version(module_name)
     changelogs = _get_changelogs()
     new_version = _get_new_version(current_version, changelogs)
+    if not new_version:
+        print('No changelog entries found that would bump, nothing to do')
+        exit(1)
     new_version = _format_version(new_version)
     buf.write(new_version)
     buf.write(' - ')
@@ -224,6 +247,11 @@ def bump(argv):
         buf.write('\n')
 
     buf.write('\n')
+
+    if not args.make_changes:
+        print(f'New version number {new_version}\n')
+        print(buf.getvalue())
+        exit(0)
 
     with open('CHANGELOG.md') as fh:
         existing = fh.read()

--- a/script/changelog
+++ b/script/changelog
@@ -67,7 +67,7 @@ and links.''',
 def check(argv):
     if isdir('.changelog'):
         result = run(
-            ['git', 'diff', '--name-only', 'main', '.changelog/'],
+            ['git', 'diff', '--name-only', 'origin/main', '.changelog/'],
             check=False,
             stdout=PIPE,
         )

--- a/script/changelog
+++ b/script/changelog
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
 
-from argparse import ArgumentParser
+from argparse import ArgumentParser, RawTextHelpFormatter
 from datetime import datetime
 from importlib import import_module
 from io import StringIO
 from json import loads
-from os import getcwd, listdir, makedirs
+from os import getcwd, listdir, makedirs, remove
 from os.path import basename, isdir, join
 from subprocess import PIPE, run
-from sys import argv, exit, path
+from sys import argv, exit, path, stderr
 from uuid import uuid4
 
 from yaml import safe_load_all
@@ -18,9 +18,9 @@ def create(argv):
     prog = basename(argv.pop(0))
     parser = ArgumentParser(
         prog=f'{prog} create',
-        description='TODO: description',
-        epilog='TODO: epilog',
+        description='Creates a new changelog entry.',
         add_help=True,
+        formatter_class=RawTextHelpFormatter,
     )
 
     parser.add_argument(
@@ -28,19 +28,40 @@ def create(argv):
         '--type',
         choices=('none', 'patch', 'minor', 'major'),
         required=True,
-        help='TODO: type',
+        help='''The scope of the change.
+
+* patch - This is a bug fix
+* minor - This adds new functionality or makes changes in a fully backwards
+          compatible way
+* major - This includes substantial new functionality and/or changes that break
+          compatibility and may require careful migration
+* none - This change does not need to be mentioned in the changelog
+
+See https://semver.org/ for more info''',
     )
-    parser.add_argument('md', metavar='change-description-markdown', nargs='+')
+    parser.add_argument(
+        'md',
+        metavar='change-description-markdown',
+        nargs='+',
+        help='''A short description of the changes in this PR, suitable as an entry in
+CHANGELOG.md. Should be a single line. Can include simple markdown formatting
+and links.''',
+    )
 
     args = parser.parse_args(argv)
 
     if not isdir('.changelog'):
         makedirs('.changelog')
-    with open(join('.changelog', f'{uuid4().hex}.md'), 'w') as fh:
+    filepath = join('.changelog', f'{uuid4().hex}.md')
+    with open(filepath, 'w') as fh:
         fh.write('---\ntype: ')
         fh.write(args.type)
         fh.write('\n---\n')
         fh.write(' '.join(args.md))
+
+    print(
+        f'Created {filepath}, it can be further edited and should be committed to your branch.'
+    )
 
 
 def check(argv):
@@ -54,7 +75,8 @@ def check(argv):
             exit(0)
 
     print(
-        'PR is missing required changelog file, run ./script/changelog create'
+        'PR is missing required changelog file, run ./script/changelog create',
+        file=stderr,
     )
     exit(1)
 
@@ -116,23 +138,20 @@ def _get_changelogs():
         with open(filepath) as fh:
             data, md = safe_load_all(fh)
         pr, time = _ChangeMeta.get(filepath)
+        if not pr:
+            continue
         ret.append(
             {
-                'type': data.get('type', None),
+                'filepath': filepath,
                 'md': md,
                 'pr': pr,
                 'time': time,
-                'ordering': {
-                    'major': 0,
-                    'minor': 1,
-                    'patch': 2,
-                    'none': 3,
-                    '': 3,
-                }[data.get('type', '').lower()],
+                'type': data.get('type', '').lower(),
             }
         )
 
-    ret.sort(key=lambda c: (c['ordering'], c['time']))
+    ordering = {'major': 0, 'minor': 1, 'patch': 2, 'none': 3, '': 3}
+    ret.sort(key=lambda c: (ordering[c['type']], c['time']))
     return ret
 
 
@@ -220,19 +239,42 @@ def bump(argv):
     with open(f'{module_name}/__init__.py', 'w') as fh:
         fh.write(existing.replace(current_version, new_version))
 
+    for changelog in changelogs:
+        remove(changelog['filepath'])
+
 
 cmds = {'create': create, 'check': check, 'bump': bump}
 
+
+def general_usage(msg=None):
+    global cmds
+
+    exe = basename(argv[0])
+    cmds = ','.join(sorted(cmds.keys()))
+    print(f'usage: {exe} {{{cmds}}} ...')
+    if msg:
+        print(msg)
+    else:
+        print(
+            '''
+Creates and checks or changelog entries, located in the .changelog directory.
+Additionally supports updating CHANGELOG.md and bumping the package version
+based on one or more entries in that directory.
+'''
+        )
+
+
 try:
-    cmd = cmds[argv.pop(1).lower()]
+    cmd = cmds[argv[1].lower()]
+    argv.pop(1)
 except IndexError:
-    cmd = None
-    print('TODO: command usage (missing)')
+    general_usage('missing command')
     exit(1)
 except KeyError:
-    cmd = None
-    print('TODO: command usage (unknown)')
+    if argv[1] in ('-h', '--help', 'help'):
+        general_usage()
+        exit(0)
+    general_usage(f'unknown command "{argv[1]}"')
     exit(1)
-
 
 cmd(argv)

--- a/script/changelog
+++ b/script/changelog
@@ -67,7 +67,7 @@ and links.''',
 def check(argv):
     if isdir('.changelog'):
         result = run(
-            ['git', 'diff', '--name-only', 'origin/main', '.changelog/'],
+            ['git', 'diff', '--name-only', 'main', '.changelog/'],
             check=False,
             stdout=PIPE,
         )


### PR DESCRIPTION
Adds a new script, `changelog`, for managing changelog entries and created CHAGELOG.md updates and version bumps. 

It's workflow is somewhat modeled after https://github.com/changesets/changesets, but it's orders of magnitude less complex and feature-ful. More importantly it's self contained and doesn't require a node install to run.

There's 3 main uses:

* Developers will run something like `./script/changelog create -t minor Add the ability to do some thing` to add a changelog entry for their PR
   * There are 4 types, major, minor, patch, and none which correspond to the relevant https://semver.org/ levels and adds none for things that aren't changelog relevant.
*  CI and pre-commit hooks will run `./script/changelog check` to verify that a changelog entry has been included in the PR.
* Maintainers will run `./script/changelog bump --make-changes` to update CHANGELOG.md and bump the package version as needed. (this will likely require further debugging/testing when the time comes for its first use)