### PR TITLE
Add new provider parameter "root_ns_warnings" to disable root NS related warnings

### DIFF
--- a/.changelog/fb7aa3d7570d4ee1ae8afb93408bfff4.md
+++ b/.changelog/fb7aa3d7570d4ee1ae8afb93408bfff4.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Add new provider parameter root_ns_warnings to disable root NS related warnings


### PR DESCRIPTION
Some people (like me) just don’t want to manage zones root NS records in OctoDNS for a number of reasons.
In this case, having multiple warnings displayed per zone can really pollute `octodns-sync` output and create a "warning fatigue" which can lead to missing important warnings.

This PR add support for a new `root_ns_warnings` parameter for providers, which default to `True`. When set to `False`, root NS related warnings aren’t logged.

Configuration example:
```yaml
providers:
  googlecloud:
    class: octodns_googlecloud.GoogleCloudProvider
    root_ns_warnings: False
```
