### PR TITLE
expirimentation around using jsonschema for validation

### DIFF
--- a/octodns/record/a.py
+++ b/octodns/record/a.py
@@ -13,6 +13,7 @@ from .ip import _IpValue
 class Ipv4Value(_IpValue):
     _address_type = _IPv4Address
     _address_name = 'IPv4'
+    _format = 'ipv4'
 
 
 Ipv4Address = Ipv4Value

--- a/octodns/record/aaaa.py
+++ b/octodns/record/aaaa.py
@@ -13,6 +13,7 @@ from .ip import _IpValue
 class Ipv6Value(_IpValue):
     _address_type = _IPv6Address
     _address_name = 'IPv6'
+    _format = 'ipv6'
 
 
 Ipv6Address = Ipv6Value

--- a/octodns/record/ip.py
+++ b/octodns/record/ip.py
@@ -5,6 +5,14 @@
 
 class _IpValue(str):
     @classmethod
+    def jsonschema(cls):
+        return {
+            'type': 'string',
+            #'pattern': cls._regex,
+            'format': cls._format,
+        }
+
+    @classmethod
     def parse_rdata_text(cls, value):
         return value
 

--- a/octodns/record/srv.py
+++ b/octodns/record/srv.py
@@ -40,6 +40,35 @@ class SrvValue(EqualityTupleMixin, dict):
         }
 
     @classmethod
+    def jsonschema(cls):
+        return {
+            'type': 'object',
+            'properties': {
+                'priority': {
+                    'type': 'integer',
+                    'minimum': 0,
+                    'maximum': 9999999999,
+                },
+                'weight': {
+                    'type': 'integer',
+                    'minimum': 0,
+                    'maximum': 9999999999,
+                },
+                'port': {
+                    'type': 'integer',
+                    'minimum': 0,
+                    'maximum': 9999999999,
+                },
+                'target': {
+                    'type': 'string',
+                    # TODO: pattern FQDN
+                },
+            },
+            'required': ['priority', 'weight', 'port', 'target'],
+            "unevaluatedProperties": False,
+        }
+
+    @classmethod
     def validate(cls, data, _type):
         reasons = []
         for value in data:


### PR DESCRIPTION
Ran across [jsonschema](https://pypi.org/project/jsonschema/) in a talk by @gizm00 at a [python meetup](https://www.meetup.com/pdxpython/events/308298313/?eventOrigin=group_past_events) and made a mental note to look into it. I thought it'd might be interesting to explore shifting record validation over to use it and ideally do a schema for the main config file and processors/providers/sources.

Look like it'd take some effort to get there, but in theory it should be able to do (most) everything we're currently doing, but in a more systemic way. 

If this direction is followed I think the biggest hurdles would be:
* Making sure that the source context is preserved and presented in the error message. The validate method takes a python dict which has no info about where in a yaml file or other source provider that data came from so it can't give the user line numbers or anything to help them track down the problem. This would be a show-stopper
* Making sure the error messages make sense to end uses. As-is they dump the relivant section of jsonschema which is going to be jibberish. The actual error message seems reasonable, there's just a lot of less useful noise accompanying it. 
* Making sure to preserve the `lenient` behavior where errors warn 

Anyway, all of this makes me feel like if this happens then it needs to be part of a major release, with an opt-in mode for several releases/a good while beforehand.

Links and notes:
* Validation of simple string formats, e.g. ipv4/ipv5, fqdns, etc. https://python-jsonschema.readthedocs.io/en/stable/validate/#validating-formats &amp; https://www.learnjsonschema.com/2020-12/format-annotation/format/
* Did a lot of searching and faffing about trying to figure out how to get different validations to apply based on the record `type` as well as get errors for unexpected keys etc. I think I got there, some links involved in figuring that out:
   * https://json-schema.org/understanding-json-schema/reference/conditionals#ifthenelse
   * https://github.com/json-schema-org/json-schema-spec/issues/556 "A simple example"
   * https://stackoverflow.com/questions/49784760/jsonschema-validate-type-based-on-value-of-another-property
* TBD how this would hook into the flow.
   * There's the obvious case where `Record.validate` would use it
   * Less clean is how YamlProvider might wrap this schema in it's own enclosure/objext to validate it's specific schema on top of the individual records

Parking this for now. It seems pretty interesting so I may play around with it, but tbd if I get into it enough to get it from here to a usable state.

/cc https://pypi.org/project/jsonschema/
