### PR TITLE
README: add ClouDNS provider and update netbox-dns provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ The table below lists the providers octoDNS supports. They are maintained in the
 | [UltraDNS](https://vercara.com/authoritative-dns) | [octodns_ultra](https://github.com/octodns/octodns-ultra/) | |
 | [YamlProvider](/octodns/provider/yaml.py) | built-in | Supports all record types and core functionality |
 | [deSEC](https://desec.io/) | [octodns_desec](https://github.com/rootshell-labs/octodns-desec) | |
+| [ClouDNS](https://www.cloudns.net/) | [octodns_cloudns](https://github.com/ClouDNS/octodns_cloudns) | |
+
 
 ### Updating to use extracted providers
 

--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ If you have a problem or suggestion, please [open an issue](https://github.com/o
   - [`doddo/octodns-lexicon`](https://github.com/doddo/octodns-lexicon): Use [Lexicon](https://github.com/AnalogJ/lexicon) providers as octoDNS providers.
   - [`asyncon/octoblox`](https://github.com/asyncon/octoblox): [Infoblox](https://www.infoblox.com/) provider.
   - [`sukiyaki/octodns-netbox`](https://github.com/sukiyaki/octodns-netbox): [NetBox](https://github.com/netbox-community/netbox) source.
-  - [`jcollie/octodns-netbox-dns`](https://github.com/jcollie/octodns-netbox-dns): [NetBox-DNS Plugin](https://github.com/auroraresearchlab/netbox-dns) provider.
+  - [`olofvndrhr/octodns-netbox-dns`](https://github.com/olofvndrhr/octodns-netbox-dns): [NetBox-DNS Plugin](https://github.com/peteeckel/netbox-plugin-dns) provider.
   - [`kompetenzbolzen/octodns-custom-provider`](https://github.com/kompetenzbolzen/octodns-custom-provider): zonefile provider & phpIPAM source.
   - [`Financial-Times/octodns-fastly`](https://github.com/Financial-Times/octodns-fastly): An octoDNS source for Fastly.
   - [`jvoss/octodns-pihole`](https://github.com/jvoss/octodns-pihole): [Pi-hole](https://pi-hole.net/) provider.


### PR DESCRIPTION
Changes to README:

- Add the official ClouDNS provider to the list: https://github.com/ClouDNS/octodns_cloudns
- Update the NetboxDNS Plugin link from [auroraresearchlab/netbox-dns](https://github.com/auroraresearchlab/netbox-dns) to [peteeckel/netbox-plugin-dns](https://github.com/peteeckel/netbox-plugin-dns) (as the repo moved about a year ago)
- Update the NetboxDNS Plugin Provider link to my fork, as the original had some outstanding bugs and the repo is inactive
