### PR TITLE
Fix encoding and decoding of mixed idna fqdns

### DIFF
--- a/.changelog/0452fdb43ba64ae99bffeef152a6b5f7.md
+++ b/.changelog/0452fdb43ba64ae99bffeef152a6b5f7.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+Fix encoding and decoding of mixed idna fqdns

--- a/tests/test_octodns_idna.py
+++ b/tests/test_octodns_idna.py
@@ -62,13 +62,10 @@ class TestIdna(TestCase):
 
     def test_exception_translation(self):
         with self.assertRaises(IdnaError) as ctx:
-            idna_encode('déjà..vu.')
-        self.assertEqual('Empty Label', str(ctx.exception))
-
-        with self.assertRaises(IdnaError) as ctx:
-            idna_decode('xn--djvu-1na6c.something-.com.')
+            idna_decode('xn--djvu-1na6c.xn--djvu-1234-something.com.')
         self.assertEqual(
-            'Label must not start or end with a hyphen', str(ctx.exception)
+            "Codepoint U+0675 at position 6 of 'ٴdjٱvٵuٳ-123ٰٲ4ٴ' not allowed",
+            str(ctx.exception),
         )
 
 


### PR DESCRIPTION
I'd previously looked at the `requests` library for its handling of idna, but landed on code that isn't actually what it uses for the core case. Dug into that deeper and found out that its using urllib3 for that. This round implements things based on how that works, though it only has an encode and I had to translate the process to decode.

```yaml
---
'*':
  type: A
  value: 1.2.3.4
foo._bar:
  type: A
  value: foo
zajęzyk:
  type: A
  value: 2.3.4.6
```


```console
octodns.record.exception.ValidationError: Invalid record "foo._bar.zajęzyk.pl.", ./config/zajęzyk.pl.yaml, line 6, column 3
  - invalid IPv4 address "foo"
```

/cc Fixes https://github.com/octodns/octodns/issues/1281
/cc @jleroy  