### PR TITLE
Version 1.12.0 version bump and changelog update

### DIFF
--- a/.changelog/0c0c814add3c4ce5983eb3a6d0430de4.md
+++ b/.changelog/0c0c814add3c4ce5983eb3a6d0430de4.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-New provider: Bunny DNS

--- a/.changelog/3e80c9a9167b4d0ea3eb95f8b46b177a.md
+++ b/.changelog/3e80c9a9167b4d0ea3eb95f8b46b177a.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Fixes for geo-data.py action

--- a/.changelog/44274039f47d4df0946a45fb9c228d3f.md
+++ b/.changelog/44274039f47d4df0946a45fb9c228d3f.md
@@ -1,4 +1,0 @@
----
-type: none
----
-update markdown tables

--- a/.changelog/4af5a11fb21842ffb627d5ee4d80fb14.md
+++ b/.changelog/4af5a11fb21842ffb627d5ee4d80fb14.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Templating processor added

--- a/.changelog/72ba948357fb41ea948a25b8c8454131.md
+++ b/.changelog/72ba948357fb41ea948a25b8c8454131.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Cron action for geo-data.py

--- a/.changelog/acae8de42da4482ea06e380586010eb8.md
+++ b/.changelog/acae8de42da4482ea06e380586010eb8.md
@@ -1,4 +1,0 @@
----
-type: none
----
-fix markdown format

--- a/.changelog/acc2596fb367494db070e6c06abf705a.md
+++ b/.changelog/acc2596fb367494db070e6c06abf705a.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Adding changelog management infra and doc

--- a/.changelog/ad02e7c6359a43f59a92cf53c8b13e8c.md
+++ b/.changelog/ad02e7c6359a43f59a92cf53c8b13e8c.md
@@ -1,4 +1,0 @@
----
-type: none
----
-requirements-dev.txt requirements.txt

--- a/.changelog/c981d53176e142ba94d885a13e608faa.md
+++ b/.changelog/c981d53176e142ba94d885a13e608faa.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Update geo-data, Türkiye

--- a/.changelog/ff12d7ab1c614a15b3ce8c6bba3407fb.md
+++ b/.changelog/ff12d7ab1c614a15b3ce8c6bba3407fb.md
@@ -1,5 +1,0 @@
----
-type: minor
-pr: 1251
----
-Correct type-o in name of AcmeManagingProcessor, backwards compatible alias in place

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.12.0 - 2025-06-25 - Automated changelogs
+
+Minor:
+* Templating processor added [#1259](https://github.com/octodns/octodns/pull/1259)
+* Update geo-data, Türkiye [#1263](https://github.com/octodns/octodns/pull/1263)
+* New provider: Bunny DNS [#1262](https://github.com/octodns/octodns/pull/1262)
+* Correct type-o in name of AcmeManagingProcessor, backwards compatible alias in place [#1251](https://github.com/octodns/octodns/pull/1251)
+
 ## v1.11.0 - 2025-02-03 - Cleanup & deprecations with meta planning
 
 * Deprecation warning for Source.populate w/o the lenient param, to be removed

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -1,4 +1,4 @@
 'OctoDNS: DNS as code - Tools for managing DNS across multiple providers'
 
 # TODO: remove __VERSION__ w/2.x
-__version__ = __VERSION__ = '1.11.0'
+__version__ = __VERSION__ = '1.12.0'

--- a/script/changelog
+++ b/script/changelog
@@ -115,6 +115,8 @@ class _ChangeMeta:
 
     @classmethod
     def get(cls, filepath, data):
+        if 'pr' in data:
+            return data['pr'], datetime(year=1970, month=1, day=1)
         if cls._pr_cache is None:
             result = run(
                 [
@@ -148,12 +150,7 @@ class _ChangeMeta:
             return cls._pr_cache[filepath]
         except KeyError:
             # couldn't find a PR with the changelog file in it
-            try:
-                # if a PR number was specified in the changelog entry use it
-                return data['pr'], datetime(year=1970, month=1, day=1)
-            except KeyError:
-                # otherwise just give up
-                return None, datetime(year=1970, month=1, day=1)
+            return None, datetime(year=1970, month=1, day=1)
 
 
 def _get_changelogs():
@@ -182,7 +179,7 @@ def _get_changelogs():
             }
         )
 
-    ordering = {'major': 0, 'minor': 1, 'patch': 2, 'none': 3, '': 3}
+    ordering = {'major': 3, 'minor': 2, 'patch': 1, 'none': 0, '': 0}
     ret.sort(key=lambda c: (ordering[c['type']], c['time']), reverse=True)
     return ret
 


### PR DESCRIPTION
## 1.12.0 - 2025-06-25 - Automated changelogs

Minor:
* Templating processor added [#1259](https://github.com/octodns/octodns/pull/1259)
* Update geo-data, Türkiye [#1263](https://github.com/octodns/octodns/pull/1263)
* New provider: Bunny DNS [#1262](https://github.com/octodns/octodns/pull/1262)
* Correct type-o in name of AcmeManagingProcessor, backwards compatible alias in place [#1251](https://github.com/octodns/octodns/pull/1251)