### PR TITLE
Release 1.13.0 version bump and changelog update

### DIFF
--- a/.changelog/0452fdb43ba64ae99bffeef152a6b5f7.md
+++ b/.changelog/0452fdb43ba64ae99bffeef152a6b5f7.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Fix encoding and decoding of mixed idna fqdns

--- a/.changelog/0d2c45a64fdc45268b8844c0d2439c6e.md
+++ b/.changelog/0d2c45a64fdc45268b8844c0d2439c6e.md
@@ -1,4 +1,0 @@
----
-type: none
----
-New provider: Azion DNS

--- a/.changelog/3e57e696039c4f37a3062043be81199c.md
+++ b/.changelog/3e57e696039c4f37a3062043be81199c.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add trailing_dots parameter to templating processor

--- a/.changelog/464ca6c3ae0d45f3a8ba945276bf6ce2.md
+++ b/.changelog/464ca6c3ae0d45f3a8ba945276bf6ce2.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Quote NAPTR 'flags', 'service' and 'regexp' values as required by RFC2915

--- a/.changelog/4f9d1e4e41834834a21cd99ef46af928.md
+++ b/.changelog/4f9d1e4e41834834a21cd99ef46af928.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add kwags to filter processors __init__

--- a/.changelog/519279fa6fa94b2fb61bd3552084dbd6.md
+++ b/.changelog/519279fa6fa94b2fb61bd3552084dbd6.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Fix issues with using Templating processor on alias zones

--- a/.changelog/7a30ee9fb9dd433c9181ddd5628e5cd3.md
+++ b/.changelog/7a30ee9fb9dd433c9181ddd5628e5cd3.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add unescaped semicolons support to YamlProvider

--- a/.changelog/80f748502d3e4258bcbf4a05d5f5bdb0.md
+++ b/.changelog/80f748502d3e4258bcbf4a05d5f5bdb0.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Create dist directory in scripte/release if it doesn't exist

--- a/.changelog/85710a9264524662becdc7e52e71e241.md
+++ b/.changelog/85710a9264524662becdc7e52e71e241.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add validation to TXT records to check for double escaped semi-colons

--- a/.changelog/88a37c98bbcf4ea58b57854afb46b73c.md
+++ b/.changelog/88a37c98bbcf4ea58b57854afb46b73c.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add sphinx doc generation

--- a/.changelog/9be6e14916d04fcd8dead098a3e5cdeb.md
+++ b/.changelog/9be6e14916d04fcd8dead098a3e5cdeb.md
@@ -1,4 +1,0 @@
----
-type: none
----
-switch to changelet module

--- a/.changelog/af8522cac7e54d22a615eab351d445b3.md
+++ b/.changelog/af8522cac7e54d22a615eab351d445b3.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Improve error messaging for unknown templating parameters

--- a/.changelog/c4f025d1c23c40dd98380e6d3496364d.md
+++ b/.changelog/c4f025d1c23c40dd98380e6d3496364d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Documentation for processors

--- a/.changelog/db3856b033d0439cbfba28ab79b86c50.md
+++ b/.changelog/db3856b033d0439cbfba28ab79b86c50.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add support for the URI record type

--- a/.changelog/fb7aa3d7570d4ee1ae8afb93408bfff4.md
+++ b/.changelog/fb7aa3d7570d4ee1ae8afb93408bfff4.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add new provider parameter root_ns_warnings to disable root NS related warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 1.13.0 - 2025-08-06 - And then there was changelet
+
+Minor:
+* Quote NAPTR 'flags', 'service' and 'regexp' values as required by RFC2915 - [#1284](https://github.com/None/pull/1284)
+* Add new provider parameter root_ns_warnings to disable root NS related warnings - [#1282](https://github.com/None/pull/1282)
+* Fix issues with using Templating processor on alias zones - [#1279](https://github.com/None/pull/1279)
+* Add trailing_dots parameter to templating processor - [#1278](https://github.com/None/pull/1278)
+* Add unescaped semicolons support to YamlProvider - [#1253](https://github.com/None/pull/1253)
+* Add validation to TXT records to check for double escaped semi-colons - [#1253](https://github.com/None/pull/1253)
+* Add support for the URI record type - [#1275](https://github.com/None/pull/1275)
+* Add kwags to filter processors __init__ - [#1274](https://github.com/None/pull/1274)
+
+Patch:
+* Fix encoding and decoding of mixed idna fqdns - [#1285](https://github.com/None/pull/1285)
+* Improve error messaging for unknown templating parameters - [#1280](https://github.com/None/pull/1280)
+
 ## 1.12.0 - 2025-06-25 - Automated changelogs
 
 Minor:

--- a/octodns/__init__.py
+++ b/octodns/__init__.py
@@ -1,4 +1,4 @@
 'OctoDNS: DNS as code - Tools for managing DNS across multiple providers'
 
 # TODO: remove __VERSION__ w/2.x
-__version__ = __VERSION__ = '1.12.0'
+__version__ = __VERSION__ = '1.13.0'


### PR DESCRIPTION
## 1.13.0 - 2025-08-06 - And then there was changelet

Minor:
* Quote NAPTR 'flags', 'service' and 'regexp' values as required by RFC2915 - [#1284](https://github.com/None/pull/1284)
* Add new provider parameter root_ns_warnings to disable root NS related warnings - [#1282](https://github.com/None/pull/1282)
* Fix issues with using Templating processor on alias zones - [#1279](https://github.com/None/pull/1279)
* Add trailing_dots parameter to templating processor - [#1278](https://github.com/None/pull/1278)
* Add unescaped semicolons support to YamlProvider - [#1253](https://github.com/None/pull/1253)
* Add validation to TXT records to check for double escaped semi-colons - [#1253](https://github.com/None/pull/1253)
* Add support for the URI record type - [#1275](https://github.com/None/pull/1275)
* Add kwags to filter processors __init__ - [#1274](https://github.com/None/pull/1274)

Patch:
* Fix encoding and decoding of mixed idna fqdns - [#1285](https://github.com/None/pull/1285)
* Improve error messaging for unknown templating parameters - [#1280](https://github.com/None/pull/1280)