### PR TITLE
New provider: Bunny DNS

### DIFF
--- a/.changelog/0c0c814add3c4ce5983eb3a6d0430de4.md
+++ b/.changelog/0c0c814add3c4ce5983eb3a6d0430de4.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+New provider: Bunny DNS

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ The table below lists the providers octoDNS supports. They are maintained in the
 | [AutoDNS](https://www.internetx.com/autodns/) | [octodns_autodns](https://github.com/octodns/octodns-autodns) | |
 | [Azure DNS](https://azure.microsoft.com/en-us/services/dns/) | [octodns_azure](https://github.com/octodns/octodns-azure/) | |
 | [BIND, AXFR, RFC-2136](https://www.isc.org/bind/) | [octodns_bind](https://github.com/octodns/octodns-bind/) | |
+| [Bunny DNS](https://bunny.net/dns/) | [octodns_bunny](https://github.com/Relkian/octodns-bunny) | |
 | [Cloudflare DNS](https://www.cloudflare.com/dns/) | [octodns_cloudflare](https://github.com/octodns/octodns-cloudflare/) | |
 | [ClouDNS](https://www.cloudns.net/) | [octodns_cloudns](https://github.com/ClouDNS/octodns_cloudns) | |
 | [Constellix](https://constellix.com/) | [octodns_constellix](https://github.com/octodns/octodns-constellix/) | |


### PR DESCRIPTION
Add [octodns-bunny](https://github.com/Relkian/octodns-bunny), a provider for [Bunny DNS](https://bunny.net/dns/), to the providers list.
Created using octodns-template, with 100 % code coverage.

Comments welcome!