### PR TITLE
Fix include target in some Processors

### DIFF
--- a/.changelog/4f9d1e4e41834834a21cd99ef46af928.md
+++ b/.changelog/4f9d1e4e41834834a21cd99ef46af928.md
@@ -1,4 +1,4 @@
 ---
-type: none
+type: minor
 ---
-fix include-target in filter processors
+Add kwags to filter processors __init__

--- a/.changelog/4f9d1e4e41834834a21cd99ef46af928.md
+++ b/.changelog/4f9d1e4e41834834a21cd99ef46af928.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+fix include-target in filter processors

--- a/octodns/processor/filter.py
+++ b/octodns/processor/filter.py
@@ -175,8 +175,8 @@ class NameAllowlistFilter(_NameBaseFilter, AllowsMixin):
           - route53
     '''
 
-    def __init__(self, name, allowlist):
-        super().__init__(name, allowlist)
+    def __init__(self, name, allowlist, **kwargs):
+        super().__init__(name, allowlist, **kwargs)
 
 
 class NameRejectlistFilter(_NameBaseFilter, RejectsMixin):
@@ -211,8 +211,8 @@ class NameRejectlistFilter(_NameBaseFilter, RejectsMixin):
           - route53
     '''
 
-    def __init__(self, name, rejectlist):
-        super().__init__(name, rejectlist)
+    def __init__(self, name, rejectlist, **kwargs):
+        super().__init__(name, rejectlist, **kwargs)
 
 
 class _ValueBaseFilter(_FilterProcessor):
@@ -284,9 +284,9 @@ class ValueAllowlistFilter(_ValueBaseFilter, AllowsMixin):
           - route53
     '''
 
-    def __init__(self, name, allowlist):
+    def __init__(self, name, allowlist, **kwargs):
         self.log = getLogger(f'ValueAllowlistFilter[{name}]')
-        super().__init__(name, allowlist)
+        super().__init__(name, allowlist, **kwargs)
 
 
 class ValueRejectlistFilter(_ValueBaseFilter, RejectsMixin):
@@ -321,9 +321,9 @@ class ValueRejectlistFilter(_ValueBaseFilter, RejectsMixin):
           - route53
     '''
 
-    def __init__(self, name, rejectlist):
+    def __init__(self, name, rejectlist, **kwargs):
         self.log = getLogger(f'ValueRejectlistFilter[{name}]')
-        super().__init__(name, rejectlist)
+        super().__init__(name, rejectlist, **kwargs)
 
 
 class _NetworkValueBaseFilter(BaseProcessor):
@@ -500,6 +500,7 @@ class ZoneNameFilter(_FilterProcessor):
         # If true a ValidationError will be throw when such records are
         # encouterd, if false the records will just be ignored/omitted.
         # (default: true)
+        # error: True
         # Optional param that can be set to False to leave the target zone
         # alone, thus allowing deletion of existing records
         # (default: true)


### PR DESCRIPTION
Fixes the use of `include_target` in some filters where the kwargs were not passed to its parent class.

Error before:
`TypeError: NameAllowlistFilter.__init__() got an unexpected keyword argument 'include_target'`

> (also added a missing property of `ZoneNameFilter`)